### PR TITLE
Docs: Update prefix reference link in ClassTable

### DIFF
--- a/src/docs/src/components/ClassTable.svelte
+++ b/src/docs/src/components/ClassTable.svelte
@@ -26,7 +26,7 @@
               <svg class="fill-info absolute -top-1.5 left-8 scale-x-150" xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 512 512"><polygon points="256 32 20 464 492 464 256 32" /></svg>
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info-content h-4 w-4 flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               <div class="text-xs">
-                <Translate text="To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>" />
+                <Translate text="To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>" />
               </div>
             </div>
           </td>

--- a/src/docs/src/translation/en.json
+++ b/src/docs/src/translation/en.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "Here you can see how elements will look using <code>@tailwindcss/typography</code>.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>",
   "Component": "Component",
   "Modifier": "Modifier",
   "Responsive": "Responsive",

--- a/src/docs/src/translation/es.json
+++ b/src/docs/src/translation/es.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI agrega algo de estilo a @tailwindcss/typography para que use el mismo tema que otros elementos.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "Asegúrese de solicitar <span class='badge badge-outline'>daisyui</span> DESPUÉS de <span class='badge badge-outline'>@tailwindcss/typography</span> en tailwind.config.js",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "Aquí puedes ver cómo se verán los elementos usando <code>@tailwindcss/typography</code>.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "Para usar un prefijo personalizado, <a class='link' href='/docs/config/'>agregue el prefijo a la configuración</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "Para usar un prefijo personalizado, <a class='link' href='/docs/config/#prefix'>agregue el prefijo a la configuración</a>",
   "Component": "Componente",
   "Modifier": "Modificador",
   "Responsive": "Adaptable",

--- a/src/docs/src/translation/fr.json
+++ b/src/docs/src/translation/fr.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI ajoute du style à @tailwindcss/typography afin qu'il utilise le même thème que les autres éléments.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "Assurez-vous de require <span class='badge badge-outline'>daisyui</span> APRÈS <span class='badge badge-outline'>@tailwindcss/typography</span> dans tailwind.config.js",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "Ici, vous pouvez voir à quoi ressembleront les éléments en utilisant <code>@tailwindcss/typography</code>.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "Pour utiliser un préfixe personnalisé, <a class='link' href='/docs/config/'>ajoutez votre chaîne de préfixe à config</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "Pour utiliser un préfixe personnalisé, <a class='link' href='/docs/config/#prefix'>ajoutez votre chaîne de préfixe à config</a>",
   "Component": "Composant",
   "Modifier": "Modifier",
   "Responsive": "Responsive",

--- a/src/docs/src/translation/id.json
+++ b/src/docs/src/translation/id.json
@@ -318,7 +318,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI menambahkan beberapa style ke @tailwindcss/typography sehingga seluruh tema akan menerapkan style yang sama.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "Pastikan Anda menambahkan <span class='badge badge-outline'>daisyui</span> SETELAH <span class='badge badge-outline'>@tailwindcss/typography</span> di dalam tailwind.config.js",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "Disini Anda dapat melihat bagaimana elemen akan terlihat menggunakan <code>@tailwindcss/typography</code>.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>",
   "Component": "Komponen",
   "Modifier": "Modifier",
   "Responsive": "Responsif",

--- a/src/docs/src/translation/jp.json
+++ b/src/docs/src/translation/jp.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "Here you can see how elements will look using <code>@tailwindcss/typography</code>.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>",
   "Component": "Component",
   "Modifier": "Modifier",
   "Responsive": "Responsive",

--- a/src/docs/src/translation/ko.json
+++ b/src/docs/src/translation/ko.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "데이지UI는 @tailwindcss/typography에 몇몇 스타일을 추가해 서로 다른 요소들이 같은 테마를 사용할 수 있게 합니다.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "tailwind.config.js에서 꼭 <span class='badge badge-outline'>@tailwindcss/typography</span> 다음에 <span class='badge badge-outline'>daisyui</span>를 require 하세요.",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "<code>@tailwindcss/typography</code>를 사용해 요소들이 어떻게 보일지 확인할 수 있습니다.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "커스텀한 접두어를 사용하기 위해, <a class='link' href='/docs/config/'>설정에 접두어 문자열을 추가하세요.</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "커스텀한 접두어를 사용하기 위해, <a class='link' href='/docs/config/#prefix'>설정에 접두어 문자열을 추가하세요.</a>",
   "Component": "컴포넌트",
   "Modifier": "수식자",
   "Responsive": "반응형",

--- a/src/docs/src/translation/pt.json
+++ b/src/docs/src/translation/pt.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI adiciona algum estilo a @tailwindcss/typography para que use o mesmo tema que outros elementos.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "Certifique-se de exigir <span class='badge badge-outline'>daisyui</span> DEPOIS de <span class='badge badge-outline'>@tailwindcss/typography</span> em tailwind.config.js",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "Aqui você pode ver como os elementos ficarão usando <code>@tailwindcss/typography</code>.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "Para usar um prefixo personalizado, <a class='link' href='/docs/config/'>adicione sua string de prefixo à configuração</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "Para usar um prefixo personalizado, <a class='link' href='/docs/config/#prefix'>adicione sua string de prefixo à configuração</a>",
   "Component": "Componente",
   "Modifier": "Modificador",
   "Responsive": "Responsivo",

--- a/src/docs/src/translation/ru.json
+++ b/src/docs/src/translation/ru.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI добавляет некоторый стиль к @tailwindcss/typography, чтобы он использовал ту же тему, что и другие элементы.",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "Убедитесь, что <span class='badge badge-outline'>daisyui</span> ПОСЛЕ <span class='badge badge-outline'>@tailwindcss/typography</span> в tailwind.config.js",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "Здесь вы можете увидеть, как будут выглядеть элементы с использованием <code>@tailwindcss/typography</code>.",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "Чтобы использовать пользовательский префикс, <a class='link' href='/docs/config/'>добавьте вашу префиксную строку в конфигурацию</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "Чтобы использовать пользовательский префикс, <a class='link' href='/docs/config/#prefix'>добавьте вашу префиксную строку в конфигурацию</a>",
   "Component": "Компонента",
   "Modifier": "Модификатор",
   "Responsive": "Респонсивный",

--- a/src/docs/src/translation/zh_cn.json
+++ b/src/docs/src/translation/zh_cn.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI 增加一些样式给  @tailwindcss/typography 所以这些组件可以和其他元素一样获取同样的主题",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "确保你在  tailwind.config.js 引用 <span class='badge badge-outline'>daisyui</span> 在<span class='badge badge-outline'>@tailwindcss/typography</span> 的后面",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "这里你可以看到使用 <code>@tailwindcss/typography</code> 如何影响你的元素：",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "为了使用一个自定义前缀， <a class='link' href='/docs/config/'>在配置文件中增加前缀设置</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "为了使用一个自定义前缀， <a class='link' href='/docs/config/#prefix'>在配置文件中增加前缀设置</a>",
   "Component": "组件类",
   "Modifier": "装饰类",
   "Responsive": "响应类",

--- a/src/docs/src/translation/zh_tw.json
+++ b/src/docs/src/translation/zh_tw.json
@@ -317,7 +317,7 @@
   "daisyUI adds some style to @tailwindcss/typography so it will use the same theme as other elements.": "daisyUI 為 @tailwindcss/typography 新增了一些樣式，好讓它的主題與其他元素相同。",
   "Make sure you require <span class='badge badge-outline'>daisyui</span> AFTER <span class='badge badge-outline'>@tailwindcss/typography</span> in tailwind.config.js": "在 tailwind.config.js 中，請先引入 <span class='badge badge-outline'>@tailwindcss/typography</span> 再引入 <span class='badge badge-outline'>daisyui</span>。",
   "Here you can see how elements will look using <code>@tailwindcss/typography</code>.": "您可以在此預覽使用 <code>@tailwindcss/typography</code> 後的元件外觀。",
-  "To use a custom prefix, <a class='link' href='/docs/config/'>add your prefix string to config</a>": "若要使用自訂前綴，<a class='link' href='/docs/config/'>請至設定檔中加入前綴字串</a>",
+  "To use a custom prefix, <a class='link' href='/docs/config/#prefix'>add your prefix string to config</a>": "若要使用自訂前綴，<a class='link' href='/docs/config/#prefix'>請至設定檔中加入前綴字串</a>",
   "Component": "元件",
   "Modifier": "修改器",
   "Responsive": "響應式",


### PR DESCRIPTION
Prefix reference link was changed from `/docs/config/` to `/docs/config/#prefix`