### PR TITLE
fix(collapse): collapse arrow not rotated when using collapse-open

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -66,6 +66,14 @@
     }
   }
 
+  &.collapse-open {
+    &.collapse-arrow {
+      > .collapse-title:after {
+        transform: translateY(-50%) rotate(225deg);
+      }
+    }
+  }
+
   &.collapse-arrow:focus:not(.collapse-close) {
     > .collapse-title:after {
       transform: translateY(-50%) rotate(225deg);


### PR DESCRIPTION
In v4, using `collapse-open` would rotate a collapse arrow.

Currently with v5 beta, this is not the case and only the attribute `open` allows to rotate the arrow (+ input checkbox, focus and so on).

This PR proposes to align the behavior with daisyui v4.