### PR TITLE
fix: #3430 - Remove @layer from the CDN build

### DIFF
--- a/packages/daisyui/build.js
+++ b/packages/daisyui/build.js
@@ -27,7 +27,7 @@ async function generateFiles() {
         states: ["hover"],
       }),
     !isDev && generateThemeFiles({ srcDir: "src/themes", distDir: "theme" }),
-    !isDev && generateRawStyles({ srcDir: "../src/base", distDir: "../base", layer: "base" }),
+    !isDev && generateRawStyles({ srcDir: "../src/base", distDir: "../base" }),
     !isDev &&
       generateRawStyles({
         srcDir: "../src/components",
@@ -44,7 +44,6 @@ async function generateFiles() {
           "swap",
           "validator",
         ],
-        layer: "utilities",
       }),
     !isDev &&
       generateRawStyles({
@@ -52,7 +51,6 @@ async function generateFiles() {
         distDir: "../utilities",
         responsive: true,
         exclude: ["typography", "glass", "join"],
-        layer: "utilities",
       }),
     generatePlugins({ type: "base", srcDir: "src/themes", distDir: "theme" }),
     generatePlugins({ type: "base", srcDir: "src/base", distDir: "base" }),

--- a/packages/daisyui/functions/generateRawStyles.js
+++ b/packages/daisyui/functions/generateRawStyles.js
@@ -23,11 +23,6 @@ export function escapeBreakpointColon(css, breakpoint) {
   return css.replace(new RegExp(`\\.${breakpoint}:`, "g"), `.${breakpoint}\\:`)
 }
 
-// wrap styles in layer
-export function wrapInLayer(styles, layer) {
-  return layer ? `@layer ${layer} {\n${styles}\n}` : styles
-}
-
 // generate media query
 export function generateMediaQuery(breakpoint, minWidth, styles) {
   return `\n@media (min-width: ${minWidth}) {\n${styles}\n}\n\n`
@@ -75,7 +70,6 @@ async function processFile(
   theme,
   responsive,
   exclude,
-  layer,
 ) {
   const styleContent = await fs.readFile(path.join(stylesDir, `${distDir}/${file}.css`), "utf-8")
   let stylesContent = await compileAndExtractStyles(styleContent, defaultTheme, theme)
@@ -85,10 +79,6 @@ async function processFile(
   }
 
   stylesContent = cleanCss(stylesContent)
-
-  if (layer) {
-    stylesContent = `@layer ${layer} {\n${stylesContent}\n}`
-  }
 
   await fs.writeFile(
     path.join(import.meta.dirname, distDir, `${distDir}/${file}.css`),
@@ -101,7 +91,6 @@ export async function generateRawStyles({
   distDir,
   responsive = false,
   exclude = [],
-  layer = null,
 }) {
   try {
     const { defaultTheme, theme } = await loadThemes()
@@ -111,7 +100,7 @@ export async function generateRawStyles({
 
     // Process all files concurrently
     const processPromises = files.map((file) =>
-      processFile(file, stylesDir, distDir, defaultTheme, theme, responsive, exclude, layer).catch(
+      processFile(file, stylesDir, distDir, defaultTheme, theme, responsive, exclude).catch(
         (fileError) => {
           throw new Error(`Error processing file ${file}: ${fileError.message}`)
         },

--- a/packages/daisyui/functions/packCss.js
+++ b/packages/daisyui/functions/packCss.js
@@ -8,13 +8,12 @@ const readFileContent = async (filePath) => {
 }
 const getThemeDirs = () => ["light", "dark"]
 const createThemePath = (theme) => path.join("./theme", `${theme}.css`)
-const wrapThemeContent = (contents) => `@layer base{\n${contents.join("\n")}\n}`
 const readThemeCSS = async () => {
   const themeDirs = getThemeDirs()
   const themeContents = await Promise.all(
     themeDirs.map((theme) => readFileContent(createThemePath(theme))),
   )
-  return wrapThemeContent(themeContents)
+  return themeContents.join("\n")
 }
 
 const directoryMap = {
@@ -24,22 +23,18 @@ const directoryMap = {
   "./colors": "utilities",
 }
 
-const wrapInLayer = (content, layerName) => {
-  return layerName ? `@layer ${layerName}{\n${content}\n}` : content
-}
-
 const filterExcludedFiles = (files, excludeFiles) => {
   return files.filter((file) => !excludeFiles.includes(`${file}.css`))
 }
 
-const readDirectoryContent = async (directory, layerName, excludeFiles = []) => {
+const readDirectoryContent = async (directory, excludeFiles = []) => {
   const files = await getFileNames(directory, ".css", false)
   const filteredFiles = filterExcludedFiles(files, excludeFiles)
 
   const contents = await Promise.all(
     filteredFiles.map(async (file) => {
       const content = await readFileContent(`${directory}/${file}.css`)
-      return wrapInLayer(content, layerName)
+      return content
     }),
   )
 
@@ -50,7 +45,7 @@ const readAllCSSDirectories = async (excludeFiles = []) => {
   const directories = Object.keys(directoryMap)
 
   const allContents = await Promise.all(
-    directories.map((dir) => readDirectoryContent(dir, directoryMap[dir], excludeFiles)),
+    directories.map((dir) => readDirectoryContent(dir, excludeFiles)),
   )
 
   return allContents.flat()


### PR DESCRIPTION
Fix: #3430 

## Problem Cause
https://developer.mozilla.org/en-US/docs/Web/CSS/@layer#description
> Styles that are not defined in a layer always override styles declared in named and anonymous layers.

### Issue
The styles generated by `https://cdn.tailwindcss.com` are not defined within a `@layer`, which gives them the highest priority. As a result, if all daisyUI styles are defined inside a `@layer`, Tailwind CSS's base styles will always take precedence.

![_Development__Rails_Template](https://github.com/user-attachments/assets/2856ad71-563c-4b22-968d-6e0ff589493b)

So, I propose removing `@layer` in the CDN build to prevent this issue.

### Causing commit
https://github.com/saadeghi/daisyui/commit/a25eae96172fa7243bad8640b7a0b73e19d03e66

## Issue Reproduction URL (Before Fix)
https://stackblitz.com/edit/daisyui-cdn-8edfkhem?file=index.html


