### PR TITLE
Update +page.svelte.md to fix Hero component documentation

### DIFF
--- a/src/docs/src/routes/(docs)/components/hero/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/components/hero/+page.svelte.md
@@ -75,23 +75,23 @@ data="{[
 <Component title="Hero with figure but reverse order">
 <div class="hero min-h-[30rem] rounded bg-base-200">
   <div class="flex-col hero-content lg:flex-row-reverse">
-    <img src="/images/stock/photo-1635805737707-575885ab0820.jpg" class="max-w-sm rounded-lg shadow-2xl" alt="Tailwind CSS hero component" />
     <div>
       <h3 class="text-5xl font-bold">Box Office News!</h3>
       <p class="py-6">Provident cupiditate voluptatem et in. Quaerat fugiat ut assumenda excepturi exercitationem quasi. In deleniti eaque aut repudiandae et a id nisi.</p>
       <button class="btn btn-primary">Get Started</button>
     </div>
+    <img src="/images/stock/photo-1635805737707-575885ab0820.jpg" class="max-w-sm rounded-lg shadow-2xl" alt="Tailwind CSS hero component" />
   </div>
 </div>
 <pre slot="html" use:replace={{ to: $prefix }}>{
 `<div class="$$hero min-h-screen bg-base-200">
   <div class="$$hero-content flex-col lg:flex-row-reverse">
-    <img src="/images/stock/photo-1635805737707-575885ab0820.jpg" class="max-w-sm rounded-lg shadow-2xl" />
     <div>
       <h1 class="text-5xl font-bold">Box Office News!</h1>
       <p class="py-6">Provident cupiditate voluptatem et in. Quaerat fugiat ut assumenda excepturi exercitationem quasi. In deleniti eaque aut repudiandae et a id nisi.</p>
       <button class="$$btn $$btn-primary">Get Started</button>
     </div>
+    <img src="/images/stock/photo-1635805737707-575885ab0820.jpg" class="max-w-sm rounded-lg shadow-2xl" />
   </div>
 </div>`
 }</pre>


### PR DESCRIPTION
Hero component code example of "Hero with figure but reverse order" was wrong. The image tag was being put before the text div. Fix moves image to after text div. Code was causing image to render left of text instead of the right.