### PR TITLE
fix(breadcrumbs): Remove the breadcrumb separator background color

### DIFF
--- a/src/components/styled/breadcrumbs.css
+++ b/src/components/styled/breadcrumbs.css
@@ -16,6 +16,7 @@
         @apply block w-1.5 h-1.5 transform rotate-45 ml-2 mr-3 opacity-40;
         border-top: 1px solid;
         border-right: 1px solid;
+        background-color: transparent;
       }
     }
   }


### PR DESCRIPTION
As shown, the breadcrumb separator is overlaid with a global style, so I set the background of the separator to a transparent color.

![image](https://user-images.githubusercontent.com/29443755/148654133-f39d7a80-ed94-4a14-8e91-5c0672399172.png)