### PR TITLE
[doc ]Fixed navbar unwanted scroll behavior

### DIFF
--- a/src/docs/package-lock.json
+++ b/src/docs/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "color": "^4.2.1",
-        "daisyui": "^2.11.1",
+        "daisyui": "^2.22.0",
         "emoji-unicode": "^2.0.1",
         "lodash.debounce": "^4.0.8",
         "nanoid": "^3.3.1",
@@ -640,14 +640,14 @@
       }
     },
     "node_modules/daisyui": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.11.1.tgz",
-      "integrity": "sha512-99LD0kheC7v9U/S5jY+b4Nt7ekfpbPCK7fuDBxSxPpuxO1uq6PxEtTIa6DQwlh6/0Sh2CgqDmIQzfdMzdP5DMw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.22.0.tgz",
+      "integrity": "sha512-H08aQP+Mfl2fQOmyaxd1NP54gQbr2xRUj2MmFFvfJ5EDGbthVBICDMNFKyia/zBfR58G8eTJo3CmydglM81/7Q==",
       "dependencies": {
         "color": "^4.2",
         "css-selector-tokenizer": "^0.8.0",
         "postcss-js": "^4.0.0",
-        "tailwindcss": "^3.0"
+        "tailwindcss": "^3"
       },
       "peerDependencies": {
         "autoprefixer": "^10.0.2",
@@ -3187,14 +3187,14 @@
       }
     },
     "daisyui": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.11.1.tgz",
-      "integrity": "sha512-99LD0kheC7v9U/S5jY+b4Nt7ekfpbPCK7fuDBxSxPpuxO1uq6PxEtTIa6DQwlh6/0Sh2CgqDmIQzfdMzdP5DMw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.22.0.tgz",
+      "integrity": "sha512-H08aQP+Mfl2fQOmyaxd1NP54gQbr2xRUj2MmFFvfJ5EDGbthVBICDMNFKyia/zBfR58G8eTJo3CmydglM81/7Q==",
       "requires": {
         "color": "^4.2",
         "css-selector-tokenizer": "^0.8.0",
         "postcss-js": "^4.0.0",
-        "tailwindcss": "^3.0"
+        "tailwindcss": "^3"
       },
       "dependencies": {
         "postcss-js": {

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "color": "^4.2.1",
-    "daisyui": "^2.11.1",
+    "daisyui": "^2.22.0",
     "emoji-unicode": "^2.0.1",
     "lodash.debounce": "^4.0.8",
     "nanoid": "^3.3.1",

--- a/src/docs/src/routes/__layout.svelte
+++ b/src/docs/src/routes/__layout.svelte
@@ -42,6 +42,10 @@
   onMount(() => {
     parseContentScroll()
     parseSidebarScroll()
+
+    // fix for https://github.com/sveltejs/kit/issues/3501
+    // todo: upgrade to latest svelte-kit version instead
+    document.body.removeAttribute("tabindex")
   })
 
   afterNavigate(() => {
@@ -66,13 +70,13 @@
 
 <div class={`bg-base-100 drawer ${pagesThatDontNeedSidebar.includes($page.url.pathname) ? "" : "drawer-mobile"}`}>
   <input id="drawer" type="checkbox" class="drawer-toggle" bind:checked />
-  <div bind:this={drawercontent} on:scroll={parseContentScroll} class={`drawer-content`} style="scroll-behavior: smooth; scroll-padding-top: 5rem;">
+  <div bind:this={drawercontent} on:scroll={parseContentScroll} class={`drawer-content`} style="scroll-behavior: smooth;">
     <Navbar {drawerContentScrollY} />
     <div class={`${pagesThatDontNeedSidebar.includes($page.url.pathname) ? "" : "p-6 pb-16"}`}>
       <slot />
     </div>
   </div>
-  <div class="drawer-side" style="scroll-behavior: smooth; scroll-padding-top: 5rem;" bind:this={drawersidebar} on:scroll={parseSidebarScroll}>
+  <div class="drawer-side" style="scroll-behavior: smooth;" bind:this={drawersidebar} on:scroll={parseSidebarScroll}>
     <label for="drawer" class="drawer-overlay" />
     <aside class="bg-base-200 w-80">
       <Sidebar {closeDrawer} {openDrawer} {drawerSidebarScrollY} />


### PR DESCRIPTION
Fixes for #875.

Like stated in the issue, the `tabindex` problem has been fixed in the latest version of svelte-kit but attempting the upgrade introduced other issues, such as css selector changing specificities, breaking some global styles.

When in comes to the unwanted scroll behavior, removing the `scroll-padding-top` property from the layout seems to do the trick. Even after reading and testing how this property behaves (never used to before to be honest!), I don't see how it was impactful or what the intended behavior was. Let me know if this PR breaks anything. 