### PR TITLE
feat: add theme extraction helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "!dist/*.rtl.css",
     "src/index.js",
     "src/theming/*.js",
+    "src/helpers/*.*",
     "src/index.d.ts"
   ],
   "engines": {

--- a/src/helpers/index.d.ts
+++ b/src/helpers/index.d.ts
@@ -1,0 +1,29 @@
+export interface ThemeColors {
+    primary: string;
+    primaryFocus: string;
+    primaryContent: string;
+    secondary: string;
+    secondaryFocus: string;
+    secondaryContent: string;
+    accent: string;
+    accentFocus: string;
+    accentContent: string;
+    neutral: string;
+    neutralFocus: string;
+    neutralContent: string;
+    base100: string;
+    base200: string;
+    base300: string;
+    baseContent: string;
+    info: string;
+    infoContent: string;
+    success: string;
+    successContent: string;
+    warning: string;
+    warningContent: string;
+    error: string;
+    errorContent: string;
+}
+
+
+export function extractThemeColorsFromDOM(): ThemeColors

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,31 @@
+function extractThemeColorsFromDOM() {
+    const computedStyles = getComputedStyle(document.querySelector(':root'));
+    return {
+        primary: `hsl(${computedStyles.getPropertyValue('--p')}`,
+        primaryFocus: `hsl(${computedStyles.getPropertyValue('--pf')}`,
+        primaryContent: `hsl(${computedStyles.getPropertyValue('--pc')}`,
+        secondary: `hsl(${computedStyles.getPropertyValue('--s')}`,
+        secondaryFocus: `hsl(${computedStyles.getPropertyValue('--sf')}`,
+        secondaryContent: `hsl(${computedStyles.getPropertyValue('--sc')}`,
+        accent: `hsl(${computedStyles.getPropertyValue('--a')}`,
+        accentFocus: `hsl(${computedStyles.getPropertyValue('--af')}`,
+        accentContent: `hsl(${computedStyles.getPropertyValue('--ac')}`,
+        neutral: `hsl(${computedStyles.getPropertyValue('--n')}`,
+        neutralFocus: `hsl(${computedStyles.getPropertyValue('--nf')}`,
+        neutralContent: `hsl(${computedStyles.getPropertyValue('--nc')}`,
+        base100: `hsl(${computedStyles.getPropertyValue('--b1')}`,
+        base200: `hsl(${computedStyles.getPropertyValue('--b2')}`,
+        base300: `hsl(${computedStyles.getPropertyValue('--b3')}`,
+        baseContent: `hsl(${computedStyles.getPropertyValue('--bc')}`,
+        info: `hsl(${computedStyles.getPropertyValue('--in')}`,
+        infoContent: `hsl(${computedStyles.getPropertyValue('--inc')}`,
+        success: `hsl(${computedStyles.getPropertyValue('--su')}`,
+        successContent: `hsl(${computedStyles.getPropertyValue('--suc')}`,
+        warning: `hsl(${computedStyles.getPropertyValue('--wa')}`,
+        warningContent: `hsl(${computedStyles.getPropertyValue('--wac')}`,
+        error: `hsl(${computedStyles.getPropertyValue('--er')}`,
+        errorContent: `hsl(${computedStyles.getPropertyValue('--erc')}`,
+    };
+}
+
+module.exports = {extractThemeColorsFromDOM}


### PR DESCRIPTION
This PR adds a utility function to extract the theme from the DOM, as discussed here: https://github.com/saadeghi/daisyui/discussions/415#discussioncomment-6406762

I'm afraid I didn't add documentation for this, since I have no idea how the documentation works. 