### PR TITLE
Corrected example code by removing incorrect colons

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/themes/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/themes/+page.md
@@ -171,11 +171,11 @@ All the other values will be inherited from the original theme.
 
 ```css:app.css
 [data-theme="light"] {
-  .my-btn: {
+  .my-btn {
     background-color: #1EA1F1;
     border-color: #1EA1F1;
   }
-  .my-btn:hover: {
+  .my-btn:hover {
     background-color: #1C96E1;
     border-color: #1C96E1;
   }


### PR DESCRIPTION
Removed unnecessary colons after class names in the example code, which were causing syntax errors.