### PR TITLE
fix: #3268 unstyled collapse input size

### DIFF
--- a/src/components/styled/collapse.css
+++ b/src/components/styled/collapse.css
@@ -58,7 +58,7 @@ details.collapse summary {
 .collapse-title,
 :where(.collapse > input[type="checkbox"]),
 :where(.collapse > input[type="radio"]) {
-  @apply w-full p-4 pe-12;
+  @apply p-4 pe-12;
   min-height: 3.75rem;
   transition: background-color 0.2s ease-out;
 }

--- a/src/components/unstyled/collapse.css
+++ b/src/components/unstyled/collapse.css
@@ -16,6 +16,10 @@
 .collapse > input[type="radio"] {
   @apply appearance-none opacity-0;
 }
+:where(.collapse > input[type="checkbox"]),
+:where(.collapse > input[type="radio"]) {
+  @apply w-full h-full
+}
 .collapse-content {
   @apply invisible col-start-1 row-start-2 min-h-0;
   transition: visibility 0.2s;


### PR DESCRIPTION
Closes: https://github.com/saadeghi/daisyui/issues/3268

Specifying width and height for collapse input to make sure it is taking up all space in grid using any browsers.