### PR TITLE
fix: #1888 drawer now animates out

### DIFF
--- a/src/components/unstyled/drawer.css
+++ b/src/components/unstyled/drawer.css
@@ -2,7 +2,7 @@
   @apply grid relative;
   grid-auto-columns: max-content auto;
   &-content {
-    @apply row-start-1 col-start-2 translate-x-0 transition-all;
+    @apply row-start-1 col-start-2;
   }
   &-side {
     @apply w-full pointer-events-none grid grid-cols-1 grid-rows-1 items-start justify-items-start overscroll-contain row-start-1 col-start-1 fixed top-0 left-0 overflow-y-auto;
@@ -27,11 +27,8 @@
     }
   }
   &-toggle {
-    @apply fixed h-0 w-0 appearance-none opacity-0; 
+    @apply fixed h-0 w-0 appearance-none opacity-0;
     &:checked {
-      & ~ .drawer-content {
-        @apply translate-x-2;
-      }
       & ~ .drawer-side {
         @apply visible pointer-events-auto;
         & > *:not(.drawer-overlay) {

--- a/src/components/unstyled/drawer.css
+++ b/src/components/unstyled/drawer.css
@@ -2,7 +2,7 @@
   @apply grid relative;
   grid-auto-columns: max-content auto;
   &-content {
-    @apply row-start-1 col-start-2;
+    @apply row-start-1 col-start-2 translate-x-0 transition-all;
   }
   &-side {
     @apply w-full pointer-events-none grid grid-cols-1 grid-rows-1 items-start justify-items-start overscroll-contain row-start-1 col-start-1 fixed top-0 left-0 overflow-y-auto;
@@ -28,10 +28,15 @@
   }
   &-toggle {
     @apply fixed h-0 w-0 appearance-none opacity-0; 
-    &:checked ~ .drawer-side {
-      @apply visible pointer-events-auto;
-      & > *:not(.drawer-overlay) {
-        transform: translateX(0%);
+    &:checked {
+      & ~ .drawer-content {
+        @apply translate-x-2;
+      }
+      & ~ .drawer-side {
+        @apply visible pointer-events-auto;
+        & > *:not(.drawer-overlay) {
+          transform: translateX(0%);
+        }
       }
     }
   }

--- a/src/components/unstyled/drawer.css
+++ b/src/components/unstyled/drawer.css
@@ -5,12 +5,18 @@
     @apply row-start-1 col-start-2;
   }
   &-side {
-    @apply invisible w-full pointer-events-none grid grid-cols-1 grid-rows-1 items-start justify-items-start overscroll-contain row-start-1 col-start-1 fixed top-0 left-0 overflow-y-auto;
+    @apply w-full pointer-events-none grid grid-cols-1 grid-rows-1 items-start justify-items-start overscroll-contain row-start-1 col-start-1 fixed top-0 left-0 overflow-y-auto;
     height: 100vh;
     height: 100dvh;
     scrollbar-width: none;
     &::-webkit-scrollbar {
       @apply hidden;
+    }
+    & > .drawer-overlay {
+      @apply place-self-stretch sticky top-0;
+    }
+    & > * {
+      @apply col-start-1 row-start-1;
     }
     & > *:not(.drawer-overlay) {
       transition: transform 0.4s cubic-bezier(0, 0, 0.58, 1);
@@ -21,17 +27,11 @@
     }
   }
   &-toggle {
-    @apply fixed h-0 w-0 appearance-none opacity-0;
+    @apply fixed h-0 w-0 appearance-none opacity-0; 
     &:checked ~ .drawer-side {
       @apply visible pointer-events-auto;
-      & > * {
-        @apply col-start-1 row-start-1;
-        &:not(.drawer-overlay) {
-          transform: translateX(0%);
-        }
-      }
-      & > .drawer-overlay {
-        @apply place-self-stretch sticky top-0;
+      & > *:not(.drawer-overlay) {
+        transform: translateX(0%);
       }
     }
   }


### PR DESCRIPTION
Fixes bug #1888, `drawer-overlay`'s dimensions no longer collapse and `drawer-side` no longer disappears when the drawer is closed.

https://github.com/saadeghi/daisyui/assets/54014569/c285ba58-effe-44f5-9dbf-062f85c086ec

