### PR TITLE
added :not(.join)

### DIFF
--- a/src/components/unstyled/join.css
+++ b/src/components/unstyled/join.css
@@ -7,7 +7,7 @@
     border-top-left-radius: 0;
   }
   & .join-item:not(:first-child):not(:last-child),
-  & *:not(:first-child):not(:last-child) .join-item {
+  & *:not(:first-child):not(:last-child):not(.join) .join-item {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
@@ -15,25 +15,25 @@
   }
 
   & .join-item:first-child:not(:last-child),
-  & *:first-child:not(:last-child) .join-item {
+  & *:first-child:not(:last-child):not(.join) .join-item {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
 
   & :where(.join-item:first-child:not(:last-child)),
-  & :where(*:first-child:not(:last-child) .join-item) {
+  & :where(*:first-child:not(:last-child):not(.join) .join-item) {
     border-bottom-left-radius: inherit;
     border-top-left-radius: inherit;
   }
 
   & .join-item:last-child:not(:first-child),
-  & *:last-child:not(:first-child) .join-item {
+  & *:last-child:not(:first-child):not(.join) .join-item {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
   }
 
   & :where(.join-item:last-child:not(:first-child)),
-  & :where(*:last-child:not(:first-child) .join-item) {
+  & :where(*:last-child:not(:first-child):not(.join) .join-item) {
     border-top-right-radius: inherit;
     border-bottom-right-radius: inherit;
   }


### PR DESCRIPTION
Allows for the "pulling out" of a `join-item` from the border-radius first/last rounding system, by using nested `join`s.

_e.g.:_

`before`
![image](https://github.com/saadeghi/daisyui/assets/4650770/090624ad-cb94-43fb-b749-e0e97a891f97)

`after`
![image](https://github.com/saadeghi/daisyui/assets/4650770/c0277e3e-819f-46f4-b7da-6470b4912222)

```html
<div class="join">
    <button class="btn pointer-events-none">Types</button>
    <div class="join">
        <input class="join-item btn btn-outline" type="checkbox" aria-label="Shares">
        <input class="join-item btn btn-outline" type="checkbox" aria-label="Photos">
        <input class="join-item btn btn-outline" type="checkbox" aria-label="Videos">
    </div>
</div>
```