### PR TITLE
feat: Add support for WindiCSS

### DIFF
--- a/colors/color-values.js
+++ b/colors/color-values.js
@@ -1,4 +1,4 @@
-let colorValues = {
+module.exports = {
   "primary"           : {name: "p", value: "259 94% 51%"},
   "primary-focus"     : {name: "pf", value: "259 94% 41%"},
   "primary-content"   : {name: "pc", value: "0 0% 100%"},
@@ -25,21 +25,3 @@ let colorValues = {
   "warning"           : {name: "wa", value: "36 100% 50%"},
   "error"             : {name: "er", value: "14 100% 57%"},
 }
-
-let colorObject = {
-  "transparent": "transparent",
-}
-
-for (const [key, item] of Object.entries(colorValues)) {
-  colorObject[key] = ({ opacityVariable, opacityValue }) => {
-    if (opacityValue !== undefined) {
-      return `hsla(var(--`+ item['name'] +`, `+ item['value'] +`) / ${opacityValue})`
-    }
-    if (opacityVariable !== undefined) {
-      return `hsla(var(--`+ item['name'] +`, `+ item['value'] +`) / var(${opacityVariable}, 1))`
-    }
-    return `hsl(var(--`+ item['name'] +`, `+ item['value']+ `))`
-  }
-}
-
-module.exports = colorObject;

--- a/colors/index.js
+++ b/colors/index.js
@@ -1,0 +1,19 @@
+const colorValues = require('./color-values')
+
+let colorObject = {
+  "transparent": "transparent",
+}
+
+for (const [key, item] of Object.entries(colorValues)) {
+  colorObject[key] = ({ opacityVariable, opacityValue }) => {
+    if (opacityValue !== undefined) {
+      return `hsla(var(--`+ item['name'] +`, `+ item['value'] +`) / ${opacityValue})`
+    }
+    if (opacityVariable !== undefined) {
+      return `hsla(var(--`+ item['name'] +`, `+ item['value'] +`) / var(${opacityVariable}, 1))`
+    }
+    return `hsl(var(--`+ item['name'] +`, `+ item['value']+ `))`
+  }
+}
+
+module.exports = colorObject

--- a/colors/windi.js
+++ b/colors/windi.js
@@ -1,0 +1,11 @@
+const colorValues = require('./color-values')
+
+let colorObject = {
+  "transparent": "transparent",
+}
+
+for (const [key, item] of Object.entries(colorValues)) {
+  colorObject[key] = `hsla(var(--${item.name}, ${item.value}) / var(--tw-bg-opacity, 1))`
+}
+
+module.exports = colorObject


### PR DESCRIPTION
Support WindiCSS color format in tailwind.config.js.  Non-breaking change.

- Moves the colors.js file into /colors/index.
- Moves the colorValues variable into its own file.
- Creates a new `colors/windi.js` file, which allows user to `require(‘daisyui/colors/windi’)`

## More about this PR

Hi, @saadeghi!  I really appreciate your work with DaisyUI.  Actually, I appreciate it so much that I spent the day figuring out how to get it to work with WindiCSS (https://windicss.org/).  WindiCSS is the TailwindCSS compiler that inspired creation of the new TailwindJIT compiler that was announced in the last week or so.  The competition has definitely been supportive for the Tailwind community, and now we have options.

Tailwind and Windi support the same classes and utilities, but their plugin APIs are different.

- The existing `daisyui/colors` object is not supported by Windi.  This PR adds support for windi at `daisyui/colors/windi`.
- Windi already has a plugin that converts the `daisyui` plugin to work.

Earlier today, I submitted a PR to WindiCSS to add support for DaisyUI.

https://github.com/windicss/windicss/pull/198

Once it’s merged, I would absolutely love it if this PR could also be merged.  (I will submit a PR for the docs, too.)
