### PR TITLE
v5 (Docs): Updated WordPress installation guide

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/wordpress/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/wordpress/+page.md
@@ -37,7 +37,7 @@ Then, click the `main.css` file on the explorer sidebar to open the file editor.
 Add daisyUI at the end of code in the `main.css` file
 
 ```postcss:main.css
-@plugin "daisyui@beta";
+@plugin "https://esm.run/daisyui@beta";
 ```
 
 Now you can use daisyUI class names!


### PR DESCRIPTION
Until this PR https://github.com/esm-dev/esm.sh/pull/1077 got deployed on the esm.sh, we are using the jsDelivr CDN.