### PR TITLE
fx: modify CSS selector of menu's children

### DIFF
--- a/src/components/unstyled/menu.css
+++ b/src/components/unstyled/menu.css
@@ -3,7 +3,7 @@
   :where(li ul) {
     @apply relative whitespace-nowrap;
   }
-  :where(li:not(.menu-title) > *:not(ul):not(details):not(.menu-title)),
+  :where(li:not(.menu-title) > *:not(ul):not(details):not(.menu-title):not(style):not(script):not(astro-island)),
   :where(li:not(.menu-title) > details > summary:not(.menu-title)) {
     @apply grid grid-flow-col items-center gap-2 content-start;
     grid-auto-columns: minmax(auto, max-content) auto max-content;


### PR DESCRIPTION
Hi

I used to daisyui with astro but It has issue.

li tag's children in .menu selector gives display: grid style almost everything. because It's asterisk selector. even though style, script, astro-island tag!

- My code
![Untitled](https://github.com/saadeghi/daisyui/assets/63291908/9783fef1-5e92-4238-abb9-2fb6049c37fe)
![Untitled](https://github.com/saadeghi/daisyui/assets/63291908/f445f45f-de9b-4c27-b6cf-dd3e423cecdd)

- Result
![Untitled](https://github.com/saadeghi/daisyui/assets/63291908/6e906011-f6bd-4372-9c52-80c0419cd6af)
![Untitled](https://github.com/saadeghi/daisyui/assets/63291908/81659c43-c4d8-4149-97a4-d810e97cf812)
