### PR TITLE
Fix doc's jsx sample for navbar menu with submenu

### DIFF
--- a/src/docs/src/routes/components/navbar/+page.svelte.md
+++ b/src/docs/src/routes/components/navbar/+page.svelte.md
@@ -122,16 +122,16 @@ data="{[
     <ul class="$$menu $$menu-horizontal px-1">
       <li><a>Link</a></li>
       <li>
-      <details>
-        <summary>
-          Parent
-        </summary>
-        <ul class="p-2 bg-base-100">
-          <li><a>Link 1</a></li>
-          <li><a>Link 2</a></li>
-        </ul>
+        <details>
+          <summary>
+            Parent
+          </summary>
+          <ul class="p-2 bg-base-100">
+            <li><a>Link 1</a></li>
+            <li><a>Link 2</a></li>
+          </ul>
+        </details>
       </li>
-      </details>
     </ul>
   </div>
 </div>`


### PR DESCRIPTION
While testing JSX sample for "Navbar with menu and submenu".. with Qwik, saw error for `<details>` tag not closing properly.

The sample code had a slight mis-order 

```
  <li>
    <details>
      ...
  </li>
  </details>
```

bringing closing `</details>` tag under `<li/>` fixes the run issue & is the correct nesting anyway.