### PR TITLE
fix: border-radius in now applied to all tabs, whether active or not (in tabs-boxed layout)

### DIFF
--- a/src/components/styled/tab.css
+++ b/src/components/styled/tab.css
@@ -92,7 +92,10 @@
 }
 .tabs-boxed {
   @apply bg-base-200 p-1 rounded-btn;
+  .tab {
+    @apply rounded-btn;
+  }
   .tab-active {
-    @apply bg-primary text-primary-content rounded-btn hover:text-primary-content;
+    @apply bg-primary text-primary-content hover:text-primary-content;
   }
 }


### PR DESCRIPTION
Hello! I made a very simple and straightforward modification to fix a bug that I found in a project of mine.

**Description of the problem**: In the layout [Boxed Tabs](https://daisyui.com/components/tab/#boxed), the tabs had `border-radius` set only when _active_ (with the attribute `tab-active`).

The implications of such behavior are evident if, for instance, we set a different `background-color` for the other elements:
![immagine](https://user-images.githubusercontent.com/8852116/220436547-681bd125-bb6e-4828-80de-845394f59fa0.png)
Such behavior is also quite annoying while working with transitions or other kind of animations.

**The solution**: The easy and clean solution is simply to apply the `border-radius` to all the `.tab` elements. Even if they are transparent, they will have the property set and they will behave accordingly even when colored or animated.

Thank you very much for such a great and clean project!! :heart: 
