### PR TITLE
perf: cache functions that get called frequently

### DIFF
--- a/src/theming/functions.js
+++ b/src/theming/functions.js
@@ -3,6 +3,9 @@ const themeDefaults = require("./themeDefaults")
 
 const { toGamut, interpolate, wcagContrast } = require("culori")
 
+const cutNumber = (number) => (number ? +number.toFixed(6) : 0);
+const toGamutOKLCH = toGamut("oklch");
+
 module.exports = {
   isDark: (color) => {
     if (wcagContrast(color, "black") < wcagContrast(color, "white")) {
@@ -12,14 +15,8 @@ module.exports = {
   },
 
   colorObjToString: function (input) {
-    const cut = (number) => {
-      if (!number) {
-        return 0
-      }
-      return +number.toFixed(6)
-    }
     const { l, c, h } = input
-    return `${cut(l)} ${cut(c)} ${cut(h)}`
+    return `${cutNumber(l)} ${cutNumber(c)} ${cutNumber(h)}`
   },
 
   generateForegroundColorFrom: function (input, percentage = 0.8) {
@@ -41,7 +38,7 @@ module.exports = {
 
     Object.entries(input).forEach(([rule, value]) => {
       if (colorNames.hasOwnProperty(rule)) {
-        const colorObj = toGamut("oklch")(value)
+        const colorObj = toGamutOKLCH(value)
         resultObj[colorNames[rule]] = this.colorObjToString(colorObj)
       } else {
         resultObj[rule] = value


### PR DESCRIPTION
Hey!

Again, great release!

Since we're using the DaisyUI's custom theme generator in our application, performance really matters to us

After a first look, I see that `toGamut` function is always constructed with oklch, so we can extract it to make it a lot faster as V8 will now be able to optimize it, same goes with `cut`

Hope to create more PRs improving performance soon 🙏