### PR TITLE
feat: use for border radius -box instead of -xl so they can match with theme configuration

### DIFF
--- a/src/components/styled/table.css
+++ b/src/components/styled/table.css
@@ -48,11 +48,11 @@
   :where(*:first-child) {
     :where(th, td) {
       &:first-child {
-        @apply rounded-tl-lg;
+        @apply rounded-tl-box;
       }
 
       &:last-child {
-        @apply rounded-tr-lg;
+        @apply rounded-tr-box;
       }
     }
   }
@@ -62,11 +62,11 @@
   :where(*:last-child) {
     :where(th, td) {
       &:first-child {
-        @apply rounded-bl-lg;
+        @apply rounded-bl-box;
       }
 
       &:last-child {
-        @apply rounded-br-lg;
+        @apply rounded-br-box;
       }
     }
   }


### PR DESCRIPTION
So the table uses the normal tailwind classes
```
 @apply rounded-tl-lg;
 @apply rounded-tr-lg;
 @apply rounded-bl-lg;
 @apply rounded-br-lg;
 ```

this  dosnt match with themes that dont have border radius

so i made that they use the daisyui -box modifier
```
@apply rounded-tl-box;
@apply rounded-tr-box;
@apply rounded-bl-box;
@apply rounded-br-box;
```
now the table border radius match with the theme config