### PR TITLE
fix: safari radio component transition

### DIFF
--- a/src/components/styled/radio.css
+++ b/src/components/styled/radio.css
@@ -1,7 +1,6 @@
 .radio {
   --chkbg: var(--bc);
   @apply h-6 w-6 cursor-pointer appearance-none rounded-full border border-base-content border-opacity-20;
-  transition: background, box-shadow var(--animation-input, 0.2s) ease-in-out;
   &:focus-visible {
     outline: 2px solid hsl(var(--bc));
     outline-offset: 2px;


### PR DESCRIPTION
the transition of radio component doesn't work well at Safari.

https://user-images.githubusercontent.com/62830430/234827331-4ac1ad69-a0ad-49d9-84b2-12905740b53d.mov
![video-to-gif-converter](https://user-images.githubusercontent.com/62830430/234828351-1fcdd8fb-5138-4cf5-8d8b-58e4225a938b.gif)

removing this transition doesn't change any animation effect of radio.
