### PR TITLE
Navbar example closes details tag in the wrong order

### DIFF
--- a/src/docs/src/routes/components/navbar/+page.svelte.md
+++ b/src/docs/src/routes/components/navbar/+page.svelte.md
@@ -100,14 +100,14 @@ data="{[
     <ul class="menu menu-horizontal px-1 bg-base-100">
       <li><a>Link</a></li>
       <li>
-      <details>
-        <summary>
-          Parent
-        </summary>
-        <ul class="p-2 bg-base-100">
-          <li><a>Link 1</a></li>
-          <li><a>Link 2</a></li>
-        </ul>
+        <details>
+          <summary>
+            Parent
+          </summary>
+          <ul class="p-2 bg-base-100">
+            <li><a>Link 1</a></li>
+            <li><a>Link 2</a></li>
+          </ul>
         </details>
       </li>
     </ul>
@@ -122,16 +122,16 @@ data="{[
     <ul class="$$menu $$menu-horizontal px-1">
       <li><a>Link</a></li>
       <li>
-      <details>
-        <summary>
-          Parent
-        </summary>
-        <ul class="p-2 bg-base-100">
-          <li><a>Link 1</a></li>
-          <li><a>Link 2</a></li>
-        </ul>
+        <details>
+          <summary>
+            Parent
+          </summary>
+          <ul class="p-2 bg-base-100">
+            <li><a>Link 1</a></li>
+            <li><a>Link 2</a></li>
+          </ul>
+        </details>
       </li>
-      </details>
     </ul>
   </div>
 </div>`


### PR DESCRIPTION
Make `<details>` tags close in the correct order and not straddle `<li>` tags, and also make the indentation standard to match the other examples.