### PR TITLE
fix(getFileNames): Fix the recursive call to add the extension

### DIFF
--- a/packages/daisyui/functions/getFileNames.js
+++ b/packages/daisyui/functions/getFileNames.js
@@ -9,7 +9,7 @@ export const getFileNames = async (dir, extension, recursive = true) => {
     const filePath = path.join(dir, file.name)
 
     if (file.isDirectory() && recursive) {
-      const subDirFiles = await getFileNames(filePath, recursive)
+      const subDirFiles = await getFileNames(filePath, extension, recursive)
       fileNames = fileNames.concat(subDirFiles)
     } else if (file.isFile() && file.name.endsWith(extension)) {
       // Extract the file name without extension


### PR DESCRIPTION
This fixes an issue where the recursive call to `getFileNames` mistakenly passed `recursive` instead of `extension`. 
Now, the function correctly uses the `extension` parameter in recursive calls.

This PR is targeted for the `v5` branch.