### PR TITLE
Fix: strokeLineCap in navbar example

### DIFF
--- a/src/docs/src/routes/components/navbar.svelte.md
+++ b/src/docs/src/routes/components/navbar.svelte.md
@@ -477,7 +477,7 @@ data="{[
   <div className="$$navbar-start">
     <div className="$$dropdown">
       <label tabIndex={0} className="$$btn $$btn-ghost $$btn-circle">
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
       </label>
       <ul tabIndex={0} className="$$menu $$menu-compact $$dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52">
         <li><a>Homepage</a></li>


### PR DESCRIPTION
Fix missspelling of strokeLinecap in Navbar example in the docs