### PR TITLE
Add missing `$` to `Join` docs

### DIFF
--- a/src/docs/src/routes/components/join/+page.svelte.md
+++ b/src/docs/src/routes/components/join/+page.svelte.md
@@ -43,9 +43,9 @@ data="{[
 </div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<div class="$$join $$join-vertical">
-  <button class="$btn $$join-item">Button</button>
-  <button class="$btn $$join-item">Button</button>
-  <button class="$btn $$join-item">Button</button>
+  <button class="$$btn $$join-item">Button</button>
+  <button class="$$btn $$join-item">Button</button>
+  <button class="$$btn $$join-item">Button</button>
 </div>`
 }</pre>
 </Component>


### PR DESCRIPTION
In the [docs](https://daisyui.com/components/join/#group-items-vertically) at `Group items vertically` there is a typo. This fixes the typo.