### PR TITLE
fix: typo in 'rating' component documentation

### DIFF
--- a/src/docs/src/routes/(docs)/components/rating/+page.svx
+++ b/src/docs/src/routes/(docs)/components/rating/+page.svx
@@ -211,7 +211,7 @@ data="{[
 {/snippet}
 </Component>
 
-<Component title="with `rating-hidden`" desc="`rating-hidden` is a hidden radio at the start to allow uses remove their rating.">
+<Component title="with `rating-hidden`" desc="`rating-hidden` is a hidden radio at the start to allow users to remove their rating.">
 <div class="rating rating-lg">
   <input type="radio" name="rating-9" class="rating-hidden" />
   <input type="radio" name="rating-9" class="mask mask-star-2" />


### PR DESCRIPTION
Fix typo in "rating" component documentation under "rating-hidden"
