### PR TITLE
fix: #1350 File Input Button for Safari

### DIFF
--- a/src/components/styled/file-input.css
+++ b/src/components/styled/file-input.css
@@ -1,7 +1,7 @@
 .file-input {
   @apply border border-base-content border-opacity-0 bg-base-100 rounded-btn text-base;
   &::file-selector-button {
-    @apply font-semibold uppercase no-underline border-neutral bg-neutral text-neutral-content;
+    @apply font-semibold uppercase no-underline border-neutral bg-neutral text-neutral-content rounded-btn;
     border-width: var(--border-btn, 1px);
     animation: button-pop var(--animation-btn, 0.25s) ease-out;
     text-transform: var(--btn-text-case, uppercase);


### PR DESCRIPTION
This adds `rounded-btn` to the file-selector-button pseudo element that Safari renders the file input button as. Closes #1350 