### PR TITLE
chore: add fontSize(text-2xs,text-xxs)  

### DIFF
--- a/src/utilities/global/fontSize.css
+++ b/src/utilities/global/fontSize.css
@@ -1,3 +1,6 @@
+.text-xxs {
+  font-size: 0.6875rem;
+}
 .text-2xs {
-  font-size: 0.7rem;
+  font-size: 0.8125rem;
 }


### PR DESCRIPTION
The XS in Tailwind has a size of 0.75 REM. Since 2XS is larger than XS, the value should be greater than 0.75 REM. Therefore, XXS is more appropriate.

https://tailwindcss.com/docs/font-size
#1069 