### PR TITLE
fix: remove collapse-content cutoff

### DIFF
--- a/src/components/unstyled/collapse.css
+++ b/src/components/unstyled/collapse.css
@@ -21,5 +21,5 @@
 .collapse:not(.collapse-close)
   input[type="checkbox"]:checked
   ~ .collapse-content {
-  max-height: 9000px;
+  max-height: none;
 }


### PR DESCRIPTION
In a personal project I have a collapsed list that exceeds `9000px` when opened. As far as I understand it this value is a probably-big-enough value to offset the `max-height: 0` when the collapse is closed. Since the CSS selector is more specific `max-height: none` in the `collapse-content` should also create the same behaviour while allowing for any height.

Let me know if I'm missing something.