### PR TITLE
fix: #2505 missing border on select component

### DIFF
--- a/src/components/styled/select.css
+++ b/src/components/styled/select.css
@@ -1,5 +1,4 @@
-.select,
-:where(select.select) {
+.select {
   @apply bg-base-100 rounded-btn border border-transparent pr-10;
   &-bordered {
     @apply border-base-content/20;


### PR DESCRIPTION
Issue: css selector can't find the select element.
Related issue tickets: 
* https://github.com/saadeghi/daisyui/issues/2505 
* https://github.com/saadeghi/daisyui/issues/2513

See example in docs: https://daisyui.com/components/select/

Before PR:
![Screenshot 2023-11-13 at 11 42 22](https://github.com/saadeghi/daisyui/assets/6431031/1f591cda-e065-455b-b18f-e889cbeb67bb)

After PR: 
![Screenshot 2023-11-13 at 11 40 22](https://github.com/saadeghi/daisyui/assets/6431031/ee110838-3db8-464f-8360-0aa7e0ba0cae)

