### PR TITLE
Added vertical ranges

### DIFF
--- a/src/components/styled/range.css
+++ b/src/components/styled/range.css
@@ -95,18 +95,42 @@
     &.range-xs {
       width: 1rem;
       height: 100%;
+      &::-webkit-slider-runnable-track {
+        width: 0.25rem
+      }
+      &::-moz-range-track {
+        width: 0.25rem
+      }
     }
     &.range-sm {
       width: 1.25rem;
       height: 100%;
+      &::-webkit-slider-runnable-track {
+        width: 0.25rem
+      }
+      &::-moz-range-track {
+        width: 0.25rem
+      }
     }
     &.range-md {
       width: 1.5rem;
       height: 100%;
+      &::-webkit-slider-runnable-track {
+        width: 0.5rem
+      }
+      &::-moz-range-track {
+        width: 0.5rem
+      }
     }
     &.range-lg {
       width: 2rem;
       height: 100%;
+      &::-webkit-slider-runnable-track {
+        width: 1rem
+      }
+      &::-moz-range-track {
+        width: 1rem
+      }
     }
   }
   &-primary {

--- a/src/components/styled/range.css
+++ b/src/components/styled/range.css
@@ -45,7 +45,6 @@
     writing-mode: vertical-lr;
     direction: rtl;
     height: 100%;
-    max-height: 10em;
     width: 1.5rem;
 
     &:focus-visible::-webkit-slider-thumb {

--- a/src/components/styled/range.css
+++ b/src/components/styled/range.css
@@ -92,6 +92,23 @@
           0 calc(var(--filler-size) * -1 - var(--filler-offset)) 0 var(--filler-size);
       }
     }
+
+    &.range-xs {
+      width: 1rem;
+      height: 100%;
+    }
+    &.range-sm {
+      width: 1.25rem;
+      height: 100%;
+    }
+    &.range-md {
+      width: 1.5rem;
+      height: 100%;
+    }
+    &.range-lg {
+      width: 2rem;
+      height: 100%;
+    }
   }
   &-primary {
     --range-shdw: theme(colors.primary);

--- a/src/components/styled/range.css
+++ b/src/components/styled/range.css
@@ -40,6 +40,59 @@
       var(--focus-shadow, 0 0),
       calc(var(--filler-size) * -1 - var(--filler-offset)) 0 0 var(--filler-size);
   }
+
+  &-vertical {
+    writing-mode: vertical-lr;
+    direction: rtl;
+    height: 100%;
+    max-height: 10em;
+    width: 1.5rem;
+
+    &:focus-visible::-webkit-slider-thumb {
+      --focus-shadow: 0 0 0 6px theme(colors.base-100) inset, 0 0 0 2rem var(--range-shdw) inset;
+    }
+    &:focus-visible::-moz-range-thumb {
+      --focus-shadow: 0 0 0 6px theme(colors.base-100) inset, 0 0 0 2rem var(--range-shdw) inset;
+    }
+    &::-webkit-slider-runnable-track {
+      @apply w-2 h-full;
+    }
+    &::-moz-range-track {
+      @apply w-2 h-full;
+    }
+    &::-webkit-slider-thumb {
+      top: 0%;
+      left: 50%;
+      transform: translateX(-50%);
+      box-shadow:
+        0 0 0 3px var(--range-shdw) inset,
+        var(--focus-shadow, 0 0),
+        0 calc(var(--filler-size) * 1 + var(--filler-offset)) 0 var(--filler-size);
+    }
+    &::-moz-range-thumb {
+      top: 0%;
+      left: 50%;
+      box-shadow:
+        0 0 0 3px var(--range-shdw) inset,
+        var(--focus-shadow, 0 0),
+        0 calc(var(--filler-size) * 1 + var(--filler-offset)) 0 var(--filler-size);
+    }
+    &.range-invert {
+      direction: ltr;
+      &::-webkit-slider-thumb {
+        box-shadow:
+          0 0 0 3px var(--range-shdw) inset,
+          var(--focus-shadow, 0 0),
+          0 calc(var(--filler-size) * -1 - var(--filler-offset)) 0 var(--filler-size);
+      }
+      &::-moz-range-thumb {
+        box-shadow:
+          0 0 0 3px var(--range-shdw) inset,
+          var(--focus-shadow, 0 0),
+          0 calc(var(--filler-size) * -1 - var(--filler-offset)) 0 var(--filler-size);
+      }
+    }
+  }
   &-primary {
     --range-shdw: theme(colors.primary);
   }

--- a/src/docs/src/routes/(docs)/components/range/+page.svx
+++ b/src/docs/src/routes/(docs)/components/range/+page.svx
@@ -179,16 +179,18 @@ data="{[
 </Component>
 
 <Component title="Vertical and inverted">
-<input type="range" min="0" max="100" value="100" class="range range-vertical max-w-xs" />
-<input type="range" min="0" max="100" value="10" class="range range-vertical range-invert max-w-xs" />
-<input type="range" min="0" max="100" value="80" class="range range-vertical range-xs max-w-xs" />
-<input type="range" min="0" max="100" value="30" class="range range-vertical range-invert range-xs max-w-xs" />
-<input type="range" min="0" max="100" value="60" class="range range-vertical range-sm max-w-xs" />
-<input type="range" min="0" max="100" value="50" class="range range-vertical range-invert range-sm max-w-xs" />
-<input type="range" min="0" max="100" value="40" class="range range-vertical range-md max-w-xs" />
-<input type="range" min="0" max="100" value="70" class="range range-vertical range-invert range-md max-w-xs" />
-<input type="range" min="0" max="100" value="20" class="range range-vertical range-lg max-w-xs" />
-<input type="range" min="0" max="100" value="90" class="range range-vertical range-invert range-lg max-w-xs" />
+<div style="max-height:10em;">
+  <input type="range" min="0" max="100" value="100" class="range range-vertical max-w-xs" />
+  <input type="range" min="0" max="100" value="10" class="range range-vertical range-invert max-w-xs" />
+  <input type="range" min="0" max="100" value="80" class="range range-vertical range-xs max-w-xs" />
+  <input type="range" min="0" max="100" value="30" class="range range-vertical range-invert range-xs max-w-xs" />
+  <input type="range" min="0" max="100" value="60" class="range range-vertical range-sm max-w-xs" />
+  <input type="range" min="0" max="100" value="50" class="range range-vertical range-invert range-sm max-w-xs" />
+  <input type="range" min="0" max="100" value="40" class="range range-vertical range-md max-w-xs" />
+  <input type="range" min="0" max="100" value="70" class="range range-vertical range-invert range-md max-w-xs" />
+  <input type="range" min="0" max="100" value="20" class="range range-vertical range-lg max-w-xs" />
+  <input type="range" min="0" max="100" value="90" class="range range-vertical range-invert range-lg max-w-xs" />
+</div>
 {#snippet html()}
 
 ```html

--- a/src/docs/src/routes/(docs)/components/range/+page.svx
+++ b/src/docs/src/routes/(docs)/components/range/+page.svx
@@ -179,31 +179,27 @@ data="{[
 </Component>
 
 <Component title="Vertical and inverted">
-<div style="max-height:10em;">
-  <input type="range" min="0" max="100" value="100" class="range range-vertical max-w-xs" />
-  <input type="range" min="0" max="100" value="10" class="range range-vertical range-invert max-w-xs" />
+<div class="flex h-full items-center gap-4 max-h-40">
   <input type="range" min="0" max="100" value="80" class="range range-vertical range-xs max-w-xs" />
-  <input type="range" min="0" max="100" value="30" class="range range-vertical range-invert range-xs max-w-xs" />
-  <input type="range" min="0" max="100" value="60" class="range range-vertical range-sm max-w-xs" />
-  <input type="range" min="0" max="100" value="50" class="range range-vertical range-invert range-sm max-w-xs" />
-  <input type="range" min="0" max="100" value="40" class="range range-vertical range-md max-w-xs" />
+  <input type="range" min="0" max="100" value="70" class="range range-vertical range-sm max-w-xs" />
+  <input type="range" min="0" max="100" value="60" class="range range-vertical range-md max-w-xs" />
+  <input type="range" min="0" max="100" value="50" class="range range-vertical range-lg max-w-xs" />
+  <input type="range" min="0" max="100" value="60" class="range range-vertical range-invert range-lg max-w-xs" />
   <input type="range" min="0" max="100" value="70" class="range range-vertical range-invert range-md max-w-xs" />
-  <input type="range" min="0" max="100" value="20" class="range range-vertical range-lg max-w-xs" />
-  <input type="range" min="0" max="100" value="90" class="range range-vertical range-invert range-lg max-w-xs" />
+  <input type="range" min="0" max="100" value="80" class="range range-vertical range-invert range-sm max-w-xs" />
+  <input type="range" min="0" max="100" value="90" class="range range-vertical range-invert range-xs max-w-xs" />
 </div>
 {#snippet html()}
 
 ```html
-<input type="range" min="0" max="100" value="100" class="$$range $$range-vertical max-w-xs" />
-<input type="range" min="0" max="100" value="10" class="$$range $$range-vertical $$range-invert max-w-xs" />
-<input type="range" min="0" max="100" value="80" class="$$range $$range-vertical $$range-xs max-w-xs" />
-<input type="range" min="0" max="100" value="30" class="$$range $$range-vertical $$range-invert $$range-xs max-w-xs" />
-<input type="range" min="0" max="100" value="60" class="$$range $$range-vertical $$range-sm max-w-xs" />
-<input type="range" min="0" max="100" value="50" class="$$range $$range-vertical $$range-invert $$range-sm max-w-xs" />
-<input type="range" min="0" max="100" value="40" class="$$range $$range-vertical $$range-md max-w-xs" />
-<input type="range" min="0" max="100" value="70" class="$$range $$range-vertical $$range-invert $$range-md max-w-xs" />
-<input type="range" min="0" max="100" value="20" class="$$range $$range-vertical $$range-lg max-w-xs" />
-<input type="range" min="0" max="100" value="90" class="$$range $$range-vertical $$range-invert $$range-lg max-w-xs" />
+<input type="range" min="0" max="100" value="80" class="range range-vertical range-xs max-w-xs" />
+<input type="range" min="0" max="100" value="70" class="range range-vertical range-sm max-w-xs" />
+<input type="range" min="0" max="100" value="60" class="range range-vertical range-md max-w-xs" />
+<input type="range" min="0" max="100" value="50" class="range range-vertical range-lg max-w-xs" />
+<input type="range" min="0" max="100" value="60" class="range range-vertical range-invert range-lg max-w-xs" />
+<input type="range" min="0" max="100" value="70" class="range range-vertical range-invert range-md max-w-xs" />
+<input type="range" min="0" max="100" value="80" class="range range-vertical range-invert range-sm max-w-xs" />
+<input type="range" min="0" max="100" value="90" class="range range-vertical range-invert range-xs max-w-xs" />
 ```
 
 {/snippet}

--- a/src/docs/src/routes/(docs)/components/range/+page.svx
+++ b/src/docs/src/routes/(docs)/components/range/+page.svx
@@ -179,13 +179,29 @@ data="{[
 </Component>
 
 <Component title="Vertical and inverted">
-<input type="range" min="0" max="100" value="40" class="range range-vertical max-w-xs" />
-<input type="range" min="0" max="100" value="40" class="range range-vertical range-invert max-w-xs" />
+<input type="range" min="0" max="100" value="100" class="range range-vertical max-w-xs" />
+<input type="range" min="0" max="100" value="10" class="range range-vertical range-invert max-w-xs" />
+<input type="range" min="0" max="100" value="80" class="range range-vertical range-xs max-w-xs" />
+<input type="range" min="0" max="100" value="30" class="range range-vertical range-invert range-xs max-w-xs" />
+<input type="range" min="0" max="100" value="60" class="range range-vertical range-sm max-w-xs" />
+<input type="range" min="0" max="100" value="50" class="range range-vertical range-invert range-sm max-w-xs" />
+<input type="range" min="0" max="100" value="40" class="range range-vertical range-md max-w-xs" />
+<input type="range" min="0" max="100" value="70" class="range range-vertical range-invert range-md max-w-xs" />
+<input type="range" min="0" max="100" value="20" class="range range-vertical range-lg max-w-xs" />
+<input type="range" min="0" max="100" value="90" class="range range-vertical range-invert range-lg max-w-xs" />
 {#snippet html()}
 
 ```html
-<input type="range" min="0" max="100" value="40" class="range range-vertical max-w-xs" />
-<input type="range" min="0" max="100" value="40" class="range range-vertical range-invert max-w-xs" />
+<input type="range" min="0" max="100" value="100" class="$$range $$range-vertical max-w-xs" />
+<input type="range" min="0" max="100" value="10" class="$$range $$range-vertical $$range-invert max-w-xs" />
+<input type="range" min="0" max="100" value="80" class="$$range $$range-vertical $$range-xs max-w-xs" />
+<input type="range" min="0" max="100" value="30" class="$$range $$range-vertical $$range-invert $$range-xs max-w-xs" />
+<input type="range" min="0" max="100" value="60" class="$$range $$range-vertical $$range-sm max-w-xs" />
+<input type="range" min="0" max="100" value="50" class="$$range $$range-vertical $$range-invert $$range-sm max-w-xs" />
+<input type="range" min="0" max="100" value="40" class="$$range $$range-vertical $$range-md max-w-xs" />
+<input type="range" min="0" max="100" value="70" class="$$range $$range-vertical $$range-invert $$range-md max-w-xs" />
+<input type="range" min="0" max="100" value="20" class="$$range $$range-vertical $$range-lg max-w-xs" />
+<input type="range" min="0" max="100" value="90" class="$$range $$range-vertical $$range-invert $$range-lg max-w-xs" />
 ```
 
 {/snippet}

--- a/src/docs/src/routes/(docs)/components/range/+page.svx
+++ b/src/docs/src/routes/(docs)/components/range/+page.svx
@@ -177,3 +177,16 @@ data="{[
 
 {/snippet}
 </Component>
+
+<Component title="Vertical and inverted">
+<input type="range" min="0" max="100" value="40" class="range range-vertical max-w-xs" />
+<input type="range" min="0" max="100" value="40" class="range range-vertical range-invert max-w-xs" />
+{#snippet html()}
+
+```html
+<input type="range" min="0" max="100" value="40" class="range range-vertical max-w-xs" />
+<input type="range" min="0" max="100" value="40" class="range range-vertical range-invert max-w-xs" />
+```
+
+{/snippet}
+</Component>


### PR DESCRIPTION
Fixes #1483.

Adds styles for vertical Range sliders: `.range-vertical` and `.range-vertical.range-invert`.

I chose `.range-invert` because I'm not sure if there'll be an intent to add such a feature for all other sliders...