### PR TITLE
Fixes checkbox check mark direction in RTL

### DIFF
--- a/src/components/styled/checkbox.css
+++ b/src/components/styled/checkbox.css
@@ -74,3 +74,14 @@
 .checkbox-mark {
   @apply hidden;
 }
+
+body[dir="rtl"] {
+  .checkbox {
+    --chkbg: var(--bc);
+    --chkfg: var(--b1);
+    &:checked,
+    &[checked="true"] {
+      background-image: linear-gradient(45deg, transparent 65%, hsl(var(--chkbg)) 65.99%), linear-gradient(-45deg, transparent 75%, hsl(var(--chkbg)) 75.99%), linear-gradient(45deg, hsl(var(--chkbg)) 40%, transparent 40.99%), linear-gradient(-45deg, hsl(var(--chkbg)) 30%, hsl(var(--chkfg)) 30.99%, hsl(var(--chkfg)) 40%, transparent 40.99%), linear-gradient(45deg, hsl(var(--chkfg)) 50%, hsl(var(--chkbg)) 50.99%);
+    }
+  }
+}


### PR DESCRIPTION
Hi Pouya,
When I used checkboxes on my rtl direction web page, the check symbol appeared incorrectly.

![checkbox](https://user-images.githubusercontent.com/714741/154777239-3bb123ca-257c-4631-a7bb-ef3d39b7c657.png)

