### PR TITLE
Dark mode selector update

### DIFF
--- a/src/docs/src/routes/(docs)/docs/themes/+page.svx
+++ b/src/docs/src/routes/(docs)/docs/themes/+page.svx
@@ -287,6 +287,6 @@ module.exports = {
   daisyui: {
     themes: ['winter', 'night']
   },
-  darkMode: ['class', '[data-theme="night"]']
+  darkMode: ['selector', '[data-theme="night"]']
 }
 ```


### PR DESCRIPTION
it's will not work with class we should use `selector`

ref: https://tailwindcss.com/docs/dark-mode#customizing-the-selector