### PR TITLE
Update diff.css

### DIFF
--- a/src/components/unstyled/diff.css
+++ b/src/components/unstyled/diff.css
@@ -1,5 +1,6 @@
 .diff {
   @apply relative grid w-full overflow-hidden;
+  direction: ltr;
   container-type: inline-size;
   grid-template-columns: auto 1fr;
 }


### PR DESCRIPTION
The `Diff` component was not work working on RTL sites. While there may be alternative solutions, this fix offers a simple and effective solution.

### Changes:
- Applied a `direction: ltr` style to the `Diff` component to ensure proper alignment and functionality in RTL environments.

### Before (without `direction: ltr`):
![image](https://github.com/user-attachments/assets/487b8a36-cd79-4f55-b392-ee0567964ecc)

### After (with `direction: ltr`):
![image](https://github.com/user-attachments/assets/a1783274-67ee-4a6b-a771-a1c3890705ec)