### PR TITLE
Docs: Accessibility Note on Radial Progress Bar

### DIFF
--- a/src/docs/src/routes/(docs)/components/radial-progress/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/components/radial-progress/+page.svelte.md
@@ -15,9 +15,11 @@ layout: components
 
 <Translate text="Radial progress needs `--value` CSS variable to work.<br />To change the size, use `--size` CSS variable which has a default value of `4rem`.<br />To change the thickness, use `--thickness` CSS variable which is 10% of the size by default.<br />" />
 
-<div class="alert alert-info text-sm">
+<div class="alert alert-info text-sm mt-2">
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info-content flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
   For radial progress we use &lt;div&gt; instead of &lt;progress&gt; tag because Browsers are unable to show the text inside &lt;progress&gt; tag and Firefox doesn't show the pseudo elements inside &lt;progress&gt; bar at all.
+  For accessibility, a role of 'progressbar' is given to each &lt;div&gt; explicitly, while 
+  &lt;progress&gt; receives this role implicitly.
 </div>
 
 <ClassTable
@@ -27,66 +29,66 @@ data="{[
 />
 
 <Component title="Radial progress">
-<div class="radial-progress" style="--value:70;">70%</div>
+<div class="radial-progress" style="--value:70;" role="progressbar">70%</div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
-`<div class="$$radial-progress" style="--value:70;">70%</div>`
+`<div class="$$radial-progress" style="--value:70;" role="progressbar">70%</div>`
 }</pre>
 <pre slot="jsx" use:replace={{ to: $prefix }}>{
-`<div className="$$radial-progress" style={{"--value":70}}>70%</div>`
+`<div className="$$radial-progress" style={{"--value":70}} role="progressbar">70%</div>`
 }</pre>
 </Component>
 
 <Component title="Different values">
-<div class="radial-progress" style="--value:0;">0%</div>
-<div class="radial-progress" style="--value:20;">20%</div>
-<div class="radial-progress" style="--value:60;">60%</div>
-<div class="radial-progress" style="--value:80;">80%</div>
-<div class="radial-progress" style="--value:100;">100%</div>
+<div class="radial-progress" style="--value:0;" role="progressbar">0%</div>
+<div class="radial-progress" style="--value:20;" role="progressbar">20%</div>
+<div class="radial-progress" style="--value:60;" role="progressbar">60%</div>
+<div class="radial-progress" style="--value:80;" role="progressbar">80%</div>
+<div class="radial-progress" style="--value:100;" role="progressbar">100%</div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
-`<div class="$$radial-progress" style="--value:0;">0%</div>
-<div class="$$radial-progress" style="--value:20;">20%</div>
-<div class="$$radial-progress" style="--value:60;">60%</div>
-<div class="$$radial-progress" style="--value:80;">80%</div>
-<div class="$$radial-progress" style="--value:100;">100%</div>`
+`<div class="$$radial-progress" style="--value:0;" role="progressbar">0%</div>
+<div class="$$radial-progress" style="--value:20;" role="progressbar">20%</div>
+<div class="$$radial-progress" style="--value:60;" role="progressbar">60%</div>
+<div class="$$radial-progress" style="--value:80;" role="progressbar">80%</div>
+<div class="$$radial-progress" style="--value:100;" role="progressbar">100%</div>`
 }</pre>
 <pre slot="jsx" use:replace={{ to: $prefix }}>{
-`<div className="$$radial-progress" style={{"--value":0}}>0%</div>
-<div className="$$radial-progress" style={{"--value":20}}>20%</div>
-<div className="$$radial-progress" style={{"--value":60}}>60%</div>
-<div className="$$radial-progress" style={{"--value":80}}>80%</div>
-<div className="$$radial-progress" style={{"--value":100}}>100%</div>`
+`<div className="$$radial-progress" style={{"--value":0}} role="progressbar">0%</div>
+<div className="$$radial-progress" style={{"--value":20}} role="progressbar">20%</div>
+<div className="$$radial-progress" style={{"--value":60}} role="progressbar">60%</div>
+<div className="$$radial-progress" style={{"--value":80}} role="progressbar">80%</div>
+<div className="$$radial-progress" style={{"--value":100}} role="progressbar">100%</div>`
 }</pre>
 </Component>
 
 <Component title="Custom color">
-<div class="radial-progress text-primary" style="--value:70;">70%</div>
+<div class="radial-progress text-primary" style="--value:70;" role="progressbar">70%</div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
-`<div class="$$radial-progress text-primary" style="--value:70;">70%</div>`
+`<div class="$$radial-progress text-primary" style="--value:70;" role="progressbar">70%</div>`
 }</pre>
 <pre slot="jsx" use:replace={{ to: $prefix }}>{
-`<div className="$$radial-progress text-primary" style={{"--value":70}}>70%</div>`
+`<div className="$$radial-progress text-primary" style={{"--value":70}} role="progressbar">70%</div>`
 }</pre>
 </Component>
 
 <Component title="With background color and border">
-<div class="radial-progress bg-primary text-primary-content border-4 border-primary" style="--value:70;">70%</div>
+<div class="radial-progress bg-primary text-primary-content border-4 border-primary" style="--value:70;" role="progressbar">70%</div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
-`<div class="$$radial-progress bg-primary text-primary-content border-4 border-primary" style="--value:70;">70%</div>`
+`<div class="$$radial-progress bg-primary text-primary-content border-4 border-primary" style="--value:70;" role="progressbar">70%</div>`
 }</pre>
 <pre slot="jsx" use:replace={{ to: $prefix }}>{
-`<div className="$$radial-progress bg-primary text-primary-content border-4 border-primary" style={{"--value":70}}>70%</div>`
+`<div className="$$radial-progress bg-primary text-primary-content border-4 border-primary" style={{"--value":70}} role="progressbar">70%</div>`
 }</pre>
 </Component>
 
 <Component title="Custom size and custom thickness">
-<div class="radial-progress" style="--value:70; --size:12rem; --thickness: 2px;">70%</div>
-<div class="radial-progress" style="--value:70; --size:12rem; --thickness: 2rem;">70%</div>
+<div class="radial-progress" style="--value:70; --size:12rem; --thickness: 2px;" role="progressbar">70%</div>
+<div class="radial-progress" style="--value:70; --size:12rem; --thickness: 2rem;" role="progressbar">70%</div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
-`<div class="$$radial-progress" style="--value:70; --size:12rem; --thickness: 2px;">70%</div>
-<div class="$$radial-progress" style="--value:70; --size:12rem; --thickness: 2rem;">70%</div>`
+`<div class="$$radial-progress" style="--value:70; --size:12rem; --thickness: 2px;" role="progressbar">70%</div>
+<div class="$$radial-progress" style="--value:70; --size:12rem; --thickness: 2rem;" role="progressbar">70%</div>`
 }</pre>
 <pre slot="jsx" use:replace={{ to: $prefix }}>{
-`<div className="$$radial-progress" style={{ "--value": "70", "--size": "12rem", "--thickness": "2px" }}>70%</div>
-<div className="$$radial-progress" style={{ "--value": "70", "--size": "12rem", "--thickness": "2rem" }}>70%</div>`
+`<div className="$$radial-progress" style={{ "--value": "70", "--size": "12rem", "--thickness": "2px" }} role="progressbar">70%</div>
+<div className="$$radial-progress" style={{ "--value": "70", "--size": "12rem", "--thickness": "2rem" }}role="progressbar">70%</div>`
 }</pre>
 </Component>

--- a/src/docs/src/routes/(docs)/components/radial-progress/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/components/radial-progress/+page.svelte.md
@@ -89,6 +89,6 @@ data="{[
 }</pre>
 <pre slot="jsx" use:replace={{ to: $prefix }}>{
 `<div className="$$radial-progress" style={{ "--value": "70", "--size": "12rem", "--thickness": "2px" }} role="progressbar">70%</div>
-<div className="$$radial-progress" style={{ "--value": "70", "--size": "12rem", "--thickness": "2rem" }}role="progressbar">70%</div>`
+<div className="$$radial-progress" style={{ "--value": "70", "--size": "12rem", "--thickness": "2rem" }} role="progressbar">70%</div>`
 }</pre>
 </Component>


### PR DESCRIPTION
I reviewed #2472 and have tried to consider the discussion there in the changes made. 

**Changes**
This PR adds an explicit role of 'progressbar' to all JSX and HTML examples.

There is already an alert calling out the fact that the standard progress bar uses a `<progress>` element while the radial progress bar uses a `<div>` to work around browser-side issues, this has been expanded to explain that `<progress>` receives it's role implicitly so when using a `<div>` instead we need to add this role explicitly.

**Rationale**
This is not an exhaustive list of the boxes that I would want to see checked from an accessibility perspective, but as mentioned in referenced issue and in Twitter discussion, because Daisy is pure-CSS, there are some things that cannot be demonstrated effectively without JS implementations that are by-intention withheld.

For example
- Best practice would be that a progress bar be labeled and the `progressbar` role allows for labeling via a `<label>` element or one of the `aria-*` labeling properties, but this would be the scope of the parent component that renders the Daisy progress bar, not the progress bar its self directly so this was not included.
- A loading indicator that is being used for a loading-state for a UI that has not yet rendered should receive `aria-busy`, but again this is a consideration of the parent, not the progress bar its self.

**Going Forward**
I wanted to start off small so we can figure out the answers to the questions around where does the Daisy team want to draw the line in regards to what is demonstrated vs what isn't. 

I think that more information would be helpful like advising people of using an indicator of which tab is currently active/selected like the referenced PR, but this is not the most cut and dry work ever because another library doc site that has partial information repeating commonly available information found elsewhere (ie WCAG documentation) so format and leaning heavily on established standards is important. This is probably a larger conversation, but wanted to go ahead and kick the conversation off.

An alternative approach might be a generalized accessibility page that lists the general thoughts expressed here and in #2472 that Daisy inherently can't be treated the same as a fully-fledged (JavaScript) UI kit and a lot will be implemented in user land. Then each component could link to additional information (ie WCAG/APG) so that users can research the requirements. 

Once scope and expectations a little more defined, I'm happy to begin going through other components and looking for opportunities. 