### PR TITLE
docs: use webp image on tailwindplay

### DIFF
--- a/src/docs/src/routes/(redirects)/tailwindplay/+page.server.js
+++ b/src/docs/src/routes/(redirects)/tailwindplay/+page.server.js
@@ -1,5 +1,5 @@
 export const ssr = false
 import { redirect } from "@sveltejs/kit"
 export function load() {
-  redirect(301, "https://play.tailwindcss.com/IvZT5sJSsa")
+  redirect(301, "https://play.tailwindcss.com/wWndQ9FxeZ")
 }


### PR DESCRIPTION
# Summary
Update an image extension at chat bubble avatar on tailwindplay.

## Description
The [present tailwindplay](https://play.tailwindcss.com/IvZT5sJSsa) uses [jpg image](https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg) at avatar.
However, jpg image doesn't load anymore.

Then I recreate [new tailwindplay link](https://play.tailwindcss.com/wWndQ9FxeZ) (https://play.tailwindcss.com/wWndQ9FxeZ) which has webp image.
It shows a women face correctly.