### PR TITLE
fix: #1995 invalid "for" property in examples

### DIFF
--- a/src/docs/src/routes/components/modal/+page.svelte.md
+++ b/src/docs/src/routes/components/modal/+page.svelte.md
@@ -138,7 +138,7 @@ data="{[
 <button class="$$btn" onclick="my_modal_3.showModal()">open modal</button>
 <dialog id="my_modal_3" class="$$modal">
   <form method="dialog" class="$$modal-box">
-    <button for="my-modal-3" class="$$btn $$btn-sm $$btn-circle $$btn-ghost absolute right-2 top-2">✕</button>
+    <button class="$$btn $$btn-sm $$btn-circle $$btn-ghost absolute right-2 top-2">✕</button>
     <h3 class="font-bold text-lg">Hello!</h3>
     <p class="py-4">Press ESC key or click on ✕ button to close</p>
   </form>
@@ -149,7 +149,7 @@ data="{[
 <button className="$$btn" onClick={()=>window.my_modal_3.showModal()}>open modal</button>
 <dialog id="my_modal_3" className="$$modal">
   <form method="dialog" className="$$modal-box">
-    <button for="my-modal-3" className="$$btn $$btn-sm $$btn-circle $$btn-ghost absolute right-2 top-2">✕</button>
+    <button className="$$btn $$btn-sm $$btn-circle $$btn-ghost absolute right-2 top-2">✕</button>
     <h3 className="font-bold text-lg">Hello!</h3>
     <p className="py-4">Press ESC key or click on ✕ button to close</p>
   </form>


### PR DESCRIPTION
In the PR #1923, this issue was fixed in the component itself.

This PR also removes it from the example code.