### PR TITLE
Fix bordered menu entry on sub menus

### DIFF
--- a/src/components/styled/menu.css
+++ b/src/components/styled/menu.css
@@ -1,6 +1,6 @@
 .menu {
   &.horizontal {
-    li {
+    > li {
       &.bordered {
         > a,
         > button,


### PR DESCRIPTION
Without this fix:
![image](https://user-images.githubusercontent.com/3696730/212931954-78abfa28-7213-4673-92ac-75cb244755c4.png)

With fix:
![image](https://user-images.githubusercontent.com/3696730/212932061-c4fea2da-a37e-476e-b153-6881d54ad546.png)
