### PR TITLE
fix: duplicate theme color

### DIFF
--- a/src/colors/themes.js
+++ b/src/colors/themes.js
@@ -243,7 +243,6 @@ module.exports = {
     "base-200": "#f9fafb",
     "base-300": "#d1d5db",
     "--rounded-btn": "1.9rem",
-    "--rounded-btn": "1.9rem",
   },
   "[data-theme=retro]": {
     primary: "#ef9995",


### PR DESCRIPTION
There is a duplicate `--rounded-btn` in Pastel theme.