### PR TITLE
docs : Fix - Add and handle Regex replacing logics and add regex for …

### DIFF
--- a/src/docs/src/lib/actions.svelte.js
+++ b/src/docs/src/lib/actions.svelte.js
@@ -62,7 +62,8 @@ export function htmlToJsx(node) {
   )
 
   function update() {
-    originalContent = originalContent.replace(
+    let JSXContent = originalContent
+    JSXContent = JSXContent.replace(
       re,
       (matched) => stringsToReplace[matched.toLowerCase()]
     )
@@ -70,10 +71,10 @@ export function htmlToJsx(node) {
     // Replace parts base of patterns and replacements in stringsToReplaceRegex
     Object.keys(stringsToReplaceRegex)
       .forEach(regexPattern =>
-        originalContent = originalContent.replace(new RegExp(regexPattern, "gi"), stringsToReplaceRegex[regexPattern])
+        JSXContent = JSXContent.replace(new RegExp(regexPattern, "gi"), stringsToReplaceRegex[regexPattern])
       )
     
-    node.innerHTML = originalContent
+    node.innerHTML = JSXContent
   }
 
   update()

--- a/src/docs/src/lib/actions.svelte.js
+++ b/src/docs/src/lib/actions.svelte.js
@@ -25,7 +25,6 @@ export function htmlToJsx(node) {
 
   const stringsToReplace = {
     onclick: "onClick",
-    '"0"': "{0}",
     "&lt;!--": "{/*",
     "--&gt;": "*/}",
     '<span class="token attr-name">class</span>': '<span class="token attr-name">className</span>',
@@ -48,6 +47,13 @@ export function htmlToJsx(node) {
     "stroke-opacity": "strokeOpacity",
     "stroke-width": "strokeWidth",
   }
+
+  // Couples of RegExp patterns and replacements
+  const stringsToReplaceRegex = {
+    // pattern(string) : replacement(string)
+    '"(\\d+)"' : '\{$1\}',
+  }
+  
   const re = new RegExp(
     Object.keys(stringsToReplace)
       .map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
@@ -56,10 +62,18 @@ export function htmlToJsx(node) {
   )
 
   function update() {
-    node.innerHTML = originalContent.replace(
+    originalContent = originalContent.replace(
       re,
       (matched) => stringsToReplace[matched.toLowerCase()]
     )
+
+    // Replace parts base of patterns and replacements in stringsToReplaceRegex
+    Object.keys(stringsToReplaceRegex)
+      .forEach(regexPattern =>
+        originalContent = originalContent.replace(new RegExp(regexPattern), stringsToReplaceRegex[regexPattern])
+      )
+    
+    node.innerHTML = originalContent
   }
 
   update()

--- a/src/docs/src/lib/actions.svelte.js
+++ b/src/docs/src/lib/actions.svelte.js
@@ -70,7 +70,7 @@ export function htmlToJsx(node) {
     // Replace parts base of patterns and replacements in stringsToReplaceRegex
     Object.keys(stringsToReplaceRegex)
       .forEach(regexPattern =>
-        originalContent = originalContent.replace(new RegExp(regexPattern), stringsToReplaceRegex[regexPattern])
+        originalContent = originalContent.replace(new RegExp(regexPattern, "gi"), stringsToReplaceRegex[regexPattern])
       )
     
     node.innerHTML = originalContent


### PR DESCRIPTION
…numbers

I added a an abilitity to jsx converter, for replacing with the Regex patterns. In another hand, you can use youre desired Regex patterns after now for converting desired text parts to the desired replacement.

e.g. I added an example for number convertion
```html
<progress class="progress w-56" value="10" max="100"></progress>
```
Will be such as below
```jsx
<Progress className="progress w-56" value={10} max={100}></Progress>
```