### PR TITLE
docs: remove unnecessary classes

### DIFF
--- a/packages/docs/src/routes/(routes)/components/join/+page.md
+++ b/packages/docs/src/routes/(routes)/components/join/+page.md
@@ -73,10 +73,10 @@ classnames:
 <div class="join">
   <div>
     <div>
-      <input class="input input-bordered join-item w-[5.3rem] md:w-52" placeholder="Search"/>
+      <input class="input join-item w-[5.3rem] md:w-52" placeholder="Search"/>
     </div>
   </div>
-  <select class="select select-bordered join-item w-[5.8rem] md:w-auto">
+  <select class="select join-item w-[5.8rem] md:w-auto">
     <option disabled selected>Filter</option>
     <option>Sci-fi</option>
     <option>Drama</option>
@@ -92,10 +92,10 @@ classnames:
 <div class="$$join">
   <div>
     <div>
-      <input class="$$input $$input-bordered $$join-item" placeholder="Search" />
+      <input class="$$input $$join-item" placeholder="Search" />
     </div>
   </div>
-  <select class="$$select $$select-bordered $$join-item">
+  <select class="$$select $$join-item">
     <option disabled selected>Filter</option>
     <option>Sci-fi</option>
     <option>Drama</option>
@@ -111,13 +111,13 @@ classnames:
 
 ### ~Custom border radius
 <div class="join">
-  <input class="input input-bordered join-item w-36 lg:w-52" placeholder="Email"/>
+  <input class="input join-item w-36 lg:w-52" placeholder="Email"/>
   <button class="btn join-item rounded-r-full">Subscribe</button>
 </div>
 
 ```html
 <div class="$$join">
-  <input class="$$input $$input-bordered $$join-item" placeholder="Email" />
+  <input class="$$input $$join-item" placeholder="Email" />
   <button class="$$btn $$join-item rounded-r-full">Subscribe</button>
 </div>
 ```


### PR DESCRIPTION
Remove `input-bordered` and `select-bordered` classes  (not needed anymore).