### PR TITLE
Add carousel-start modifier

### DIFF
--- a/src/components/unstyled/carousel.css
+++ b/src/components/unstyled/carousel.css
@@ -10,6 +10,9 @@
     @apply box-content flex flex-none;
     scroll-snap-align: start;
   }
+  &-start .carousel-item {
+    scroll-snap-align: start;
+  }
   &-center .carousel-item {
     scroll-snap-align: center;
   }

--- a/src/docs/src/routes/(docs)/components/carousel/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/components/carousel/+page.svelte.md
@@ -20,6 +20,7 @@ layout: components
 data="{[
   { type:'component', class: 'carousel', desc: 'Container element' },
   { type:'component', class: 'carousel-item', desc: 'Carousel item' },
+  { type:'modifier', class: 'carousel-start', desc: 'Snap elements to start(default)' },
   { type:'modifier', class: 'carousel-center', desc: 'Snap elements to center' },
   { type:'modifier', class: 'carousel-end', desc: 'Snap elements to end' },
   { type:'modifier', class: 'carousel-vertical', desc: 'Vertical carousel' },


### PR DESCRIPTION
If we add `carousel-center` to the classname for mobile devices and it'd be hard to change it back to the default `scroll-snap-align: start` behaviour for desktop. So just add this `carousel-start` modifier and use `lg:carousel-start` for this senario.