### PR TITLE
Site: Allow to directly enter color hex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn.lock
 /dist
 /colors
 /index.js
+.idea

--- a/src/docs/pages/core/colors.vue
+++ b/src/docs/pages/core/colors.vue
@@ -52,7 +52,15 @@
       <div class="grid rounded">
         <div class="flex flex-col col-start-1 row-start-1">
           <div v-for="(color, index) in colorGroup" class="relative col-start-1 row-start-1">
-            <label :class="'flex justify-start items-end w-full h-20 transform transition-all cursor-pointer shadow hover:shadow-lg hover:-translate-y-1 '+ color.class + ((index === 0) ? ' rounded-t ' : '') + ((index === colorGroup.length - 1) ? ' rounded-b ' : '')" :for="color.name">
+            <label :class="'flex flex-col justify-between items-start w-full h-20 transform transition-all cursor-pointer shadow hover:shadow-lg hover:-translate-y-1 '+ color.class + ((index === 0) ? ' rounded-t ' : '') + ((index === colorGroup.length - 1) ? ' rounded-b ' : '')" :for="color.name">
+              <div class="w-full px-1 text-sm text-white bg-black rounded bg-opacity-20">
+                <input
+                  type='text'
+                  :class="'rounded bg-opacity-20 ' + color.class + ' outline-none'"
+                  v-model="colorValues[color.name]['hex']"
+                  v-on:input="hexToHsl(color.name); applyCustomThemeToSite = true; showCustomThemeTogglerSwitch = true; "
+                >
+              </div>
               <div class="px-1 m-1 text-xs text-white bg-black rounded bg-opacity-20">
                 .bg-{{ color.title }}
               </div>

--- a/src/docs/pages/core/colors.vue
+++ b/src/docs/pages/core/colors.vue
@@ -56,7 +56,7 @@
               <div class="w-full px-1 text-sm text-white bg-black rounded bg-opacity-20">
                 <input
                   type='text'
-                  :class="'rounded bg-opacity-20 ' + color.class + ' outline-none'"
+                  :class="'w-full rounded bg-opacity-20 ' + color.class + ' outline-none'"
                   v-model="colorValues[color.name]['hex']"
                   v-on:input="hexToHsl(color.name); applyCustomThemeToSite = true; showCustomThemeTogglerSwitch = true; "
                 >

--- a/src/docs/pages/core/colors.vue
+++ b/src/docs/pages/core/colors.vue
@@ -370,7 +370,7 @@
 
       <div class="mt-6 text-sm shadow-lg mockup-code">
         <pre>
-  <code>bg-<span class="text-info">{COLOR_NAME}</span></span>
+  <code>bg-<span class="text-info">{COLOR_NAME}</span>
     text-<span class="text-info">{COLOR_NAME}</span>
     border-<span class="text-info">{COLOR_NAME}</span>
     from-<span class="text-info">{COLOR_NAME}</span>

--- a/src/docs/pages/core/colors.vue
+++ b/src/docs/pages/core/colors.vue
@@ -574,9 +574,7 @@ export default {
   },
   methods: {
     onInputColorHexChange(name, val) {
-      this.colorValues[name]['hex'] = val.startsWith('#')
-        ? val
-        : '#' + val
+      this.colorValues[name]['hex'] = val.replace(/^#*/, '#')
       this.onColorChange(name)
     },
     onColorChange(name) {

--- a/src/docs/pages/core/colors.vue
+++ b/src/docs/pages/core/colors.vue
@@ -57,8 +57,8 @@
                 <input
                   type='text'
                   :class="'w-full rounded bg-opacity-20 ' + color.class + ' outline-none'"
-                  v-model="colorValues[color.name]['hex']"
-                  v-on:input="hexToHsl(color.name); applyCustomThemeToSite = true; showCustomThemeTogglerSwitch = true; "
+                  :value="colorValues[color.name]['hex']"
+                  v-on:input="e => onInputColorHexChange(color.name, e.target.value)"
                 >
               </div>
               <div class="px-1 m-1 text-xs text-white bg-black rounded bg-opacity-20">
@@ -70,7 +70,7 @@
               :id="color.name"
               class="absolute top-0 invisible opacity-0"
               v-model="colorValues[color.name]['hex']"
-              v-on:change="hexToHsl(color.name); applyCustomThemeToSite = true; showCustomThemeTogglerSwitch = true; "
+              v-on:change="onColorChange(color.name)"
             >
           </div>
         </div>
@@ -573,6 +573,17 @@ export default {
     }
   },
   methods: {
+    onInputColorHexChange(name, val) {
+      this.colorValues[name]['hex'] = val.startsWith('#')
+        ? val
+        : '#' + val
+      this.onColorChange(name)
+    },
+    onColorChange(name) {
+      this.hexToHsl(name);
+      this.applyCustomThemeToSite = true;
+      this.showCustomThemeTogglerSwitch = true;
+    },
     hexToHsl: function(name) {
       let H = this.colorValues[name]['hex'];
       let ex = /^#([\da-f]{3}){1,2}$/i;


### PR DESCRIPTION
`<input type="color"...` doesn't allow hex color value to be pasted in, it's too complicated to use. This change allows us to make it simpler
![Screen Shot 2021-08-23 at 13 18 22](https://user-images.githubusercontent.com/32500015/130399687-4c449aa1-b05a-4810-8d0b-150345019af8.png)
