### PR TITLE
docs: ghost form elements' descriptions always refer to checkbox

### DIFF
--- a/src/docs/src/routes/components/input.svelte.md
+++ b/src/docs/src/routes/components/input.svelte.md
@@ -17,7 +17,7 @@ data="{[
   { type:'component', class: 'label', desc: 'For helper text' },
   { type:'component', class: 'input', desc: 'For <input> element' },
   { type:'modifier', class: 'input-bordered', desc: 'Adds border to input' },
-  { type:'modifier', class: 'input-ghost', desc: 'Adds ghost style to checkbox' },
+  { type:'modifier', class: 'input-ghost', desc: 'Adds ghost style to input' },
   { type:'modifier', class: 'input-primary', desc: 'Adds `primary` color to input' },
   { type:'modifier', class: 'input-secondary', desc: 'Adds `secondary` color to input' },
   { type:'modifier', class: 'input-accent', desc: 'Adds `accent` color to input' },

--- a/src/docs/src/routes/components/select.svelte.md
+++ b/src/docs/src/routes/components/select.svelte.md
@@ -17,7 +17,7 @@ data="{[
   { type:'component', class: 'label', desc: 'For helper text' },
   { type:'component', class: 'select', desc: 'For <select> element' },
   { type:'modifier', class: 'select-bordered', desc: 'Adds border to select' },
-  { type:'modifier', class: 'select-ghost', desc: 'Adds ghost style to checkbox' },
+  { type:'modifier', class: 'select-ghost', desc: 'Adds ghost style to select' },
   { type:'modifier', class: 'select-primary', desc: 'Adds `primary` color to select' },
   { type:'modifier', class: 'select-secondary', desc: 'Adds `secondary` color to select' },
   { type:'modifier', class: 'select-accent', desc: 'Adds `accent` color to select' },

--- a/src/docs/src/routes/components/textarea.svelte.md
+++ b/src/docs/src/routes/components/textarea.svelte.md
@@ -17,7 +17,7 @@ data="{[
   { type:'modifier', class: 'label', desc: 'For helper text' },
   { type:'modifier', class: 'textarea', desc: 'For <textarea> element' },
   { type:'modifier', class: 'textarea-bordered', desc: 'Adds border to textarea' },
-  { type:'modifier', class: 'textarea-ghost', desc: 'Adds ghost style to checkbox' },
+  { type:'modifier', class: 'textarea-ghost', desc: 'Adds ghost style to textarea' },
   { type:'modifier', class: 'textarea-primary', desc: 'Adds `primary` color to textarea' },
   { type:'modifier', class: 'textarea-secondary', desc: 'Adds `secondary` color to textarea' },
   { type:'modifier', class: 'textarea-accent', desc: 'Adds `accent` color to textarea' },


### PR DESCRIPTION
In the documentation, all the descriptions of the ghost variant referred to the checkbox ("_Adds ghost style to checkbox"_).

To be more precise, it appeared in:

- [Text input](https://daisyui.com/components/input/);
- [Select](https://daisyui.com/components/select/);
- [Textarea](https://daisyui.com/components/textarea/);