### PR TITLE
#1508 Make non-checkbox collapse closable on second click

### DIFF
--- a/src/components/styled/collapse.css
+++ b/src/components/styled/collapse.css
@@ -27,6 +27,11 @@
 .collapse:focus:not(.collapse-open):not(.collapse-close) .collapse-title {
   cursor: unset;
 }
+
+.collapse:focus {
+    @apply pointer-events-none;
+}
+
 .collapse-title {
   @apply relative;
 }

--- a/src/components/styled/collapse.css
+++ b/src/components/styled/collapse.css
@@ -32,6 +32,10 @@
     @apply pointer-events-none;
 }
 
+.collapse:focus a {
+    @apply pointer-events-auto;
+}
+
 .collapse-title {
   @apply relative;
 }


### PR DESCRIPTION
To close a [collapse container](https://daisyui.com/components/collapse/) you need to click outside of it to remove the focus. Imho closing it should also be possible with a second click inside the container.
This is at the moment only possible by using the [collapse with a checkbox](https://daisyui.com/components/collapse/#collapse-with-checkbox).

This implements this workaround/possibility as described in #1508 