### PR TITLE
remove taiwan flag

### DIFF
--- a/src/docs/src/components/LangChange.svelte
+++ b/src/docs/src/components/LangChange.svelte
@@ -34,7 +34,7 @@
         {#if $t("__name", {}, langItem, false) !== "__name"}
           <li>
             <button class:active={$currentLang == langItem} on:click={() => setLang(langItem)}>
-              {#if $t("__flag", {}, langItem, false) !== "__flag"}
+              {#if $t("__flag", {}, langItem, false) !== "__flag" && $t("__name_en", {}, langItem, false) !== "taiwan"}
                 <img
                   class="drop-shadow"
                   loading="lazy"

--- a/src/docs/src/translation/zh_tw.json
+++ b/src/docs/src/translation/zh_tw.json
@@ -1,5 +1,6 @@
 {
   "__name": "繁體中文",
+  "__name_en": "taiwan",
   "__flag": "🇹🇼",
   "__status": "",
   "Tailwind CSS Components": "Tailwind CSS 元件",


### PR DESCRIPTION
Hi, @saadeghi ,Thanks for your hard work to bring this awesome css lib to us developers.

This PR is just a fix to daisyui docs website, which make a mistake at TaiWan flag.

TaiWan is not a country, is essentially a province of China. currently it's a district because of some history reasons.

So, TaiWan flag should not be placed along with other REAL country flags, It's a big misleading to website visitors.

----------------

Besides, 繁体中文，not only spoken by taiwan people, but also HongKong people, Macao people and many overseas-chinese people.
so taiwan flag can not represents 繁体中文 at all. 

----------------
My fix is to hidden taiwan flag, and preserve 繁体中文 name. below are screenshots showing brefore and after views:

Before:

<img width="379" alt="Screen Shot 2023-07-19 at 5 55 56 PM" src="https://github.com/saadeghi/daisyui/assets/5372618/0a2d7e1b-e87d-4649-891a-a3d92ebe74a4">

After:

![Screen Shot 2023-07-19 at 6 47 25 PM](https://github.com/saadeghi/daisyui/assets/5372618/45a9a582-679a-49b1-86ae-013a84803745)
