### PR TITLE
fix a very tiny typo at Text Input

### DIFF
--- a/src/docs/src/routes/components/input.svelte.md
+++ b/src/docs/src/routes/components/input.svelte.md
@@ -68,7 +68,7 @@ data="{[
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<div class="$$form-control w-full max-w-xs">
   <label class="$$label">
-    <span class="$$label-text">Your email address</span>
+    <span class="$$label-text">What is your name?</span>
     <span class="$$label-text-alt">Alt label</span>
   </label>
   <input type="text" placeholder="Type here" class="$$input $$input-bordered w-full max-w-xs">


### PR DESCRIPTION
tiny typo at https://daisyui.com/components/input/.
Preview and html texts are not same. 

### Preview
"What is your name?"
![CleanShot 2022-03-13 at 00 49 47](https://user-images.githubusercontent.com/38400669/158024958-de7ea089-1bf0-4db8-8fba-78f03d9a7f6a.png)

### HTML
"Your email address"
![CleanShot 2022-03-13 at 00 50 20](https://user-images.githubusercontent.com/38400669/158024981-41994823-e1d3-4f42-a537-b187e0a22845.png)

Changed html label-text ("Your email address") to "What is your name?".