### PR TITLE
feat(collapse): inherit focus state from children via `:focus-within`

### DIFF
--- a/src/components/styled/collapse.css
+++ b/src/components/styled/collapse.css
@@ -48,7 +48,7 @@ details.collapse summary {
 .collapse:not(.collapse-open):not(.collapse-close) .collapse-title {
   @apply cursor-pointer;
 }
-.collapse:focus:not(.collapse-open):not(.collapse-close):not(.collapse[open]) .collapse-title {
+.collapse:focus-within:not(.collapse-open):not(.collapse-close):not(.collapse[open]) .collapse-title {
   cursor: unset;
 }
 .collapse-title {
@@ -73,7 +73,7 @@ details.collapse summary {
 }
 .collapse[open] :where(.collapse-content),
 .collapse-open :where(.collapse-content),
-.collapse:focus:not(.collapse-close) :where(.collapse-content),
+.collapse:focus-within:not(.collapse-close) :where(.collapse-content),
 .collapse:not(.collapse-close) :where(input[type="checkbox"]:checked ~ .collapse-content),
 .collapse:not(.collapse-close) :where(input[type="radio"]:checked ~ .collapse-content) {
   @apply pb-4;
@@ -82,14 +82,14 @@ details.collapse summary {
 
 .collapse[open].collapse-arrow .collapse-title:after,
 .collapse-open.collapse-arrow .collapse-title:after,
-.collapse-arrow:focus:not(.collapse-close) .collapse-title:after,
+.collapse-arrow:focus-within:not(.collapse-close) .collapse-title:after,
 .collapse-arrow:not(.collapse-close) input[type="checkbox"]:checked ~ .collapse-title:after,
 .collapse-arrow:not(.collapse-close) input[type="radio"]:checked ~ .collapse-title:after {
   @apply rotate-[225deg] translate-y-[-50%];
 }
 [dir="rtl"] .collapse[open].collapse-arrow .collapse-title:after,
 [dir="rtl"] .collapse-open.collapse-arrow .collapse-title:after,
-[dir="rtl"] .collapse-arrow:focus:not(.collapse-close) .collapse-title:after,
+[dir="rtl"] .collapse-arrow:focus-within:not(.collapse-close) .collapse-title:after,
 [dir="rtl"]
   .collapse-arrow:not(.collapse-close)
   input[type="checkbox"]:checked
@@ -98,7 +98,7 @@ details.collapse summary {
 }
 .collapse[open].collapse-plus .collapse-title:after,
 .collapse-open.collapse-plus .collapse-title:after,
-.collapse-plus:focus:not(.collapse-close) .collapse-title:after,
+.collapse-plus:focus-within:not(.collapse-close) .collapse-title:after,
 .collapse-plus:not(.collapse-close) input[type="checkbox"]:checked ~ .collapse-title:after,
 .collapse-plus:not(.collapse-close) input[type="radio"]:checked ~ .collapse-title:after {
   content: "−";

--- a/src/components/unstyled/collapse.css
+++ b/src/components/unstyled/collapse.css
@@ -22,7 +22,7 @@
 }
 .collapse[open],
 .collapse-open,
-.collapse:focus:not(.collapse-close) {
+.collapse:focus-within:not(.collapse-close) {
   grid-template-rows: auto 1fr;
 }
 .collapse:not(.collapse-close):has(> input[type="checkbox"]:checked),
@@ -31,7 +31,7 @@
 }
 .collapse[open] .collapse-content,
 .collapse-open .collapse-content,
-.collapse:focus:not(.collapse-close) .collapse-content,
+.collapse:focus-within:not(.collapse-close) .collapse-content,
 .collapse:not(.collapse-close) input[type="checkbox"]:checked ~ .collapse-content,
 .collapse:not(.collapse-close) input[type="radio"]:checked ~ .collapse-content {
   @apply visible min-h-fit;


### PR DESCRIPTION
With simple `:focus` selector, focusing on content (e.g. an input) will cause the box to collapse:

```html
<div class="collapse">
  <div class="collapse-title">
    <h1>Collapse</h1>
  </div>

  <div class="collapse-content">
    <!-- trying to type in the text input will close the container -->
    <input type="text">
  </div>
</div>
```

Instead, we can use `:focus-within` to inherit focus state from children as well. This prevents focus on children nodes from triggering the collapse. [It's fully supported across all browsers.](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within)