### PR TITLE
fix(homepage): center get started button on md and lg

### DIFF
--- a/src/docs/src/routes/+page.svelte
+++ b/src/docs/src/routes/+page.svelte
@@ -977,7 +977,7 @@
           )}
         </p>
         <div class="h-10" />
-        <div class="flex w-full justify-center md:justify-start">
+        <div class="flex w-full justify-center xl:justify-start">
           <a
             data-sveltekit-preload-data="hover"
             href="/docs/install"


### PR DESCRIPTION
Fixes "Get Started" button alignment in the homepage when breakpoint is md or lg.

<details>
  <summary>Current behaviour:</summary>

![old = md](https://github.com/saadeghi/daisyui/assets/6226131/7a7637d2-8db0-48b8-ab3c-bad4e9587f59)
</details>

<details>
  <summary>Fixed behaviour:</summary>

![new = md](https://github.com/saadeghi/daisyui/assets/6226131/0d829464-4d49-4b9e-ab46-798b86bb3483)
</details>

Other breakpoints remain unchanged:

<details>
  <summary>Up to sm:</summary>

![ md](https://github.com/saadeghi/daisyui/assets/6226131/123f9b10-79d9-48f7-aaff-14e8a288b315)
</details>

<details>
  <summary>Xl onwards:</summary>

![ md](https://github.com/saadeghi/daisyui/assets/6226131/80069528-eac7-45d5-9e64-f586775e761f)
</details>