### PR TITLE
fix: btn-group right-to-left direction border radius

### DIFF
--- a/src/utilities/styled/button.css
+++ b/src/utilities/styled/button.css
@@ -1,58 +1,58 @@
 /* group */
 .btn-group {
   .btn:not(:first-child):not(:last-child) {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-start-radius: 0;
+    border-start-end-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
   }
   .btn:first-child:not(:last-child) {
     @apply -mt-0 -ml-px;
-    border-top-left-radius: var(--rounded-btn, 0.5rem);
-    border-top-right-radius: 0;
-    border-bottom-left-radius: var(--rounded-btn, 0.5rem);
-    border-bottom-right-radius: 0;
+    border-start-start-radius: var(--rounded-btn, 0.5rem);
+    border-start-end-radius: 0;
+    border-end-start-radius: var(--rounded-btn, 0.5rem);
+    border-end-end-radius: 0;
   }
   .btn:last-child:not(:first-child) {
-    border-top-left-radius: 0;
-    border-top-right-radius: var(--rounded-btn, 0.5rem);
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: var(--rounded-btn, 0.5rem);
+    border-start-start-radius: 0;
+    border-start-end-radius: var(--rounded-btn, 0.5rem);
+    border-end-start-radius: 0;
+    border-end-end-radius: var(--rounded-btn, 0.5rem);
   }
   &-horizontal {
     .btn:not(:first-child):not(:last-child) {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      border-start-start-radius: 0;
+      border-start-end-radius: 0;
+      border-end-start-radius: 0;
+      border-end-end-radius: 0;
     }
     .btn:first-child:not(:last-child) {
       @apply -mt-0 -ml-px;
-      border-top-left-radius: var(--rounded-btn, 0.5rem);
-      border-top-right-radius: 0;
-      border-bottom-left-radius: var(--rounded-btn, 0.5rem);
-      border-bottom-right-radius: 0;
+      border-start-start-radius: var(--rounded-btn, 0.5rem);
+      border-start-end-radius: 0;
+      border-end-start-radius: var(--rounded-btn, 0.5rem);
+      border-end-end-radius: 0;
     }
     .btn:last-child:not(:first-child) {
-      border-top-left-radius: 0;
-      border-top-right-radius: var(--rounded-btn, 0.5rem);
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: var(--rounded-btn, 0.5rem);
+      border-start-start-radius: 0;
+      border-start-end-radius: var(--rounded-btn, 0.5rem);
+      border-end-start-radius: 0;
+      border-end-end-radius: var(--rounded-btn, 0.5rem);
     }
   }
   &-vertical {
     .btn:first-child:not(:last-child) {
       @apply -mt-px -ml-0;
-      border-top-left-radius: var(--rounded-btn, 0.5rem);
-      border-top-right-radius: var(--rounded-btn, 0.5rem);
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      border-start-start-radius: var(--rounded-btn, 0.5rem);
+      border-start-end-radius: var(--rounded-btn, 0.5rem);
+      border-end-start-radius: 0;
+      border-end-end-radius: 0;
     }
     .btn:last-child:not(:first-child) {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-      border-bottom-left-radius: var(--rounded-btn, 0.5rem);
-      border-bottom-right-radius: var(--rounded-btn, 0.5rem);
+      border-start-start-radius: 0;
+      border-start-end-radius: 0;
+      border-end-start-radius: var(--rounded-btn, 0.5rem);
+      border-end-end-radius: var(--rounded-btn, 0.5rem);
     }
   }
 }


### PR DESCRIPTION
This PR fixes the button group border-radius issue on the right-to-left pages.

Before:
![image](https://github.com/saadeghi/daisyui/assets/17345129/e68b7bff-e3cf-439a-a41a-b8ed6787bde5)

After:
![image](https://github.com/saadeghi/daisyui/assets/17345129/ffec98b8-dc94-45de-bc07-2f5bbeafb9e1)
