### PR TITLE
fix: tooltip z-index

### DIFF
--- a/src/components/unstyled/tooltip.css
+++ b/src/components/unstyled/tooltip.css
@@ -5,13 +5,14 @@
 .tooltip:before {
   @apply absolute;
   pointer-events: none;
-  z-index: 1;
+  z-index: 999;
 }
 .tooltip:before {
   content: var(--tw-content);
   --tw-content: attr(data-tip);
 }
-.tooltip, .tooltip-top {
+.tooltip,
+.tooltip-top {
   &:before {
     transform: translateX(-50%);
     top: auto;


### PR DESCRIPTION
Fixes bug: tooltip z-index should be greater than `<th>` element #1798
Fixes #1798 