### PR TITLE
Adjusted default dock component (dock-md) sizes for A11Y compliance (min 12px) and ensured linear scaling with size class.

### DIFF
--- a/packages/daisyui/src/components/dock.css
+++ b/packages/daisyui/src/components/dock.css
@@ -29,7 +29,7 @@
     }
 
     .dock-label {
-      font-size: 0.6875rem;
+      font-size: 0.75rem;
     }
   }
 }
@@ -61,7 +61,7 @@
   }
 
   .dock-label {
-    font-size: 0.625rem;
+    font-size: 0.6875rem;
   }
 }
 
@@ -69,7 +69,7 @@
   height: 4rem;
   height: calc(4rem + env(safe-area-inset-bottom));
   .dock-label {
-    font-size: 0.6875rem;
+    font-size: 0.75rem;
   }
 }
 
@@ -84,7 +84,7 @@
   }
 
   .dock-label {
-    font-size: 0.625rem;
+    font-size: 0.775rem;
   }
 }
 
@@ -99,6 +99,6 @@
   }
 
   .dock-label {
-    font-size: 0.75rem;
+    font-size: 0.8rem;
   }
 }


### PR DESCRIPTION
These changes comply with A11Y best practices for the default dock size, which is dock-md. 
The dock sizes now scale correctly, instead of md being bigger than lg. While respecting the minimum (xs) and maximum (xl) sizes set by the maintainer.
All of this while ensuring it still looks good to the eye on different devices.