### PR TITLE
Update modal.css

### DIFF
--- a/src/components/unstyled/modal.css
+++ b/src/components/unstyled/modal.css
@@ -27,5 +27,5 @@
 }
 :root:has(:is(.modal-open, .modal:target, .modal-toggle:checked + .modal, .modal[open])) {
   @apply overflow-hidden;
-  @apply pr-[15px];
+  scrollbar-gutter: stable;
 }

--- a/src/components/unstyled/modal.css
+++ b/src/components/unstyled/modal.css
@@ -27,4 +27,5 @@
 }
 :root:has(:is(.modal-open, .modal:target, .modal-toggle:checked + .modal, .modal[open])) {
   @apply overflow-hidden;
+  @apply pr-[15px];
 }


### PR DESCRIPTION
When opening a modal window, the scrollbar disappears, but the content shifts

This padding automatically shifts the content to the left so that the user does not notice the content moving when the scrollbar disappears

Padding is equal to the standard scrollbar width