### PR TITLE
Add more semantic focus colors

### DIFF
--- a/src/colors/colorNames.js
+++ b/src/colors/colorNames.js
@@ -21,14 +21,18 @@ module.exports = {
   "base-content": "--bc",
 
   info: "--in",
+  "info-focus": "--inf",
   "info-content": "--inc",
 
   success: "--su",
+  "success-focus": "--suf",
   "success-content": "--suc",
 
   warning: "--wa",
+  "warning-focus": "--waf",
   "warning-content": "--wac",
 
   error: "--er",
+  "error-focus": "--erf",
   "error-content": "--erc",
-};
+}

--- a/src/colors/functions.js
+++ b/src/colors/functions.js
@@ -45,6 +45,26 @@ module.exports = {
           resultObj["--nf"] = darkerHslArray[0] + " " + darkerHslArray[1] + "%" + " " + darkerHslArray[2] + "%";
         }
 
+        if (!input.hasOwnProperty("info-focus")) {
+          const darkerHslArray = Color(input["info"]).darken(0.2).hsl().round().array()
+          resultObj["--inf"] = darkerHslArray[0] + " " + darkerHslArray[1] + "%" + " " + darkerHslArray[2] + "%"
+        }
+
+        if (!input.hasOwnProperty("success-focus")) {
+          const darkerHslArray = Color(input["success"]).darken(0.2).hsl().round().array()
+          resultObj["--suf"] = darkerHslArray[0] + " " + darkerHslArray[1] + "%" + " " + darkerHslArray[2] + "%"
+        }
+
+        if (!input.hasOwnProperty("warning-focus")) {
+          const darkerHslArray = Color(input["warning"]).darken(0.2).hsl().round().array()
+          resultObj["--waf"] = darkerHslArray[0] + " " + darkerHslArray[1] + "%" + " " + darkerHslArray[2] + "%"
+        }
+
+        if (!input.hasOwnProperty("error-focus")) {
+          const darkerHslArray = Color(input["error"]).darken(0.2).hsl().round().array()
+          resultObj["--erf"] = darkerHslArray[0] + " " + darkerHslArray[1] + "%" + " " + darkerHslArray[2] + "%"
+        }
+
         // auto generate base colors
         if (!input.hasOwnProperty("base-100")) {
           resultObj["--b1"] = 0 + " " + 0 + "%" + " " + 100 + "%";

--- a/src/colors/index.js
+++ b/src/colors/index.js
@@ -37,15 +37,19 @@ let colorObject = {
   "base-content": withOpacityValue("--bc"),
 
   info: withOpacityValue("--in"),
+  "info-focus": withOpacityValue("--inf", "--in"),
   "info-content": withOpacityValue("--inc", "--nc"),
 
   success: withOpacityValue("--su"),
+  "success-focus": withOpacityValue("--suf", "--su"),
   "success-content": withOpacityValue("--suc", "--nc"),
 
   warning: withOpacityValue("--wa"),
+  "warning-focus": withOpacityValue("--waf", "--wa"),
   "warning-content": withOpacityValue("--wac", "--nc"),
 
   error: withOpacityValue("--er"),
+  "error-focus": withOpacityValue("--erf", "--er"),
   "error-content": withOpacityValue("--erc", "--nc"),
 };
 


### PR DESCRIPTION
Add the following semantic colors:

info-focus
success-focus
warning-focus
error-focus
Primary, secondary and accent colors, have a 'focus' sibling color that is a darker tone.
It would be beneficial if that was also applied to info, success, warning and error.

That would enable designs to have a success / warning box with a fitting border colour etc.