### PR TITLE
Fix #1537: Add input-default class to reset input color

### DIFF
--- a/src/components/styled/input.css
+++ b/src/components/styled/input.css
@@ -63,6 +63,13 @@
   &[disabled] {
     @apply cursor-not-allowed border-base-200 bg-base-200 text-opacity-20 placeholder-base-content placeholder-opacity-20;
   }
+  &-default {
+    @apply border-base-content;
+    &:focus {
+      outline: 2px solid hsla(var(--bc) / 0.2);
+      outline-offset: 2px;
+    }
+  }
   /* &::-webkit-calendar-picker-indicator {
     display: none;
   } */

--- a/src/docs/src/routes/components/input.svelte.md
+++ b/src/docs/src/routes/components/input.svelte.md
@@ -25,6 +25,7 @@ data="{[
   { type:'modifier', class: 'input-success', desc: 'Adds `success` color to input' },
   { type:'modifier', class: 'input-warning', desc: 'Adds `warning` color to input' },
   { type:'modifier', class: 'input-error', desc: 'Adds `error` color to input' },
+  { type:'modifier', class: 'input-default', desc: 'Returns input to default color' },
   { type:'responsive', class: 'input-lg', desc: 'Large size for input' },
   { type:'responsive', class: 'input-md', desc: 'Medium (default) size for input' },
   { type:'responsive', class: 'input-sm', desc: 'Small size for input' },
@@ -169,6 +170,16 @@ data="{[
 }</pre>
 <pre slot="react" use:replace={{ to: $prefix }}>{
 `<input type="text" placeholder="Type here" className="$$input $$input-bordered $$input-error w-full max-w-xs" />`
+}</pre>
+</Component>
+
+<Component title="Error color, returning to default on focus">
+<input type="text" placeholder="Type here" class="input input-bordered input-error w-full max-w-xs focus:input-default" />
+<pre slot="html" use:replace={{ to: $prefix }}>{
+`<input type="text" placeholder="Type here" class="$$input $$input-bordered $$input-error w-full max-w-xs $$focus:input-default" />`
+}</pre>
+<pre slot="react" use:replace={{ to: $prefix }}>{
+`<input type="text" placeholder="Type here" className="$$input $$input-bordered $$input-error w-full max-w-xs $$focus:input-default" />`
 }</pre>
 </Component>
 


### PR DESCRIPTION
Also update the docs to show an example of resetting input style on focus.

---

@saadeghi I could not get the `focus:` variant to work correctly on the docs site in development mode, however, running it with `NODE_ENV=production` functions as expected.

I suspect this is because in development mode, the generated CSS files from daisyui `dist` are imported directly, without the focus variants being generated by the tailwindcss plugin. I attempted to resolve this by forcing generation in both `lib/responsiveRegex.js` and in the tailwind `safelist` in `docs/tailwind.config.cjs`, but neither worked. I couldn't figure out how the CSS is being imported in development mode in order to debug further.