### PR TITLE
docs

### DIFF
--- a/src/docs/src/routes/(docs)/docs/install/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/docs/install/+page.svelte.md
@@ -23,7 +23,7 @@ npm i -D daisyui@latest
 2. <Translate text="Then add daisyUI to your <code>tailwind.config.js</code> files" />:
 
 ```js
-module.exports = {
+export default {
   //...
   plugins: [require("daisyui")],
 }


### PR DESCRIPTION
Default tailwind setup seems to be:

export default {
  content: [],
  theme: {
    extend: {},
  },
  plugins: [],
}