### PR TITLE
added: #847 btn-group-vertical

### DIFF
--- a/src/components/styled/button.css
+++ b/src/components/styled/button.css
@@ -221,6 +221,15 @@
   & > .btn:not(:last-of-type) {
     @apply rounded-r-none;
   }
+  &-vertical
+  {
+    .btn:not(:first-of-type) {
+      @apply -mt-px rounded-t-none;
+    }
+    .btn:not(:last-of-type) {
+      @apply rounded-b-none;
+    }
+}
 }
 
 @keyframes button-pop {

--- a/src/components/unstyled/button.css
+++ b/src/components/unstyled/button.css
@@ -57,4 +57,7 @@
   & > input[type="radio"].btn:before {
     content: attr(data-title);
   }
+  &-vertical {
+    @apply flex-col flex-nowrap;
+  }
 }


### PR DESCRIPTION
Known bug: button's hover state behaves weird when multiple buttons are vertically one on top of another, the button to the top stays hovered in some conditions, eventually i will try to fix the bug, although it's not my fault (it happend even before i added btn-group-vertical)
it's not a bug that causes much trouble generally, it doesn't affect onclick on all mainstream browsers (firefox and chromium)

i may not have the time to add docs or hunt down the bug, sorry, i really wanted to contribute more, i say it so if you find the bug before i do you can fix it