### PR TITLE
#3060 - update drawer.css z-index

### DIFF
--- a/src/components/styled/drawer.css
+++ b/src/components/styled/drawer.css
@@ -1,6 +1,7 @@
 .drawer {
   width: 100%;
   &-side {
+    @apply z-10;
     & > .drawer-overlay {
       @apply cursor-pointer bg-transparent transition-colors duration-200 ease-out;
     }


### PR DESCRIPTION
Related to https://github.com/saadeghi/daisyui/issues/3060

Should prevent any elements in DaisyUI from having a higher z-index than the drawer.