### PR TITLE
fix: #428 checkbox input shrink property.

### DIFF
--- a/src/components/unstyled/checkbox.css
+++ b/src/components/unstyled/checkbox.css
@@ -1,4 +1,5 @@
-.checkbox{
+.checkbox {
+  flex-shrink: 0;
   &:focus {
     @apply outline-none;
   }


### PR DESCRIPTION
This fixes the issue of checkboxes shrinking in flex and grid containers by default. I added the flex-shrink property to the checkbox class with a value of 0.