### PR TITLE
fix: #394 prevent toggle from shrinking by default

### DIFF
--- a/src/components/unstyled/toggle.css
+++ b/src/components/unstyled/toggle.css
@@ -1,4 +1,5 @@
-.toggle{
+.toggle {
+  flex-shrink: 0;
   &:focus {
     @apply outline-none;
   }


### PR DESCRIPTION
I added the flex-shrink property to the unstyled toggle class to prevent the toggle from shrinking in a flex container.