### PR TITLE
Fix border radius on mixed type buttons

### DIFF
--- a/src/utilities/styled/button.css
+++ b/src/utilities/styled/button.css
@@ -1,20 +1,20 @@
 /* group */
 .btn-group,
 .btn-group.btn-group-horizontal {
-  .btn {
+  .btn:not(:first-child):not(:last-child) {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .btn:first-child {
+  .btn:first-child:not(:last-child) {
     @apply -ml-px -mt-0;
     border-top-left-radius: var(--rounded-btn, 0.5rem);
     border-top-right-radius: 0;
     border-bottom-left-radius: var(--rounded-btn, 0.5rem);
     border-bottom-right-radius: 0;
   }
-  .btn:last-child {
+  .btn:last-child:not(:first-child) {
     border-top-left-radius: 0;
     border-top-right-radius: var(--rounded-btn, 0.5rem);
     border-bottom-left-radius: 0;
@@ -22,14 +22,14 @@
   }
 }
 .btn-group.btn-group-vertical {
-  .btn:first-child {
+  .btn:first-child:not(:last-child) {
     @apply -ml-0 -mt-px;
     border-top-left-radius: var(--rounded-btn, 0.5rem);
     border-top-right-radius: var(--rounded-btn, 0.5rem);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .btn:last-child {
+  .btn:last-child:not(:first-child) {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     border-bottom-left-radius: var(--rounded-btn, 0.5rem);

--- a/src/utilities/styled/button.css
+++ b/src/utilities/styled/button.css
@@ -1,20 +1,20 @@
 /* group */
 .btn-group,
 .btn-group.btn-group-horizontal {
-  .btn:not(:first-of-type):not(:last-of-type) {
+  .btn {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .btn:first-of-type:not(:last-of-type) {
+  .btn:first-child {
     @apply -ml-px -mt-0;
     border-top-left-radius: var(--rounded-btn, 0.5rem);
     border-top-right-radius: 0;
     border-bottom-left-radius: var(--rounded-btn, 0.5rem);
     border-bottom-right-radius: 0;
   }
-  .btn:last-of-type:not(:first-of-type) {
+  .btn:last-child {
     border-top-left-radius: 0;
     border-top-right-radius: var(--rounded-btn, 0.5rem);
     border-bottom-left-radius: 0;
@@ -22,14 +22,14 @@
   }
 }
 .btn-group.btn-group-vertical {
-  .btn:first-of-type:not(:last-of-type) {
+  .btn:first-child {
     @apply -ml-0 -mt-px;
     border-top-left-radius: var(--rounded-btn, 0.5rem);
     border-top-right-radius: var(--rounded-btn, 0.5rem);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .btn:last-of-type:not(:first-of-type) {
+  .btn:last-child {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     border-bottom-left-radius: var(--rounded-btn, 0.5rem);


### PR DESCRIPTION
Currently, if you have buttons of different types (`a` vs `button` for example), the button styling breaks because the selectors depend on the button type:

![Screen Shot 2022-09-19 at 1 34 22 PM](https://user-images.githubusercontent.com/157695/191112185-10828c3b-88ff-4022-a4eb-3ea9653dc214.png)

Change to using child selectors as this doesn't care what type of child exists.

Note I haven't directly tested this change against DaisyUI's demos, etc, instead I applied these styles locally to verify:

```css
.btn-group .btn {
	@apply rounded-none;

	&:first-child {
		@apply rounded-l-lg;
	}
	&:last-child {
		@apply rounded-r-lg;
	}
}
```

PS any reason not to use `@apply` in the code?