### PR TITLE
fix(docs): Bordered menu item preview has incorrect class

### DIFF
--- a/src/docs/src/routes/components/menu.svelte.md
+++ b/src/docs/src/routes/components/menu.svelte.md
@@ -160,7 +160,7 @@ data="{[
 <Component title="Item with border">
 <ul class="menu bg-base-100 w-56 shadow-xl rounded-box">
   <li><a>Item 1</a></li>
-  <li class="borderedbordered"><a>I have border</a></li>
+  <li class="bordered"><a>I have border</a></li>
   <li><a>Item 3</a></li>
 </ul>
 <pre slot="html" use:replace={{ to: $prefix }}>{


### PR DESCRIPTION
As you can see in https://daisyui.com/components/menu/#item-with-border, the item that is meant to have a border, does not.