### PR TITLE
update install markdown, use ESM for tailwind config.

### DIFF
--- a/src/docs/src/routes/(docs)/docs/install/+page.svelte.md
+++ b/src/docs/src/routes/(docs)/docs/install/+page.svelte.md
@@ -23,10 +23,15 @@ npm i -D daisyui@latest
 2. <Translate text="Then add daisyUI to your <code>tailwind.config.js</code> files" />:
 
 ```js
-module.exports = {
-  //...
-  plugins: [require("daisyui")],
+...
+import daisyui from 'daisyui'
+
+const config = {
+  // ...
+  plugins: [daisyui],
 }
+
+export default config
 ```
 
 ## <Translate text="daisyUI example repositories"/>


### PR DESCRIPTION
Tailwind is using ESM for its config file by default for while now.