### PR TITLE
Parameterise modal background colours

### DIFF
--- a/src/components/styled/modal.css
+++ b/src/components/styled/modal.css
@@ -1,11 +1,13 @@
 .modal {
-  @apply bg-neutral-focus bg-opacity-40 duration-200 ease-in-out;
+  @apply bg-opacity-40 duration-200 ease-in-out;
+  background-color: var(--modal-overlay-bg, theme('colors.neutral-focus'));
   transition-property: transform, opacity;
   overflow-y: hidden;
   overscroll-behavior: contain;
 }
 .modal-box {
-  @apply w-full translate-y-10 transform bg-base-100 p-6 transition duration-200 ease-in-out rounded-t-box sm:max-w-lg sm:translate-y-0 sm:scale-90 sm:rounded-b-box;
+  @apply w-full translate-y-10 transform p-6 transition duration-200 ease-in-out rounded-t-box sm:max-w-lg sm:translate-y-0 sm:scale-90 sm:rounded-b-box;
+  background-color: var(--modal-box-bg, theme('colors.base-100'));
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
   overflow-y: auto;
   overscroll-behavior: contain;


### PR DESCRIPTION
Since my I've designed my app to use the darker colours at the back and the lighter colour at the front, it felt weird that the modals didn't follow the same colour scheme.

It would make sense to have this override behaviour, considering it's available for the lifted tabs (although surprisingly not available for the boxed tabs).