### PR TITLE
fix docs for customizing themes

### DIFF
--- a/src/docs/src/routes/docs/themes/+page.svelte.md
+++ b/src/docs/src/routes/docs/themes/+page.svelte.md
@@ -230,7 +230,7 @@ module.exports = {
     themes: [
       {
         light: {
-          ...require("daisyui/src/theming/themes")["[data-theme=light]"],
+          ...require("daisyui/src/colors/themes")["[data-theme=light]"],
           "primary": "blue",
           "primary-focus": "mediumblue",
         },
@@ -252,7 +252,7 @@ module.exports = {
     themes: [
       {
         light: {
-          ...require("daisyui/src/theming/themes")["[data-theme=light]"],
+          ...require("daisyui/src/colors/themes")["[data-theme=light]"],
           ".btn-twitter": {
             "background-color": "#1EA1F1",
             "border-color": "#1EA1F1",


### PR DESCRIPTION
RIght now the docs for "How to customize an existing theme?" and  "How to add custom styles for a specific theme?" says we have to require `...require("daisyui/src/theming/themes")["[data-theme=light]"]` but this line give me an error, so I fix this error by changing to `...require("daisyui/src/colors/themes")["[data-theme=light]"]` 

Screenshot for the error
<img width="512" alt="image" src="https://github.com/saadeghi/daisyui/assets/49960993/9eaf4bd5-2234-439a-baa4-e5df80965511">
<img width="802" alt="image" src="https://github.com/saadeghi/daisyui/assets/49960993/1b1123e4-75a3-4da6-b6d0-70ebf5fbf7e7">
