### PR TITLE
Add "bun.lock" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 yarn.lock
 package-lock.json
 bun.lockb
+bun.lock
 dist
 
 .DS_Store


### PR DESCRIPTION
 Bun v1.2 changed the default lockfile format to the text-based `bun.lock`.
[Source](https://bun.sh/docs/install/lockfile)