### PR TITLE
fix: modify File input Chinese translation

### DIFF
--- a/src/docs/src/translation/zh_hans.json
+++ b/src/docs/src/translation/zh_hans.json
@@ -66,6 +66,7 @@
   "Tooltip": "Tooltip 文字提示",
   "Data input": "数据输入",
   "Checkbox": "Checkbox 复选框",
+  "File input": "File input 文件输入框",
   "Text input": "Text input 文字输入框",
   "Radio": "Radio 单选框",
   "Range": "Range 范围滑块",


### PR DESCRIPTION

When the language is Chinese, there is a problem with the File Input display in the menu bar.   

<img width="960" alt="Snipaste_2023-12-27_16-45-44" src="https://github.com/saadeghi/daisyui/assets/52070630/c3929149-0765-4ef0-b75b-13490d243c66">

