### PR TITLE
fix(docs):  Move 'font-semibold' inside the class attribute

### DIFF
--- a/packages/docs/src/components/themegenerator/PreviewGrid.svelte
+++ b/packages/docs/src/components/themegenerator/PreviewGrid.svelte
@@ -194,7 +194,7 @@
       sizes: [""],
       label: "",
       content:
-        "<div class='text-xs'>Daisy grows happily under the warm sunlight</div><div class='text-sm'>Daisy grows happily under the warm sunlight</div><div class='text-md'>Daisy grows happily under the warm sunlight</div><div class='text-lg'>Daisy grows happily under the warm sunlight</div><div class='text-xl' font-semibold>Daisy grows happily under the warm sunlight</div><div class='text-2xl font-bold'>Daisy grows happily under the warm sunlight</div><div class='text-3xl font-black'>Daisy grows happily under the warm sunlight</div>",
+        "<div class='text-xs'>Daisy grows happily under the warm sunlight</div><div class='text-sm'>Daisy grows happily under the warm sunlight</div><div class='text-md'>Daisy grows happily under the warm sunlight</div><div class='text-lg'>Daisy grows happily under the warm sunlight</div><div class='text-xl font-semibold'>Daisy grows happily under the warm sunlight</div><div class='text-2xl font-bold'>Daisy grows happily under the warm sunlight</div><div class='text-3xl font-black'>Daisy grows happily under the warm sunlight</div>",
     },
   }
 </script>


### PR DESCRIPTION
Minor class misplacement issue 
```
<div class='text-xl' font-semibold>Daisy grows happily under the warm sunlight</div>
```
