### PR TITLE
Removes the triangle icon in multiple select

### DIFF
--- a/src/components/styled/select.css
+++ b/src/components/styled/select.css
@@ -68,4 +68,8 @@
   &[disabled] {
     @apply cursor-not-allowed bg-base-200 border-base-200 text-opacity-20 placeholder-base-content placeholder-opacity-20;
   }
+  &-multiple,
+  &[multiple] {
+    @apply bg-none pr-4;
+  }
 }


### PR DESCRIPTION
Hi Pouya,
When the <select> element multiple attribute is active, I notice the triangle icons are shown, but in this situation it's not useful, so I removed it.

![screenshot](https://user-images.githubusercontent.com/714741/149685978-0f187b1d-14d6-48e7-9878-3c4a211d85c7.png)

