### PR TITLE
fix #1205

### DIFF
--- a/src/lib/responsiveRegex.js
+++ b/src/lib/responsiveRegex.js
@@ -20,7 +20,7 @@ module.exports = [
   },
   {
     // responsive utilites for daisyUI components
-    pattern: /(modal-middle|card-side)/,
+    pattern: /(modal-middle|card-side|stats)/,
     variants: [
       "sm",
       "md",


### PR DESCRIPTION
A simple fix to #1205 by adding the `stats` module to the `src/lib/responsiveRegex.js`.

The fix is based on [this commit](https://github.com/saadeghi/daisyui/commit/e81fda2db63ffc758597e16f08a0280b9f4d60e3).