### PR TITLE
[DOC SITE] Small change to capitalization in final stat component example

### DIFF
--- a/src/docs/src/routes/(docs)/components/stat/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/components/stat/+page.svelte.md
@@ -324,7 +324,7 @@ data="{[
     <div class="stat-value">$89,400</div>
     <div class="stat-actions">
       <button class="btn btn-sm">Withdrawal</button> 
-      <button class="btn btn-sm">deposit</button>
+      <button class="btn btn-sm">Deposit</button>
     </div>
   </div>
 </div>
@@ -344,7 +344,7 @@ data="{[
     <div class="$$stat-value">$89,400</div>
     <div class="$$stat-actions">
       <button class="$$btn $$btn-sm">Withdrawal</button> 
-      <button class="$$btn $$btn-sm">deposit</button>
+      <button class="$$btn $$btn-sm">Deposit</button>
     </div>
   </div>
   


### PR DESCRIPTION
Changed "deposit" to "Deposit" to maintain consistent capitalization as I believe it makes the docs more consistent both aesthetically and in logic.

Feel free to disregard if not needed!