### PR TITLE
fix: tabindex=0 breaks collapse with checkbox on safari

### DIFF
--- a/src/docs/src/routes/components/collapse.svelte.md
+++ b/src/docs/src/routes/components/collapse.svelte.md
@@ -45,17 +45,17 @@ data="{[
 </Component>
 
 <Component title="Collapse with checkbox" desc="This collapse works with checkbox instead of focus. It needs to get clicked again to get closed.">
-<div tabindex="0" class="collapse">
+<div class="collapse">
   <input type="checkbox" />
   <div class="collapse-title text-xl font-medium">
     Click me to show/hide content
   </div>
   <div class="collapse-content">
-    <p>tabindex="0" attribute is necessary to make the div focusable</p>
+    <p>hello</p>
   </div>
 </div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
-`<div tabindex="0" class="$$collapse">
+`<div class="$$collapse">
   <input type="checkbox" /> 
   <div class="$$collapse-title text-xl font-medium">
     Click me to show/hide content
@@ -194,17 +194,17 @@ data="{[
 </Component>
 
 <Component title="Custom colors for collapse that works with checkbox" desc="Use Tailwind CSS `peer` and `peer-checked` utilities to apply style when sibling checkbox is checked">
-<div tabindex="0" class="collapse">
+<div class="collapse">
   <input type="checkbox" class="peer" /> 
   <div class="collapse-title bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
     Click me to show/hide content
   </div>
   <div class="collapse-content bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content"> 
-    <p>tabindex="0" attribute is necessary to make the div focusable</p>
+    <p>hello</p>
   </div>
 </div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
-`<div tabindex="0" class="collapse">
+`<div class="collapse">
   <input type="checkbox" class="peer" /> 
   <div class="$$collapse-title bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
     Click me to show/hide content


### PR DESCRIPTION
Changing the text inside the collapse modifies the width of the containers in the docs to not line up - see below.

If that's a problem could set a fixed width for them all? 


<img width="776" alt="Screenshot 2022-05-10 at 10 38 32" src="https://user-images.githubusercontent.com/6919834/167600277-8d909a97-762b-44d0-b798-9d49f92cbc27.png">
<img width="802" alt="Screenshot 2022-05-10 at 10 36 31" src="https://user-images.githubusercontent.com/6919834/167600284-92466715-6865-478a-a920-7ed986f8705f.png">
 