### PR TITLE
Fix small typo in css comments

### DIFF
--- a/src/components/styled/checkbox.css
+++ b/src/components/styled/checkbox.css
@@ -126,7 +126,7 @@
   }
 }
 
-/* backward comptability */
+/* backward compatibility */
 .checkbox-mark {
   @apply hidden;
 }

--- a/src/components/styled/radio.css
+++ b/src/components/styled/radio.css
@@ -106,7 +106,7 @@
   }
 }
 
-/* backward comptability */
+/* backward compatibility */
 .radio-mark {
   @apply hidden;
 }

--- a/src/components/styled/toggle.css
+++ b/src/components/styled/toggle.css
@@ -112,7 +112,7 @@
   }
 }
 
-/* backward comptability */
+/* backward compatibility */
 .toggle-mark {
   @apply hidden;
 }


### PR DESCRIPTION
The word `compatibility` is misspelled in various components. 