### PR TITLE
Removes the triangle in select (size attribute)

### DIFF
--- a/src/components/styled/select.css
+++ b/src/components/styled/select.css
@@ -69,7 +69,8 @@
     @apply cursor-not-allowed bg-base-200 border-base-200 text-opacity-20 placeholder-base-content placeholder-opacity-20;
   }
   &-multiple,
-  &[multiple] {
+  &[multiple],
+  &[size]&:not([size="1"]) {
     @apply bg-none pr-4;
   }
 }


### PR DESCRIPTION
Removes the triangle icon in select when the size attribute is used and the size is not equal to one