### PR TITLE
Use h6 instead of header in footer component examples

### DIFF
--- a/src/docs/src/routes/(docs)/components/footer/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/components/footer/+page.svelte.md
@@ -27,21 +27,21 @@ data="{[
 <Component title="Footer">
 <footer class="p-10 footer bg-neutral text-neutral-content rounded">
   <nav>
-    <header class="footer-title">Services</header> 
+    <h6 class="footer-title">Services</h6> 
     <button class="link link-hover">Branding</button>
     <button class="link link-hover">Design</button>
     <button class="link link-hover">Marketing</button>
     <button class="link link-hover">Advertisement</button>
   </nav> 
   <nav>
-    <header class="footer-title">Company</header> 
+    <h6 class="footer-title">Company</h6> 
     <button class="link link-hover">About us</button>
     <button class="link link-hover">Contact</button>
     <button class="link link-hover">Jobs</button>
     <button class="link link-hover">Press kit</button>
   </nav> 
   <nav>
-    <header class="footer-title">Legal</header> 
+    <h6 class="footer-title">Legal</h6> 
     <button class="link link-hover">Terms of use</button>
     <button class="link link-hover">Privacy policy</button>
     <button class="link link-hover">Cookie policy</button>
@@ -50,21 +50,21 @@ data="{[
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<footer class="$$footer p-10 bg-neutral text-neutral-content">
   <nav>
-    <header class="$$footer-title">Services</header> 
+    <h6 class="$$footer-title">Services</h6> 
     <a class="$$link $$link-hover">Branding</a>
     <a class="$$link $$link-hover">Design</a>
     <a class="$$link $$link-hover">Marketing</a>
     <a class="$$link $$link-hover">Advertisement</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Company</header> 
+    <h6 class="$$footer-title">Company</h6> 
     <a class="$$link $$link-hover">About us</a>
     <a class="$$link $$link-hover">Contact</a>
     <a class="$$link $$link-hover">Jobs</a>
     <a class="$$link $$link-hover">Press kit</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Legal</header> 
+    <h6 class="$$footer-title">Legal</h6> 
     <a class="$$link $$link-hover">Terms of use</a>
     <a class="$$link $$link-hover">Privacy policy</a>
     <a class="$$link $$link-hover">Cookie policy</a>
@@ -77,24 +77,24 @@ data="{[
 <footer class="p-10 footer bg-base-200 text-base-content rounded">
   <aside>
     <svg width="50" height="50" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
-    <p>ACME Industries Ltd.<br/>Providing reliable tech since 1992</p>
+    <p>ACME Industries Ltd.<br>Providing reliable tech since 1992</p>
   </aside> 
   <nav>
-    <header class="footer-title">Services</header> 
+    <h6 class="footer-title">Services</h6> 
     <button class="link link-hover">Branding</button>
     <button class="link link-hover">Design</button>
     <button class="link link-hover">Marketing</button>
     <button class="link link-hover">Advertisement</button>
   </nav> 
   <nav>
-    <header class="footer-title">Company</header> 
+    <h6 class="footer-title">Company</h6> 
     <button class="link link-hover">About us</button>
     <button class="link link-hover">Contact</button>
     <button class="link link-hover">Jobs</button>
     <button class="link link-hover">Press kit</button>
   </nav> 
   <nav>
-    <header class="footer-title">Legal</header> 
+    <h6 class="footer-title">Legal</h6> 
     <button class="link link-hover">Terms of use</button>
     <button class="link link-hover">Privacy policy</button>
     <button class="link link-hover">Cookie policy</button>
@@ -104,24 +104,24 @@ data="{[
 `<footer class="$$footer p-10 bg-base-200 text-base-content">
   <aside>
     <svg width="50" height="50" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
-    <p>ACME Industries Ltd.<br/>Providing reliable tech since 1992</p>
+    <p>ACME Industries Ltd.<br>Providing reliable tech since 1992</p>
   </aside> 
   <nav>
-    <header class="$$footer-title">Services</header> 
+    <h6 class="$$footer-title">Services</h6> 
     <a class="$$link $$link-hover">Branding</a>
     <a class="$$link $$link-hover">Design</a>
     <a class="$$link $$link-hover">Marketing</a>
     <a class="$$link $$link-hover">Advertisement</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Company</header> 
+    <h6 class="$$footer-title">Company</h6> 
     <a class="$$link $$link-hover">About us</a>
     <a class="$$link $$link-hover">Contact</a>
     <a class="$$link $$link-hover">Jobs</a>
     <a class="$$link $$link-hover">Press kit</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Legal</header> 
+    <h6 class="$$footer-title">Legal</h6> 
     <a class="$$link $$link-hover">Terms of use</a>
     <a class="$$link $$link-hover">Privacy policy</a>
     <a class="$$link $$link-hover">Cookie policy</a>
@@ -133,27 +133,27 @@ data="{[
 <Component title="Footer with a form">
 <footer class="p-10 footer bg-base-200 text-base-content rounded">
   <nav>
-    <header class="footer-title">Services</header> 
+    <h6 class="footer-title">Services</h6> 
     <button class="link link-hover">Branding</button>
     <button class="link link-hover">Design</button>
     <button class="link link-hover">Marketing</button>
     <button class="link link-hover">Advertisement</button>
   </nav> 
   <nav>
-    <header class="footer-title">Company</header> 
+    <h6 class="footer-title">Company</h6> 
     <button class="link link-hover">About us</button>
     <button class="link link-hover">Contact</button>
     <button class="link link-hover">Jobs</button>
     <button class="link link-hover">Press kit</button>
   </nav> 
   <nav>
-    <header class="footer-title">Legal</header> 
+    <h6 class="footer-title">Legal</h6> 
     <button class="link link-hover">Terms of use</button>
     <button class="link link-hover">Privacy policy</button>
     <button class="link link-hover">Cookie policy</button>
   </nav> 
   <form>
-    <header class="footer-title">Newsletter</header> 
+    <h6 class="footer-title">Newsletter</h6> 
     <fieldset class="form-control w-80">
       <label class="label" for="input1">
         <span class="label-text">Enter your email address</span>
@@ -168,27 +168,27 @@ data="{[
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<footer class="$$footer p-10 bg-base-200 text-base-content">
   <nav>
-    <header class="$$footer-title">Services</header> 
+    <h6 class="$$footer-title">Services</h6> 
     <a class="$$link $$link-hover">Branding</a>
     <a class="$$link $$link-hover">Design</a>
     <a class="$$link $$link-hover">Marketing</a>
     <a class="$$link $$link-hover">Advertisement</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Company</header> 
+    <h6 class="$$footer-title">Company</h6> 
     <a class="$$link $$link-hover">About us</a>
     <a class="$$link $$link-hover">Contact</a>
     <a class="$$link $$link-hover">Jobs</a>
     <a class="$$link $$link-hover">Press kit</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Legal</header> 
+    <h6 class="$$footer-title">Legal</h6> 
     <a class="$$link $$link-hover">Terms of use</a>
     <a class="$$link $$link-hover">Privacy policy</a>
     <a class="$$link $$link-hover">Cookie policy</a>
   </nav> 
   <form>
-    <header class="$$footer-title">Newsletter</header> 
+    <h6 class="$$footer-title">Newsletter</h6> 
     <fieldset class="$$form-control w-80">
       <label class="$$label">
         <span class="$$label-text">Enter your email address</span>
@@ -207,10 +207,10 @@ data="{[
 <footer class="p-10 footer bg-neutral text-neutral-content rounded">
   <aside>
     <svg width="50" height="50" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
-    <p>ACME Industries Ltd.<br/>Providing reliable tech since 1992</p>
+    <p>ACME Industries Ltd.<br>Providing reliable tech since 1992</p>
   </aside> 
   <nav>
-    <header class="footer-title">Social</header> 
+    <h6 class="footer-title">Social</h6> 
     <div class="grid grid-flow-col gap-4">
       <button><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path></svg></button>
       <button><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"></path></svg></button>
@@ -222,10 +222,10 @@ data="{[
 `<footer class="$$footer p-10 bg-neutral text-neutral-content">
   <aside>
     <svg width="50" height="50" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
-    <p>ACME Industries Ltd.<br/>Providing reliable tech since 1992</p>
+    <p>ACME Industries Ltd.<br>Providing reliable tech since 1992</p>
   </aside> 
   <nav>
-    <header class="$$footer-title">Social</header> 
+    <h6 class="$$footer-title">Social</h6> 
     <div class="grid grid-flow-col gap-4">
       <a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path></svg></a>
       <a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"></path></svg></a>
@@ -283,21 +283,21 @@ data="{[
 <Component title="Footer with links and social icons">
 <footer class="p-10 footer bg-base-300 text-base-content rounded">
   <nav>
-    <header class="footer-title">Services</header> 
+    <h6 class="footer-title">Services</h6> 
     <button class="link link-hover">Branding</button>
     <button class="link link-hover">Design</button>
     <button class="link link-hover">Marketing</button>
     <button class="link link-hover">Advertisement</button>
   </nav> 
   <nav>
-    <header class="footer-title">Company</header> 
+    <h6 class="footer-title">Company</h6> 
     <button class="link link-hover">About us</button>
     <button class="link link-hover">Contact</button>
     <button class="link link-hover">Jobs</button>
     <button class="link link-hover">Press kit</button>
   </nav> 
   <nav>
-    <header class="footer-title">Social</header> 
+    <h6 class="footer-title">Social</h6> 
     <div class="grid grid-flow-col gap-4">
       <button><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path></svg></button>
       <button><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"></path></svg></button>
@@ -308,21 +308,21 @@ data="{[
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<footer class="$$footer p-10 bg-base-300 text-base-content">
   <nav>
-    <header class="$$footer-title">Services</header> 
+    <h6 class="$$footer-title">Services</h6> 
     <a class="$$link $$link-hover">Branding</a>
     <a class="$$link $$link-hover">Design</a>
     <a class="$$link $$link-hover">Marketing</a>
     <a class="$$link $$link-hover">Advertisement</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Company</header> 
+    <h6 class="$$footer-title">Company</h6> 
     <a class="$$link $$link-hover">About us</a>
     <a class="$$link $$link-hover">Contact</a>
     <a class="$$link $$link-hover">Jobs</a>
     <a class="$$link $$link-hover">Press kit</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Social</header> 
+    <h6 class="$$footer-title">Social</h6> 
     <div class="grid grid-flow-col gap-4">
       <a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path></svg></a>
       <a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current"><path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"></path></svg></a>
@@ -336,41 +336,41 @@ data="{[
 <Component title="Footer with 2 rows">
 <footer class="grid-rows-2 p-10 footer bg-neutral text-neutral-content rounded">
   <nav>
-    <header class="footer-title">Services</header> 
+    <h6 class="footer-title">Services</h6> 
     <button class="link link-hover">Branding</button>
     <button class="link link-hover">Design</button>
     <button class="link link-hover">Marketing</button>
     <button class="link link-hover">Advertisement</button>
   </nav> 
   <nav>
-    <header class="footer-title">Company</header> 
+    <h6 class="footer-title">Company</h6> 
     <button class="link link-hover">About us</button>
     <button class="link link-hover">Contact</button>
     <button class="link link-hover">Jobs</button>
     <button class="link link-hover">Press kit</button>
   </nav> 
   <nav>
-    <header class="footer-title">Legal</header> 
+    <h6 class="footer-title">Legal</h6> 
     <button class="link link-hover">Terms of use</button>
     <button class="link link-hover">Privacy policy</button>
     <button class="link link-hover">Cookie policy</button>
   </nav> 
   <nav>
-    <header class="footer-title">Social</header> 
+    <h6 class="footer-title">Social</h6> 
     <button class="link link-hover">Twitter</button>
     <button class="link link-hover">Instagram</button>
     <button class="link link-hover">Facebook</button>
     <button class="link link-hover">Github</button>
   </nav> 
   <nav>
-    <header class="footer-title">Explore</header> 
+    <h6 class="footer-title">Explore</h6> 
     <button class="link link-hover">Features</button>
     <button class="link link-hover">Enterprise</button>
     <button class="link link-hover">Security</button>
     <button class="link link-hover">Pricing</button>
   </nav> 
   <nav>
-    <header class="footer-title">Apps</header> 
+    <h6 class="footer-title">Apps</h6> 
     <button class="link link-hover">Mac</button>
     <button class="link link-hover">Windows</button>
     <button class="link link-hover">iPhone</button>
@@ -380,41 +380,41 @@ data="{[
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<footer class="$$footer grid-rows-2 p-10 bg-neutral text-neutral-content">
   <nav>
-    <header class="$$footer-title">Services</header> 
+    <h6 class="$$footer-title">Services</h6> 
     <a class="$$link $$link-hover">Branding</a>
     <a class="$$link $$link-hover">Design</a>
     <a class="$$link $$link-hover">Marketing</a>
     <a class="$$link $$link-hover">Advertisement</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Company</header> 
+    <h6 class="$$footer-title">Company</h6> 
     <a class="$$link $$link-hover">About us</a>
     <a class="$$link $$link-hover">Contact</a>
     <a class="$$link $$link-hover">Jobs</a>
     <a class="$$link $$link-hover">Press kit</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Legal</header> 
+    <h6 class="$$footer-title">Legal</h6> 
     <a class="$$link $$link-hover">Terms of use</a>
     <a class="$$link $$link-hover">Privacy policy</a>
     <a class="$$link $$link-hover">Cookie policy</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Social</header> 
+    <h6 class="$$footer-title">Social</h6> 
     <a class="$$link $$link-hover">Twitter</a>
     <a class="$$link $$link-hover">Instagram</a>
     <a class="$$link $$link-hover">Facebook</a>
     <a class="$$link $$link-hover">Github</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Explore</header> 
+    <h6 class="$$footer-title">Explore</h6> 
     <a class="$$link $$link-hover">Features</a>
     <a class="$$link $$link-hover">Enterprise</a>
     <a class="$$link $$link-hover">Security</a>
     <a class="$$link $$link-hover">Pricing</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Apps</header> 
+    <h6 class="$$footer-title">Apps</h6> 
     <a class="$$link $$link-hover">Mac</a>
     <a class="$$link $$link-hover">Windows</a>
     <a class="$$link $$link-hover">iPhone</a>
@@ -429,7 +429,7 @@ data="{[
   <aside>
     <svg width="50" height="50" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="inline-block fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
     <p class="font-bold">
-      ACME Industries Ltd. <br/>Providing reliable tech since 1992
+      ACME Industries Ltd. <br>Providing reliable tech since 1992
     </p> 
     <p>Copyright © {new Date().getFullYear()} - All right reserved</p>
   </aside> 
@@ -446,7 +446,7 @@ data="{[
   <aside>
     <svg width="50" height="50" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="inline-block fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
     <p class="font-bold">
-      ACME Industries Ltd. <br/>Providing reliable tech since 1992
+      ACME Industries Ltd. <br>Providing reliable tech since 1992
     </p> 
     <p>Copyright © ${new Date().getFullYear()} - All right reserved</p>
   </aside> 
@@ -506,21 +506,21 @@ data="{[
 <div class="w-full">
   <footer class="p-10 footer bg-base-200 text-base-content">
     <nav>
-      <header class="footer-title">Services</header> 
+      <h6 class="footer-title">Services</h6> 
       <button class="link link-hover">Branding</button>
       <button class="link link-hover">Design</button>
       <button class="link link-hover">Marketing</button>
       <button class="link link-hover">Advertisement</button>
     </nav> 
     <nav>
-      <header class="footer-title">Company</header> 
+      <h6 class="footer-title">Company</h6> 
       <button class="link link-hover">About us</button>
       <button class="link link-hover">Contact</button>
       <button class="link link-hover">Jobs</button>
       <button class="link link-hover">Press kit</button>
     </nav> 
     <nav>
-      <header class="footer-title">Legal</header> 
+      <h6 class="footer-title">Legal</h6> 
       <button class="link link-hover">Terms of use</button>
       <button class="link link-hover">Privacy policy</button>
       <button class="link link-hover">Cookie policy</button>
@@ -529,7 +529,7 @@ data="{[
   <footer class="px-10 py-4 border-t footer bg-base-200 text-base-content border-base-300">
     <aside class="items-center grid-flow-col">
       <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
-      <p>ACME Industries Ltd. <br/>Providing reliable tech since 1992</p>
+      <p>ACME Industries Ltd. <br>Providing reliable tech since 1992</p>
     </aside> 
     <nav class="md:place-self-center md:justify-self-end">
       <div class="grid grid-flow-col gap-4">
@@ -543,21 +543,21 @@ data="{[
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<footer class="$$footer p-10 bg-base-200 text-base-content">
   <nav>
-    <header class="$$footer-title">Services</header> 
+    <h6 class="$$footer-title">Services</h6> 
     <a class="$$link $$link-hover">Branding</a>
     <a class="$$link $$link-hover">Design</a>
     <a class="$$link $$link-hover">Marketing</a>
     <a class="$$link $$link-hover">Advertisement</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Company</header> 
+    <h6 class="$$footer-title">Company</h6> 
     <a class="$$link $$link-hover">About us</a>
     <a class="$$link $$link-hover">Contact</a>
     <a class="$$link $$link-hover">Jobs</a>
     <a class="$$link $$link-hover">Press kit</a>
   </nav> 
   <nav>
-    <header class="$$footer-title">Legal</header> 
+    <h6 class="$$footer-title">Legal</h6> 
     <a class="$$link $$link-hover">Terms of use</a>
     <a class="$$link $$link-hover">Privacy policy</a>
     <a class="$$link $$link-hover">Cookie policy</a>
@@ -566,7 +566,7 @@ data="{[
 <footer class="$$footer px-10 py-4 border-t bg-base-200 text-base-content border-base-300">
   <aside class="items-center grid-flow-col">
     <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" class="fill-current"><path d="M22.672 15.226l-2.432.811.841 2.515c.33 1.019-.209 2.127-1.23 2.456-1.15.325-2.148-.321-2.463-1.226l-.84-2.518-5.013 1.677.84 2.517c.391 1.203-.434 2.542-1.831 2.542-.88 0-1.601-.564-1.86-1.314l-.842-2.516-2.431.809c-1.135.328-2.145-.317-2.463-1.229-.329-1.018.211-2.127 1.231-2.456l2.432-.809-1.621-4.823-2.432.808c-1.355.384-2.558-.59-2.558-1.839 0-.817.509-1.582 1.327-1.846l2.433-.809-.842-2.515c-.33-1.02.211-2.129 1.232-2.458 1.02-.329 2.13.209 2.461 1.229l.842 2.515 5.011-1.677-.839-2.517c-.403-1.238.484-2.553 1.843-2.553.819 0 1.585.509 1.85 1.326l.841 2.517 2.431-.81c1.02-.33 2.131.211 2.461 1.229.332 1.018-.21 2.126-1.23 2.456l-2.433.809 1.622 4.823 2.433-.809c1.242-.401 2.557.484 2.557 1.838 0 .819-.51 1.583-1.328 1.847m-8.992-6.428l-5.01 1.675 1.619 4.828 5.011-1.674-1.62-4.829z"></path></svg>
-    <p>ACME Industries Ltd. <br/>Providing reliable tech since 1992</p>
+    <p>ACME Industries Ltd. <br>Providing reliable tech since 1992</p>
   </aside> 
   <nav class="md:place-self-center md:justify-self-end">
     <div class="grid grid-flow-col gap-4">


### PR DESCRIPTION
As @bempensato mentioned in #2294 (and reported in #2789), having a `<header>` as a child of `<footer>` is invalid.

Moving to use an `<h6>` tag as it has the lowest weight of a page's heading tags and still properly represents a heading of the `<nav>` section.

Ran through the W3C validator to confirm, passes with flying colors:
![Showing results for contents of text-input area - Nu Html Checker 2024-01-24 at 3 44 44 PM](https://github.com/saadeghi/daisyui/assets/157695/e688bd1d-490b-40db-881c-2c38a10d17ca)

Note I also changed `<br/>` to `<br>` as the validator warns the trailing slash is unnecessary.

Closes #2789