### PR TITLE
Windows compatibility 2

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -1,59 +1,53 @@
 const { exec } = require("node:child_process");
-const { normalize } = require("node:path");
-const isWin = process.platform === "win32";
-const ext = isWin ? ".cmd" : "";
-const cat = isWin ? "type" : "cat";
 
 function runCommand(command) {
-    if(isWin) {
-        command = command.split(" ");
-        command[0] = command[0].replace(/\//g, "\\");
-        command = command.join(" ");
-    }
-    return new Promise((resolve, reject) => {
-        exec(command, (error, stdout, stderr) => {
-            if (error) {
-                reject(error)
-            } else {
-                resolve({ stdout, stderr })
-            }
-        })
+  if (process.platform === "win32") command = `pwsh -e "${Buffer.from(command, "utf16le").toString("base64")}"`;
+
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve({ stdout, stderr })
+      }
     })
+  })
 }
 
 async function executeCommands() {
-    try {
-        await runCommand(`node_modules/.bin/postcss${ext} --config src/base src/base/*.css --base src --dir dist`)
-        await runCommand(`${cat} ${normalize("dist/base/*.css")} > ${normalize("dist/base.css")}`)
-        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/base.css --format commonjs`)
-        // await runCommand("mv dist/base.js dist/base.cjs")
-        await runCommand(`node_modules/.bin/postcss${ext} --config src/utilities/global src/utilities/global/*.css --base src --dir dist`)
-        await runCommand(`${cat} ${normalize("dist/utilities/global/*.css")} > ${normalize("dist/utilities.css")}`)
-        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/utilities.css --format commonjs`)
-        // await runCommand("mv dist/utilities.js dist/utilities.cjs")
+  try {
+    await runCommand(`node_modules/.bin/postcss --config src/base src/base/*.css --base src --dir dist`)
+    await runCommand(`cat dist/base/*.css > dist/base.css`)
+    await runCommand(`node_modules/.bin/prejss-cli dist/base.css --format commonjs`)
+    // await runCommand("mv dist/base.js dist/base.cjs")
+    await runCommand(`node_modules/.bin/postcss --config src/utilities/global src/utilities/global/*.css --base src --dir dist`)
+    await runCommand(`cat dist/utilities/global/*.css > dist/utilities.css`)
+    await runCommand(`node_modules/.bin/prejss-cli dist/utilities.css --format commonjs`)
+    // await runCommand("mv dist/utilities.js dist/utilities.cjs")
 
-        await runCommand(`node_modules/.bin/postcss${ext} --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist`)
-        await runCommand(`${cat} ${normalize("dist/utilities/unstyled/*.css")} > ${normalize("dist/utilities-unstyled.css")}`)
-        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/utilities-unstyled.css --format commonjs`)
-        // await runCommand("mv dist/utilities-unstyled.js dist/utilities-unstyled.cjs")
-        await runCommand(`node_modules/.bin/postcss${ext} --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist`)
-        await runCommand(`${cat} ${normalize("dist/utilities/styled/*.css")} > ${normalize("dist/utilities-styled.css")}`)
-        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/utilities-styled.css --format commonjs`)
-        // await runCommand("mv dist/utilities-styled.js dist/utilities-styled.cjs")
-        await runCommand(`node_modules/.bin/postcss${ext} --config src/components src/components/**/*.css --base src --dir dist`)
-        await runCommand(`${cat} ${normalize("dist/components/unstyled/*.css")} > ${normalize("dist/unstyled.css")}`)
-        await runCommand(`${cat} ${normalize("dist/components/unstyled/*.css")} ${normalize("dist/components/styled/*.css")} > ${normalize("dist/styled.css")}`)
-        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/{unstyled,styled}.css --format commonjs`)
-        // await runCommand("mv dist/unstyled.js dist/unstyled.cjs")
-        // await runCommand("mv dist/styled.js dist/styled.cjs")
-        await runCommand(`node_modules/.bin/postcss${ext} src/themes/index.css -o dist/themes.css --config src/themes`)
+    await runCommand(`node_modules/.bin/postcss --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist`)
+    await runCommand(`cat dist/utilities/unstyled/*.css > dist/utilities-unstyled.css`)
+    await runCommand(`node_modules/.bin/prejss-cli dist/utilities-unstyled.css --format commonjs`)
+    // await runCommand("mv dist/utilities-unstyled.js dist/utilities-unstyled.cjs")
+    await runCommand(`node_modules/.bin/postcss --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist`)
+    await runCommand(`cat dist/utilities/styled/*.css > dist/utilities-styled.css`)
+    await runCommand(`node_modules/.bin/prejss-cli dist/utilities-styled.css --format commonjs`)
+    // await runCommand("mv dist/utilities-styled.js dist/utilities-styled.cjs")
+    await runCommand(`node_modules/.bin/postcss --config src/components src/components/**/*.css --base src --dir dist`)
+    await runCommand(`cat dist/components/unstyled/*.css > dist/unstyled.css`)
+    await runCommand(`cat dist/components/unstyled/*.css dist/components/styled/*.css > dist/styled.css`)
+    await runCommand(`node_modules/.bin/prejss-cli dist/styled.css --format commonjs`)
+    await runCommand(`node_modules/.bin/prejss-cli dist/unstyled.css --format commonjs`)
+    // await runCommand("mv dist/unstyled.js dist/unstyled.cjs")
+    // await runCommand("mv dist/styled.js dist/styled.cjs")
+    await runCommand(`node_modules/.bin/postcss src/themes/index.css -o dist/themes.css --config src/themes`)
 
-        if(!process.argv.includes("--skipfullcss")) {
-            await runCommand(`node_modules/.bin/postcss${ext} src/full/index.css -o dist/full.css --config src/full`)
-        }
-    } catch(error) {
-        console.error("Error executing commands:", error)
+    if(!process.argv.includes("--skipfullcss")) {
+      await runCommand(`node_modules/.bin/postcss src/full/index.css -o dist/full.css --config src/full`)
     }
+  } catch (error) {
+    console.error("Error executing commands:", error)
+  }
 }
 
 // Run the commands asynchronously

--- a/src/build.js
+++ b/src/build.js
@@ -1,4 +1,5 @@
-const { exec } = require("node:child_process")
+const { exec } = require("node:child_process");
+const { normalize } = require("node:path");
 const isWin = process.platform === "win32";
 const ext = isWin ? ".cmd" : "";
 const cat = isWin ? "type" : "cat";
@@ -9,70 +10,50 @@ function runCommand(command) {
         command[0] = command[0].replace(/\//g, "\\");
         command = command.join(" ");
     }
-  return new Promise((resolve, reject) => {
-    exec(command, (error, stdout, stderr) => {
-      if (error) {
-        reject(error)
-      } else {
-        resolve({ stdout, stderr })
-      }
+    return new Promise((resolve, reject) => {
+        exec(command, (error, stdout, stderr) => {
+            if (error) {
+                reject(error)
+            } else {
+                resolve({ stdout, stderr })
+            }
+        })
     })
-  })
 }
 
 async function executeCommands() {
-  try {
-    await runCommand(
-      "node_modules/.bin/postcss"+ext+" --config src/base src/base/*.css --base src --dir dist"
-    )
-    await runCommand(cat+" dist/base/*.css > dist/base.css")
-    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/base.css --format commonjs")
-    // await runCommand("mv dist/base.js dist/base.cjs")
-    await runCommand(
-      "node_modules/.bin/postcss"+ext+" --config src/utilities/global src/utilities/global/*.css --base src --dir dist"
-    )
-    await runCommand(cat+" dist/utilities/global/*.css > dist/utilities.css")
-    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/utilities.css --format commonjs")
-    // await runCommand("mv dist/utilities.js dist/utilities.cjs")
+    try {
+        await runCommand(`node_modules/.bin/postcss${ext} --config src/base src/base/*.css --base src --dir dist`)
+        await runCommand(`${cat} ${normalize("dist/base/*.css")} > ${normalize("dist/base.css")}`)
+        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/base.css --format commonjs`)
+        // await runCommand("mv dist/base.js dist/base.cjs")
+        await runCommand(`node_modules/.bin/postcss${ext} --config src/utilities/global src/utilities/global/*.css --base src --dir dist`)
+        await runCommand(`${cat} ${normalize("dist/utilities/global/*.css")} > ${normalize("dist/utilities.css")}`)
+        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/utilities.css --format commonjs`)
+        // await runCommand("mv dist/utilities.js dist/utilities.cjs")
 
-    await runCommand(
-      "node_modules/.bin/postcss"+ext+" --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist",
-      { stdio: [] }
-    )
-    await runCommand(cat+" dist/utilities/unstyled/*.css > dist/utilities-unstyled.css")
-    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/utilities-unstyled.css --format commonjs")
-    // await runCommand("mv dist/utilities-unstyled.js dist/utilities-unstyled.cjs")
-    await runCommand(
-      "node_modules/.bin/postcss"+ext+" --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist",
-      { stdio: [] }
-    )
-    await runCommand(cat+" dist/utilities/styled/*.css > dist/utilities-styled.css")
-    await runCommand("node_modules/.bin/prejss-cli dist/utilities-styled.css --format commonjs")
-    // await runCommand("mv dist/utilities-styled.js dist/utilities-styled.cjs")
-    await runCommand(
-      "node_modules/.bin/postcss"+ext+" --config src/components src/components/**/*.css --base src --dir dist"
-    )
-    await runCommand(cat+" dist/components/unstyled/*.css > dist/unstyled.css")
-    await runCommand(
-      cat+" dist/components/unstyled/*.css dist/components/styled/*.css > dist/styled.css"
-    )
-    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/{unstyled,styled}.css --format commonjs")
-    // await runCommand("mv dist/unstyled.js dist/unstyled.cjs")
-    // await runCommand("mv dist/styled.js dist/styled.cjs")
-    await runCommand(
-      "node_modules/.bin/postcss"+ext+" src/themes/index.css -o dist/themes.css --config src/themes",
-      {
-        stdio: [],
-      }
-    )
-    if (!process.argv.includes("--skipfullcss")) {
-      await runCommand(
-        "node_modules/.bin/postcss"+ext+" src/full/index.css -o dist/full.css --config src/full"
-      )
+        await runCommand(`node_modules/.bin/postcss${ext} --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist`)
+        await runCommand(`${cat} ${normalize("dist/utilities/unstyled/*.css")} > ${normalize("dist/utilities-unstyled.css")}`)
+        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/utilities-unstyled.css --format commonjs`)
+        // await runCommand("mv dist/utilities-unstyled.js dist/utilities-unstyled.cjs")
+        await runCommand(`node_modules/.bin/postcss${ext} --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist`)
+        await runCommand(`${cat} ${normalize("dist/utilities/styled/*.css")} > ${normalize("dist/utilities-styled.css")}`)
+        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/utilities-styled.css --format commonjs`)
+        // await runCommand("mv dist/utilities-styled.js dist/utilities-styled.cjs")
+        await runCommand(`node_modules/.bin/postcss${ext} --config src/components src/components/**/*.css --base src --dir dist`)
+        await runCommand(`${cat} ${normalize("dist/components/unstyled/*.css")} > ${normalize("dist/unstyled.css")}`)
+        await runCommand(`${cat} ${normalize("dist/components/unstyled/*.css")} ${normalize("dist/components/styled/*.css")} > ${normalize("dist/styled.css")}`)
+        await runCommand(`node_modules/.bin/prejss-cli${ext} dist/{unstyled,styled}.css --format commonjs`)
+        // await runCommand("mv dist/unstyled.js dist/unstyled.cjs")
+        // await runCommand("mv dist/styled.js dist/styled.cjs")
+        await runCommand(`node_modules/.bin/postcss${ext} src/themes/index.css -o dist/themes.css --config src/themes`)
+
+        if(!process.argv.includes("--skipfullcss")) {
+            await runCommand(`node_modules/.bin/postcss${ext} src/full/index.css -o dist/full.css --config src/full`)
+        }
+    } catch(error) {
+        console.error("Error executing commands:", error)
     }
-  } catch (error) {
-    console.error("Error executing commands:", error)
-  }
 }
 
 // Run the commands asynchronously

--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,7 @@
 const { exec } = require("node:child_process")
 const isWin = process.platform === "win32";
 const ext = isWin ? ".cmd" : "";
+const cat = isWin ? "type" : "cat";
 
 function runCommand(command) {
     if(isWin) {
@@ -24,13 +25,13 @@ async function executeCommands() {
     await runCommand(
       "node_modules/.bin/postcss"+ext+" --config src/base src/base/*.css --base src --dir dist"
     )
-    await runCommand("cat dist/base/*.css > dist/base.css")
+    await runCommand(cat+" dist/base/*.css > dist/base.css")
     await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/base.css --format commonjs")
     // await runCommand("mv dist/base.js dist/base.cjs")
     await runCommand(
       "node_modules/.bin/postcss"+ext+" --config src/utilities/global src/utilities/global/*.css --base src --dir dist"
     )
-    await runCommand("cat dist/utilities/global/*.css > dist/utilities.css")
+    await runCommand(cat+" dist/utilities/global/*.css > dist/utilities.css")
     await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/utilities.css --format commonjs")
     // await runCommand("mv dist/utilities.js dist/utilities.cjs")
 
@@ -38,22 +39,22 @@ async function executeCommands() {
       "node_modules/.bin/postcss"+ext+" --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist",
       { stdio: [] }
     )
-    await runCommand("cat dist/utilities/unstyled/*.css > dist/utilities-unstyled.css")
+    await runCommand(cat+" dist/utilities/unstyled/*.css > dist/utilities-unstyled.css")
     await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/utilities-unstyled.css --format commonjs")
     // await runCommand("mv dist/utilities-unstyled.js dist/utilities-unstyled.cjs")
     await runCommand(
       "node_modules/.bin/postcss"+ext+" --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist",
       { stdio: [] }
     )
-    await runCommand("cat dist/utilities/styled/*.css > dist/utilities-styled.css")
+    await runCommand(cat+" dist/utilities/styled/*.css > dist/utilities-styled.css")
     await runCommand("node_modules/.bin/prejss-cli dist/utilities-styled.css --format commonjs")
     // await runCommand("mv dist/utilities-styled.js dist/utilities-styled.cjs")
     await runCommand(
       "node_modules/.bin/postcss"+ext+" --config src/components src/components/**/*.css --base src --dir dist"
     )
-    await runCommand("cat dist/components/unstyled/*.css > dist/unstyled.css")
+    await runCommand(cat+" dist/components/unstyled/*.css > dist/unstyled.css")
     await runCommand(
-      "cat dist/components/unstyled/*.css dist/components/styled/*.css > dist/styled.css"
+      cat+" dist/components/unstyled/*.css dist/components/styled/*.css > dist/styled.css"
     )
     await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/{unstyled,styled}.css --format commonjs")
     // await runCommand("mv dist/unstyled.js dist/unstyled.cjs")

--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,13 @@
 const { exec } = require("node:child_process")
+const isWin = process.platform === "win32";
+const ext = isWin ? ".cmd" : "";
 
 function runCommand(command) {
+    if(isWin) {
+        command = command.split(" ");
+        command[0] = command[0].replace(/\//g, "\\");
+        command = command.join(" ");
+    }
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
       if (error) {
@@ -15,51 +22,51 @@ function runCommand(command) {
 async function executeCommands() {
   try {
     await runCommand(
-      "node_modules/.bin/postcss --config src/base src/base/*.css --base src --dir dist"
+      "node_modules/.bin/postcss"+ext+" --config src/base src/base/*.css --base src --dir dist"
     )
     await runCommand("cat dist/base/*.css > dist/base.css")
-    await runCommand("node_modules/.bin/prejss-cli dist/base.css --format commonjs")
+    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/base.css --format commonjs")
     // await runCommand("mv dist/base.js dist/base.cjs")
     await runCommand(
-      "node_modules/.bin/postcss --config src/utilities/global src/utilities/global/*.css --base src --dir dist"
+      "node_modules/.bin/postcss"+ext+" --config src/utilities/global src/utilities/global/*.css --base src --dir dist"
     )
     await runCommand("cat dist/utilities/global/*.css > dist/utilities.css")
-    await runCommand("node_modules/.bin/prejss-cli dist/utilities.css --format commonjs")
+    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/utilities.css --format commonjs")
     // await runCommand("mv dist/utilities.js dist/utilities.cjs")
 
     await runCommand(
-      "node_modules/.bin/postcss --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist",
+      "node_modules/.bin/postcss"+ext+" --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist",
       { stdio: [] }
     )
     await runCommand("cat dist/utilities/unstyled/*.css > dist/utilities-unstyled.css")
-    await runCommand("node_modules/.bin/prejss-cli dist/utilities-unstyled.css --format commonjs")
+    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/utilities-unstyled.css --format commonjs")
     // await runCommand("mv dist/utilities-unstyled.js dist/utilities-unstyled.cjs")
     await runCommand(
-      "node_modules/.bin/postcss --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist",
+      "node_modules/.bin/postcss"+ext+" --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist",
       { stdio: [] }
     )
     await runCommand("cat dist/utilities/styled/*.css > dist/utilities-styled.css")
     await runCommand("node_modules/.bin/prejss-cli dist/utilities-styled.css --format commonjs")
     // await runCommand("mv dist/utilities-styled.js dist/utilities-styled.cjs")
     await runCommand(
-      "node_modules/.bin/postcss --config src/components src/components/**/*.css --base src --dir dist"
+      "node_modules/.bin/postcss"+ext+" --config src/components src/components/**/*.css --base src --dir dist"
     )
     await runCommand("cat dist/components/unstyled/*.css > dist/unstyled.css")
     await runCommand(
       "cat dist/components/unstyled/*.css dist/components/styled/*.css > dist/styled.css"
     )
-    await runCommand("node_modules/.bin/prejss-cli dist/{unstyled,styled}.css --format commonjs")
+    await runCommand("node_modules/.bin/prejss-cli"+ext+" dist/{unstyled,styled}.css --format commonjs")
     // await runCommand("mv dist/unstyled.js dist/unstyled.cjs")
     // await runCommand("mv dist/styled.js dist/styled.cjs")
     await runCommand(
-      "node_modules/.bin/postcss src/themes/index.css -o dist/themes.css --config src/themes",
+      "node_modules/.bin/postcss"+ext+" src/themes/index.css -o dist/themes.css --config src/themes",
       {
         stdio: [],
       }
     )
     if (!process.argv.includes("--skipfullcss")) {
       await runCommand(
-        "node_modules/.bin/postcss src/full/index.css -o dist/full.css --config src/full"
+        "node_modules/.bin/postcss"+ext+" src/full/index.css -o dist/full.css --config src/full"
       )
     }
   } catch (error) {

--- a/src/build.js
+++ b/src/build.js
@@ -1,7 +1,7 @@
-const { exec } = require("node:child_process");
+const { exec } = require("node:child_process")
 
 function runCommand(command) {
-  if (process.platform === "win32") command = `pwsh -e "${Buffer.from(command, "utf16le").toString("base64")}"`;
+  if(process.platform === "win32") command = `pwsh -e "${Buffer.from(command, "utf16le").toString("base64")}"`;
 
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
@@ -16,34 +16,43 @@ function runCommand(command) {
 
 async function executeCommands() {
   try {
-    await runCommand(`node_modules/.bin/postcss --config src/base src/base/*.css --base src --dir dist`)
-    await runCommand(`cat dist/base/*.css > dist/base.css`)
-    await runCommand(`node_modules/.bin/prejss-cli dist/base.css --format commonjs`)
+    await runCommand(
+      "node_modules/.bin/postcss --config src/base src/base/*.css --base src --dir dist"
+    )
+    await runCommand("cat dist/base/*.css > dist/base.css")
+    await runCommand("node_modules/.bin/prejss-cli dist/base.css --format commonjs")
     // await runCommand("mv dist/base.js dist/base.cjs")
-    await runCommand(`node_modules/.bin/postcss --config src/utilities/global src/utilities/global/*.css --base src --dir dist`)
-    await runCommand(`cat dist/utilities/global/*.css > dist/utilities.css`)
-    await runCommand(`node_modules/.bin/prejss-cli dist/utilities.css --format commonjs`)
+    await runCommand(
+      "node_modules/.bin/postcss --config src/utilities/global src/utilities/global/*.css --base src --dir dist"
+    )
+    await runCommand("cat dist/utilities/global/*.css > dist/utilities.css")
+    await runCommand("node_modules/.bin/prejss-cli dist/utilities.css --format commonjs")
     // await runCommand("mv dist/utilities.js dist/utilities.cjs")
 
-    await runCommand(`node_modules/.bin/postcss --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist`)
-    await runCommand(`cat dist/utilities/unstyled/*.css > dist/utilities-unstyled.css`)
-    await runCommand(`node_modules/.bin/prejss-cli dist/utilities-unstyled.css --format commonjs`)
+    await runCommand("node_modules/.bin/postcss --config src/utilities/unstyled src/utilities/unstyled/*.css --base src --dir dist")
+    await runCommand("cat dist/utilities/unstyled/*.css > dist/utilities-unstyled.css")
+    await runCommand("node_modules/.bin/prejss-cli dist/utilities-unstyled.css --format commonjs")
     // await runCommand("mv dist/utilities-unstyled.js dist/utilities-unstyled.cjs")
-    await runCommand(`node_modules/.bin/postcss --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist`)
-    await runCommand(`cat dist/utilities/styled/*.css > dist/utilities-styled.css`)
-    await runCommand(`node_modules/.bin/prejss-cli dist/utilities-styled.css --format commonjs`)
+    await runCommand("node_modules/.bin/postcss --config src/utilities/styled src/utilities/styled/*.css --base src --dir dist")
+    await runCommand("cat dist/utilities/styled/*.css > dist/utilities-styled.css")
+    await runCommand("node_modules/.bin/prejss-cli dist/utilities-styled.css --format commonjs")
     // await runCommand("mv dist/utilities-styled.js dist/utilities-styled.cjs")
-    await runCommand(`node_modules/.bin/postcss --config src/components src/components/**/*.css --base src --dir dist`)
-    await runCommand(`cat dist/components/unstyled/*.css > dist/unstyled.css`)
-    await runCommand(`cat dist/components/unstyled/*.css dist/components/styled/*.css > dist/styled.css`)
-    await runCommand(`node_modules/.bin/prejss-cli dist/styled.css --format commonjs`)
-    await runCommand(`node_modules/.bin/prejss-cli dist/unstyled.css --format commonjs`)
+    await runCommand(
+      "node_modules/.bin/postcss --config src/components src/components/**/*.css --base src --dir dist"
+    )
+    await runCommand("cat dist/components/unstyled/*.css > dist/unstyled.css")
+    await runCommand(
+      "cat dist/components/unstyled/*.css dist/components/styled/*.css > dist/styled.css"
+    )
+    await runCommand("node_modules/.bin/prejss-cli dist/styled.css --format commonjs")
+    await runCommand("node_modules/.bin/prejss-cli dist/unstyled.css --format commonjs")
     // await runCommand("mv dist/unstyled.js dist/unstyled.cjs")
     // await runCommand("mv dist/styled.js dist/styled.cjs")
-    await runCommand(`node_modules/.bin/postcss src/themes/index.css -o dist/themes.css --config src/themes`)
-
-    if(!process.argv.includes("--skipfullcss")) {
-      await runCommand(`node_modules/.bin/postcss src/full/index.css -o dist/full.css --config src/full`)
+    await runCommand("node_modules/.bin/postcss src/themes/index.css -o dist/themes.css --config src/themes")
+    if (!process.argv.includes("--skipfullcss")) {
+      await runCommand(
+        "node_modules/.bin/postcss src/full/index.css -o dist/full.css --config src/full"
+      )
     }
   } catch (error) {
     console.error("Error executing commands:", error)

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -8,8 +8,8 @@
     "dev": "npm run createStyleHandlerComponent:dev --silent && vite dev --port 3000 --open",
     "build": "npm run get-json --silent && npm run createStyleHandlerComponent:prod --silent && NODE_ENV=production vite build --logLevel error",
     "preview": "npm run build && vite preview --port 3000 --open",
-    "createStyleHandlerComponent:dev": "echo $'<script>import \"$components/StyleDevelopment.svelte\"</script>' > src/components/StyleHandler.svelte",
-    "createStyleHandlerComponent:prod": "echo $'<script>import \"$components/StyleProduction.svelte\"</script>' > src/components/StyleHandler.svelte",
+    "createStyleHandlerComponent:dev": "node -e \"require('fs').writeFileSync('src/components/StyleHandler.svelte', `<script>import '$components/StyleDevelopment.svelte';</script>`)\"",
+    "createStyleHandlerComponent:prod": "node -e \"require('fs').writeFileSync('src/components/StyleHandler.svelte', `<script>import '$components/StyleProduction.svelte';</script>`)\"",
     "update-twitter-avatars": "node src/lib/scripts/get-twitter-avatars.js",
     "langdiff": "node src/lib/scripts/compare-translate-files"
   },

--- a/src/docs/vite.config.js
+++ b/src/docs/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      $components: path.resolve("/src/components"),
+      $components: path.resolve("./src/components"),
     },
   },
 })


### PR DESCRIPTION
Following from #3164, this is an update to the build script which now uses PowerShell. 

There's also some minor refactoring done for some of the `runCommand` calls to remove the erroneous `{stdio: []}` objects.

[Line 51](https://github.com/saadeghi/daisyui/compare/master...TheBrenny:daisyui:installer-fix#diff-abc8f6a58535fbae6adcdf1f8348cb6bed037902afdf5731f0070dd0cdb28753R47-R48) had to be broken up into two because Powershell kept reading the curly braces as a script block.

The changes to `package.json` make the switching between dev and prod platform agnostic by using NodeJS instead.

My builds also weren't working until I updated the vite config (windows read `/src/components/` as `C:\src\components\`), hence the change there.

Thanks for the heads up on using PowerShell! My world has low-key been opened up!