### PR TITLE
Rewrite selector causing performance issues

### DIFF
--- a/src/components/styled/stat.css
+++ b/src/components/styled/stat.css
@@ -4,7 +4,7 @@
 :where(.stats) {
   @apply divide-x divide-y-0 overflow-x-auto;
 }
-:is([dir="rtl"] .stats > :not([hidden]) ~ :not([hidden])) {
+[dir="rtl"] .stats > *:not([hidden]) + *:not([hidden]) {
   --tw-divide-x-reverse: 1;
 }
 .stat {

--- a/src/components/styled/stat.css
+++ b/src/components/styled/stat.css
@@ -4,7 +4,7 @@
 :where(.stats) {
   @apply divide-x divide-y-0 overflow-x-auto;
 }
-[dir="rtl"] .stats > *:not([hidden]) + *:not([hidden]) {
+[dir="rtl"] .stats > *:not([hidden]) ~ *:not([hidden]) {
   --tw-divide-x-reverse: 1;
 }
 .stat {


### PR DESCRIPTION
I recently noticed performance issues caused by a single selector in `src/components/styled/stat.css`:
```
:is([dir="rtl"] .stats > :not([hidden]) ~ :not([hidden])) {
  --tw-divide-x-reverse: 1;
}
```
It is taking a significant % of the total time in the Recalculate Style step (dev tools performance) with 0 matching elements. Also, my site is not `rtl` so I believe it shouldn't be trying to apply those styles. Here's a table showing the timings

| Recalculation | Total | Selector |
|--------|--------|--------|
| 1 | 139ms | 115ms |
| 2 | 107ms | 94ms |
| 3 | 112ms | 96ms |
| 4 | 119ms | 97ms |
| 5 | 117ms | 97ms | 

So on average, it takes 84% of the total recalculation and with 5 recalculations on the first page load my page is getting hit with an extra 500ms delay.

I've rewritten it, and it doesn't appear in the worst performers anymore and the page is loading much faster. Here are the results locally:

| Recalculation | Total | Selector |
|--------|--------|--------|
| 1 | 13.74ms | 0.036ms |
| 2 | 12.03ms | 0.043ms |
| 3 | 14.36ms | 0.044ms |
| 4 | 16.76ms | 0.043ms |
| 5 | 24.91ms | 0.070ms | 

Browsers I tried:
Brave 1.70.123, Edge 129.0.2792.52 (both chromium). I couldn't find a similar profiling tool in Firefox but the delay in page load seems to be there too.

I can upload the profiling file export showing the finding if required.
