### PR TITLE
zebra-alt (odd rows)

### DIFF
--- a/src/components/styled/table.css
+++ b/src/components/styled/table.css
@@ -8,9 +8,9 @@
   &-zebra tbody tr:nth-child(even) {
     @apply bg-base-200;
   }
-  tr.hover,
-  tr.hover:nth-child(even) {
-    @apply [@media(hover:hover)]:hover:bg-base-200;
+
+  &-zebra-alt tbody tr:nth-child(odd) {
+    @apply bg-base-200;
   }
 
   &-zebra {
@@ -24,6 +24,19 @@
   &-zebra tr.hover:nth-child(even) {
     @apply [@media(hover:hover)]:hover:bg-base-300;
   }
+
+  &-zebra-alt {
+    tr.active,
+    tr.active:nth-child(odd),
+    &-zebra-alt tbody tr:nth-child(odd) {
+      @apply bg-base-300;
+    }
+  }
+  &-zebra-alt tr.hover,
+  &-zebra-alt tr.hover:nth-child(odd) {
+    @apply [@media(hover:hover)]:hover:bg-base-300;
+  }
+
 
   :where(thead, tbody) {
     :where(tr:not(:last-child)),

--- a/src/components/unstyled/table.css
+++ b/src/components/unstyled/table.css
@@ -12,4 +12,7 @@
   &-zebra tbody tr:nth-child(even) :where(.table-pin-cols tr th) {
     @apply bg-base-200;
   }
+  &-zebra-alt tbody tr:nth-child(odd) :where(.table-pin-cols tr th) {
+    @apply bg-base-200;
+  }
 }

--- a/src/docs/src/routes/components/table/+page.svelte.md
+++ b/src/docs/src/routes/components/table/+page.svelte.md
@@ -15,7 +15,8 @@ layout: components
 <ClassTable
 data="{[
   { type:'component', class: 'table', desc: 'For <table> element' },
-  { type:'modifier', class: 'table-zebra', desc: 'For <table> to show zebra stripe rows' },
+  { type:'modifier', class: 'table-zebra', desc: 'For <table> to show zebra stripe on even rows' },
+  { type:'modifier', class: 'table-zebra-alt', desc: 'For <table> to show zebra stripe on odd rows' },
   { type:'modifier', class: 'table-pin-rows', desc: 'For <table> to make all the rows inside <thead> and <tfoot> sticky' },
   { type:'modifier', class: 'table-pin-cols', desc: 'For <table> to make all the <th> columns sticky' },
   { type:'responsive', class: 'table-xs', desc: 'Extra small size' },


### PR DESCRIPTION
Sorry, but even rows looks really wierd sometimes.

![image](https://github.com/saadeghi/daisyui/assets/4650770/717ca90a-e35c-47cc-a70e-e94b517f2aec)

Behold... `<table class="table table-zebra-alt">`

![image](https://github.com/saadeghi/daisyui/assets/4650770/2605a9f6-89f8-40a5-ba55-d1ec9d9794bb)
