### PR TITLE
fix #1992: add/fix anims and improve docs for collapse

### DIFF
--- a/src/components/unstyled/collapse.css
+++ b/src/components/unstyled/collapse.css
@@ -37,7 +37,7 @@
 .collapse:focus:not(.collapse-close) .collapse-content,
 .collapse:not(.collapse-close) input[type="checkbox"]:checked ~ .collapse-content,
 .collapse:not(.collapse-close) input[type="radio"]:checked ~ .collapse-content {
-  @apply visible min-h-fit h-auto translate-y-0;
+  @apply visible min-h-fit translate-y-0;
   & > * {
     @apply translate-y-0;
     transition: transform 0s ease-in-out;

--- a/src/components/unstyled/collapse.css
+++ b/src/components/unstyled/collapse.css
@@ -17,8 +17,11 @@
   @apply appearance-none opacity-0;
 }
 .collapse-content {
-  @apply col-start-1 row-start-2 invisible min-h-0;
-  transition: visibility 0.2s;
+  @apply col-start-1 row-start-2 min-h-0;
+  & > * {
+    @apply translate-y-4;
+    transition: transform 0.2s ease-in-out;
+  }
 }
 .collapse[open],
 .collapse-open,
@@ -34,5 +37,9 @@
 .collapse:focus:not(.collapse-close) .collapse-content,
 .collapse:not(.collapse-close) input[type="checkbox"]:checked ~ .collapse-content,
 .collapse:not(.collapse-close) input[type="radio"]:checked ~ .collapse-content {
-  @apply visible min-h-fit;
+  @apply visible min-h-fit h-auto translate-y-0;
+  & > * {
+    @apply translate-y-0;
+    transition: transform 0s ease-in-out;
+  }
 }

--- a/src/components/unstyled/collapse.css
+++ b/src/components/unstyled/collapse.css
@@ -17,11 +17,8 @@
   @apply appearance-none opacity-0;
 }
 .collapse-content {
-  @apply col-start-1 row-start-2 min-h-0;
-  & > * {
-    @apply translate-y-4;
-    transition: transform 0.2s ease-in-out;
-  }
+  @apply col-start-1 row-start-2 invisible min-h-0;
+  transition: visibility 0.2s;
 }
 .collapse[open],
 .collapse-open,
@@ -37,9 +34,5 @@
 .collapse:focus:not(.collapse-close) .collapse-content,
 .collapse:not(.collapse-close) input[type="checkbox"]:checked ~ .collapse-content,
 .collapse:not(.collapse-close) input[type="radio"]:checked ~ .collapse-content {
-  @apply visible min-h-fit translate-y-0;
-  & > * {
-    @apply translate-y-0;
-    transition: transform 0s ease-in-out;
-  }
+  @apply visible min-h-fit;
 }

--- a/src/docs/src/routes/components/collapse/+page.svelte.md
+++ b/src/docs/src/routes/components/collapse/+page.svelte.md
@@ -223,20 +223,20 @@ data="{[
 <Component title="Custom colors for collapse that works with checkbox" desc="Use Tailwind CSS `peer` and `peer-checked` utilities to apply style when sibling checkbox is checked">
 <div class="collapse bg-base-200">
   <input type="checkbox" class="peer" /> 
-  <div class="collapse-title bg-primary text-primary-content [input:checked~&]:bg-secondary [input:checked~&]:text-secondary-content">
+  <div class="collapse-title bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
     Click me to show/hide content
   </div>
-  <div class="collapse-content bg-primary text-primary-content [input:checked~&]:bg-secondary [input:checked~&]:text-secondary-content"> 
+  <div class="collapse-content bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content"> 
     <p>hello</p>
   </div>
 </div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<div class="collapse bg-base-200">
   <input type="checkbox" class="peer" /> 
-  <div class="$$collapse-title bg-primary text-primary-content [input:checked~&]:bg-secondary [input:checked~&]:text-secondary-content">
+  <div class="$$collapse-title bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
     Click me to show/hide content
   </div>
-  <div class="$$collapse-content bg-primary text-primary-content [input:checked~&]:bg-secondary [input:checked~&]:text-secondary-content"> 
+  <div class="$$collapse-content bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content"> 
     <p>hello</p>
   </div>
 </div>`


### PR DESCRIPTION
Added animations and fixed the border radius bug on the collapse component when it closes. I also changed [this part of the documentation for collapse](https://daisyui.com/components/collapse/#custom-colors-for-collapse-that-works-with-checkbox) to use `peer-checked` like it suggests in the info box above the code box.

Example of new behavior:


https://github.com/saadeghi/daisyui/assets/54014569/7a1e96a4-920f-40d0-873d-746a7501c729

