### PR TITLE
Prevent height change in Collapse component title

### DIFF
--- a/src/components/unstyled/collapse.css
+++ b/src/components/unstyled/collapse.css
@@ -3,7 +3,7 @@
 }
 .collapse {
   @apply relative grid overflow-hidden;
-  grid-template-rows: auto 0fr;
+  grid-template-rows: max-content 0fr;
   transition: grid-template-rows 0.2s;
 }
 .collapse-title,
@@ -23,11 +23,11 @@
 .collapse[open],
 .collapse-open,
 .collapse:focus:not(.collapse-close) {
-  grid-template-rows: auto 1fr;
+  grid-template-rows: max-content 1fr;
 }
 .collapse:not(.collapse-close):has(> input[type="checkbox"]:checked),
 .collapse:not(.collapse-close):has(> input[type="radio"]:checked) {
-  grid-template-rows: auto 1fr;
+  grid-template-rows: max-content 1fr;
 }
 .collapse[open] > .collapse-content,
 .collapse-open > .collapse-content,


### PR DESCRIPTION
When toggling show/hide, if the title has a different background color than the content, and if there is lengthy content, you can see the title row/track grow during the animation before returning to its original size. Using `max-content` instead of `auto` in the grid-template-rows rules should lock the height of the title, so only the 2nd row (content) changes from `0fr` to `1fr`.

Original issue:

https://github.com/user-attachments/assets/a56c62ec-7ed7-4dfe-ab03-6ad1bdec2bcb

With the style change in this pull request:

https://github.com/user-attachments/assets/def5447c-3d69-40e2-a15e-c31fe6bc0a4c

Thanks for considering, love the component library!