### PR TITLE
fix: #833 select with "multiple", height fixed

### DIFF
--- a/src/components/unstyled/select.css
+++ b/src/components/unstyled/select.css
@@ -7,4 +7,9 @@
   &[disabled] {
     @apply pointer-events-none;
   }
+  /* multiple */
+  &-multiple,
+  &[multiple] {
+    @apply h-auto;
+  }
 }


### PR DESCRIPTION
**now the height is h-auto instead of a fixed number so it can be changed by using the size attribute**

.

.

.

**_Note:_** _the scrollbar may look ugly but changing it didn't look like a fix related to this commit, i also thought that it may be a bad idea to thinker with styles not very well supported cross-browser, but if this becomes necessary, i already found a solution i won't add to daisyui or create an issue for it unless requested by the mantainers, the most cross browser compatible thing we can do is to change the colors, supported both in chromium and firefox but using different methods, while rounding the corners of the scrollbar is supported only by chromium, and about scrollbar thickness, firefox has an option when used the scrollbar becomes ovely thin, while chrome gives more freedom to choose how thin you want it to be_