### PR TITLE
"New component: Banner" showing up twice in Upcoming Roadmap

### DIFF
--- a/src/docs/src/lib/data/roadmap.js
+++ b/src/docs/src/lib/data/roadmap.js
@@ -326,10 +326,6 @@ export const roadmap = [
         done: false,
       },
       {
-        title: "New component: Banner",
-        done: false,
-      },
-      {
         title: "Support the upcoming Tailwind CSS v4",
         done: false,
       },


### PR DESCRIPTION
I went to the roadmap and found that under 'Upcoming,' the 'New Component: Banner' shows up twice.

<img width="921" alt="Screenshot 2023-11-14 at 6 28 46 PM" src="https://github.com/saadeghi/daisyui/assets/72112379/81981a26-70b2-45cb-a4ce-8fc1cf73185d">
