### PR TITLE
Fix visible scrollbar in drawer-end animation

### DIFF
--- a/src/docs/src/routes/components/drawer.svelte.md
+++ b/src/docs/src/routes/components/drawer.svelte.md
@@ -255,7 +255,7 @@ You can check/uncheck the checkbox using JavaScript or using `<label>` tag.
   <div class="flex flex-col items-center justify-center drawer-content">
     <label for="my-drawer-4" class="btn btn-primary drawer-button">Open drawer</label>
   </div> 
-  <div class="drawer-side">
+  <div class="drawer-side overflow-hidden">
     <label for="my-drawer-4" class="drawer-overlay"></label>
     <ul class="menu p-4 w-60 md:w-80 bg-base-100 text-base-content">
       <li><a>Sidebar Item 1</a></li>


### PR DESCRIPTION
`overflow-hidden` on the `drawer-side` removes the scrollbar while animating in the `drawer-end` example.