### PR TITLE
feat: allow adding custom dark theme variants

### DIFF
--- a/src/colors/functions.js
+++ b/src/colors/functions.js
@@ -249,7 +249,23 @@ module.exports = {
       themeOrder.push("light");
     }
 
-    // inject themes in order
+    function addTheme(themeName) {
+      if (themeName.startsWith("dark:")) {
+        addBase({
+          ["@media (prefers-color-scheme: dark)"]: {
+            ["[data-theme=" + themeName.substring(5, themeName.length) + "]"]:
+              includedThemesObj["[data-theme=" + themeName + "]"],
+          }
+        });
+      } else {
+        addBase({
+          ["[data-theme=" + themeName + "]"]:
+            includedThemesObj["[data-theme=" + themeName + "]"],
+        });
+      }
+    }
+
+// inject themes in order
     themeOrder.forEach((themeName, index) => {
       if (index === 0) {
         // first theme as root
@@ -285,20 +301,11 @@ module.exports = {
           }
         }
         // theme 0 with name
-        addBase({
-          ["[data-theme=" + themeOrder[0] + "]"]:
-            includedThemesObj["[data-theme=" + themeOrder[0] + "]"],
-        });
+        addTheme(themeOrder[0]);
         // theme 1 with name
-        addBase({
-          ["[data-theme=" + themeOrder[1] + "]"]:
-            includedThemesObj["[data-theme=" + themeOrder[1] + "]"],
-        });
+        addTheme(themeOrder[1]);
       } else {
-        addBase({
-          ["[data-theme=" + themeName + "]"]:
-            includedThemesObj["[data-theme=" + themeName + "]"],
-        });
+        addTheme(themeName);
       }
     });
 


### PR DESCRIPTION
This PR adds the functionality for custom dark themes.

Currently there is the support only for a global custom dark theme. Every section with a `[data-theme="mytheme"]` attribute is forced on that theme and doesn't change with the `@media (prefers-color-scheme: dark)` media-query.

Now it's possible to define dark variants of the themes directly inside `tailwind.config.js`:

```javascript
module.exports = {
    ...
    daisyui: {
        themes: [
            {
                mytheme: {
                    primary: "#a991f7",
                    ...
                },
                'dark:mytheme': {
                    primary: "#af1784",
                    ...
                }
            },
        ]
    },
};
```

This will generate the following css:
```css
[data-theme=mytheme] {
    --p: 254 86% 77%;
    ...
}
@media (prefers-color-scheme: dark) {
    [data-theme=mytheme] {
        --p: 317 77% 39%;
        ...
    }
}

```
