### PR TITLE
docs: typo correction in the src/docs/src/translation/pt.json

### DIFF
--- a/src/docs/src/translation/pt.json
+++ b/src/docs/src/translation/pt.json
@@ -305,7 +305,7 @@
   "Make your theme": "Faça seu tema",
   "More examples": "Mais exemplos",
   "Support daisyUI's development": "Suporte ao desenvolvimento da daisyUI",
-  "The most popular": "O mais popular",
+  "The most popular": "A mais popular",
   "component library": "biblioteca de componentes",
   "for Tailwind CSS": "para Tailwind CSS",
   "daisyUI adds component class names to Tailwind&nbsp;CSS<br /> so you can make beautiful websites <span class='border-base-content/20 border-b-2'>faster than ever.</span>": "daisyUI adiciona nomes de classe de componentes ao Tailwind&nbsp;CSS<br /> para que você possa criar sites bonitos <span class='border-base-content/20 border-b-2'>mais rápido do que nunca.</span>",


### PR DESCRIPTION
In this pull request, I made a correction to the title of the home page to improve verb agreement. I changed "O mais popular biblioteca de componentes" to "A mais popular biblioteca de componentes". This adjustment ensures that the adjective "popular" agrees correctly with the feminine singular noun "biblioteca" in the Portuguese language.

In the Portuguese language, noun-adjective agreement is an essential grammatical feature. Adjectives must agree in gender (masculine or feminine) and number (singular or plural) with the nouns they modify. This agreement helps to maintain clarity and precision in communication, as it ensures that adjectives match the gender and number of the nouns they refer to.