### PR TITLE
fix: #928

### DIFF
--- a/src/components/styled/typography.css
+++ b/src/components/styled/typography.css
@@ -27,7 +27,7 @@
   }
   pre{
     code{
-      border-radius: none;
+      border-radius: 0;
       padding: 0;
     }
   }


### PR DESCRIPTION
Fix #928 

`none` is not a valid value for the `border-radius` CSS property.

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius#values