### PR TITLE
feat(docs): add note for type usage for CSS variables in Countdown & Radial Progress components

### DIFF
--- a/src/docs/src/routes/components/countdown.svelte.md
+++ b/src/docs/src/routes/components/countdown.svelte.md
@@ -1,6 +1,6 @@
 ---
 title: Countdown
-desc: Countdown gives you a transition effect of changing numbers
+desc: Countdown gives you a transition effect of changing numbers.
 published: true
 ---
 

--- a/src/docs/src/routes/components/countdown.svelte.md
+++ b/src/docs/src/routes/components/countdown.svelte.md
@@ -26,7 +26,9 @@ published: true
   })
 </script>
 
-You need to change to `--value` CSS variable using JS. Value must be a number between 0 and 99
+You need to change to `--value` CSS variable using JS. Value must be a number between 0 and 99 
+
+Note: Use `CSSProperties` as type for `--value` if you are working with TS
 
 <ClassTable
 data="{[

--- a/src/docs/src/routes/components/countdown.svelte.md
+++ b/src/docs/src/routes/components/countdown.svelte.md
@@ -26,9 +26,9 @@ published: true
   })
 </script>
 
-You need to change to `--value` CSS variable using JS. Value must be a number between 0 and 99 
+You need to change to `--value` CSS variable using JS. Value must be a number between 0 and 99.
 
-Note: Use `CSSProperties` as type for `--value` if you are working with TS
+Note: Use `CSSProperties` as type for `--value` if you are working with TS.
 
 <ClassTable
 data="{[

--- a/src/docs/src/routes/components/radial-progress.svelte.md
+++ b/src/docs/src/routes/components/radial-progress.svelte.md
@@ -15,6 +15,8 @@ Radial progress needs `--value` CSS variable to work.
 To change the size, use `--size` CSS variable which has a default value of `4rem`.  
 To change the thickness, use `--thickness` CSS variable which is 10% of the size by default.
 
+Note: Use `CSSProperties` as type for `--value`, `--size`, and `--thickness` if you are working with TS.
+
 <div class="alert alert-info text-sm">
   <div>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info-content flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>


### PR DESCRIPTION
## Problem
TypeScript throws an error when using CSS Variables in Countdown, and Radial Progress components.

![TSError](https://user-images.githubusercontent.com/89210438/200171283-e239e785-dd9c-4c82-897e-64a04bf987b2.png)
 
Using the `CSSProperties` type fixes the error. 

![TSErrorFix](https://user-images.githubusercontent.com/89210438/200171379-66a816db-624a-459d-aea9-ebb2d6cfd92e.png)

## Proposed Solution
IMO, adding a small note for the type usage in the documentation would be beneficial for beginners.

## Changelog
- [x] Add Note for type usage in [Countdown](https://daisyui.com/components/countdown/), and [Radial Progress](https://daisyui.com/components/radial-progress/) documentation. 
- [x] Fix the missing period(s) in Countdown component [documentation](https://daisyui.com/components/countdown/).

## Screenshots

![CountdownChange](https://user-images.githubusercontent.com/89210438/200172067-1dbfc611-138b-49c6-80a4-65e81134d114.png)

![RadialProgressChange](https://user-images.githubusercontent.com/89210438/200171600-b6da21b3-70cc-42f5-b4a3-5ceb027d47f6.png)
