### PR TITLE
fix: #2333 multidirection support for `join`

### DIFF
--- a/src/components/unstyled/join.css
+++ b/src/components/unstyled/join.css
@@ -1,47 +1,47 @@
 .join {
   @apply inline-flex items-stretch;
   & :where(.join-item) {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
+    border-start-start-radius: 0;
   }
   & .join-item:not(:first-child):not(:last-child),
   & *:not(:first-child):not(:last-child) .join-item {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
+    border-start-start-radius: 0;
   }
 
   & .join-item:first-child:not(:last-child),
   & *:first-child:not(:last-child) .join-item {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
 
   & .dropdown .join-item:first-child:not(:last-child),
   & *:first-child:not(:last-child) .dropdown .join-item {
-    border-top-right-radius: inherit;
-    border-bottom-right-radius: inherit;
+    border-start-end-radius: inherit;
+    border-end-end-radius: inherit;
   }
 
   & :where(.join-item:first-child:not(:last-child)),
   & :where(*:first-child:not(:last-child) .join-item) {
-    border-bottom-left-radius: inherit;
-    border-top-left-radius: inherit;
+    border-end-start-radius: inherit;
+    border-start-start-radius: inherit;
   }
 
   & .join-item:last-child:not(:first-child),
   & *:last-child:not(:first-child) .join-item {
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
+    border-end-start-radius: 0;
+    border-start-start-radius: 0;
   }
 
   & :where(.join-item:last-child:not(:first-child)),
   & :where(*:last-child:not(:first-child) .join-item) {
-    border-top-right-radius: inherit;
-    border-bottom-right-radius: inherit;
+    border-start-end-radius: inherit;
+    border-end-end-radius: inherit;
   }
 }
 :where(.join *) {


### PR DESCRIPTION
This closes #2333.

Here's a how it looks like
![image](https://github.com/saadeghi/daisyui/assets/55551984/a09c598f-5de7-4acf-8d08-150a4956910d)

for reference, this is how it used to be:
![image](https://github.com/saadeghi/daisyui/assets/55551984/be3a0b81-7065-4d81-b1cc-9aa1dd82df2f)
