### PR TITLE
Use releases 4.0.0 version in Rails guide

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/rails/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/rails/+page.md
@@ -19,7 +19,7 @@ cd my-app
 Install [Tailwind CSS 4 gem](https://github.com/rails/tailwindcss-rails) for Rails
 
 ```sh:Terminal
-./bin/bundle add tailwindcss-rails --version "4.0.0.rc5"
+./bin/bundle add tailwindcss-rails --version "4.0.0"
 ./bin/rails tailwindcss:install
 ```
 


### PR DESCRIPTION
4.0.0 got released a few days ago: https://github.com/rails/tailwindcss-rails/releases/tag/v4.0.0