### PR TITLE
Tooltip max-width whitespace wrapping

### DIFF
--- a/src/utilities/styled/tooltip.css
+++ b/src/utilities/styled/tooltip.css
@@ -13,7 +13,7 @@
   @apply absolute;
 }
 .tooltip:before {
-  @apply max-w-xs rounded px-2 py-1 text-sm;
+  @apply max-w-xs rounded px-2 py-1 text-sm whitespace-normal;
   background-color: var(--tooltip-color);
   color: var(--tooltip-text-color);
   width: max-content;


### PR DESCRIPTION
If a parent of tooltips has no-wrap or truncate, the tooltip text will overflow if it exceeds the max-width. Adding whitespace-normal to tooltip:before will reset this behavior.