### PR TITLE
fix: #778 fixed border radius of menu and submenu with only child

### DIFF
--- a/src/components/styled/menu.css
+++ b/src/components/styled/menu.css
@@ -89,6 +89,18 @@
   border-bottom-right-radius: inherit;
   border-bottom-left-radius: inherit;
 }
+.menu > :where(li:first-child:last-child) {
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+.menu > :where(li:first-child:last-child) > :where(:not(ul)) {
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
 
 .menu > :where(li) > :where(ul) {
   border-top-left-radius: inherit;
@@ -128,6 +140,18 @@
 .menu > :where(li) > :where(ul) > :where(li:last-child) > :where(:not(ul)) {
   border-top-left-radius: unset;
   border-top-right-radius: unset;
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+.menu > :where(li) > :where(ul) > :where(li:first-child:last-child) {
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+.menu > :where(li) > :where(ul) > :where(li:first-child:last-child) > :where(:not(ul)) {
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
   border-bottom-right-radius: inherit;
   border-bottom-left-radius: inherit;
 }


### PR DESCRIPTION
When there's an only child, both the `:first-child` and `:last-child` selectors match on the same element. Because of how CSS manages conflicting rules, the latter rule overrides the former, resulting in the top-left and top-right border radius getting unset.

I've added two rules for the menu and two more for the submenu in order to handle this specific case, targeting a child which is both first and last child. If that is the case we want all four corners to be set on `border-radius: inherit`.