### PR TITLE
Add 'slate' theme

### DIFF
--- a/src/theming/themes.js
+++ b/src/theming/themes.js
@@ -116,8 +116,8 @@ module.exports = {
   },
   slate: {
     "color-scheme": "dark",
-    "primary": "#088385",
-    "secondary": "#cc4304",
+    "primary": "#661AE6",
+    "secondary": "#D926AA",
     "accent": "#1FB2A5",
     "neutral": "#191D24",
     "neutral-content": "#A6ADBB",

--- a/src/theming/themes.js
+++ b/src/theming/themes.js
@@ -114,6 +114,18 @@ module.exports = {
     "base-300": "#15191e",
     "base-content": "#A6ADBB",
   },
+  slate: {
+    "color-scheme": "dark",
+    "primary": "#088385",
+    "secondary": "#cc4304",
+    "accent": "#1FB2A5",
+    "neutral": "#191D24",
+    "neutral-content": "#A6ADBB",
+      "base-100": "#2A303C",
+     "base-200": "#242933",
+    "base-300": "#20252E",
+    "base-content": "#A6ADBB",
+  },
   dracula: {
     "color-scheme": "dark",
     "primary": "#ff79c6",


### PR DESCRIPTION
The 'slate' theme has the same colors as the old daisyUI dark theme.

While the new theme is a great dark theme, it would be nice for there to be an option for a theme that's dark, but not that dark.

While halloween, dracula, and buisness are similar, none of them match the prettiness of the old dark theme. It was chosen as the default dark theme back then for a reason, I'd assume. Additionally, this would make upgrading past 2.0 easier, as users don't have to use a browser's dev tool's color picker and make a custom theme just to get it looking like it did before. (Yes, while there are files where they could copy the color values from, the average user probably wouldn't find them, especially a beginner.