### PR TITLE
V5: Fixed loading component default size

### DIFF
--- a/packages/daisyui/src/components/loading.css
+++ b/packages/daisyui/src/components/loading.css
@@ -1,5 +1,6 @@
 .loading {
-  @apply pointer-events-none inline-block aspect-square w-6 bg-current align-middle;
+  @apply pointer-events-none inline-block aspect-square bg-current align-middle;
+  width: calc(var(--size-selector, 0.25rem) * 6);
   mask-size: 100%;
   mask-repeat: no-repeat;
   mask-position: center;


### PR DESCRIPTION
For the default size, the width is defined using the Tailwind CSS `w-6` class. However, for other sizes, including `md`, the width is specified using a CSS variable.

**Changes:**

 - Removed `w-6` (fixed width class).
- Added width: calc(var(--size-selector, 0.25rem) * 6); for dynamic sizing.

**Reason for Change:**
- Enables customization of the width based on `--size-selector`, improving responsiveness and adaptability.

Let me know if you’d like any refinements!