### PR TITLE
fix(button.css): update btn-outline styles to include checked state

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -166,7 +166,7 @@
 }
 
 .btn-outline {
-  &:not(.btn-active, :hover, :active:focus, :focus-visible, :disabled, [disabled], .btn-disabled) {
+  &:not(.btn-active, :hover, :active:focus, :focus-visible, :disabled, [disabled], .btn-disabled, :checked, [checked]) {
     --btn-shadow: "";
     --btn-bg: #0000;
     --btn-fg: var(--btn-color);


### PR DESCRIPTION
When a checkbox or radio is checked and styled as btn-outline with btn-[color], the text color does not display correctly.

Before
![image](https://github.com/user-attachments/assets/d6d64025-d764-47da-9d65-860e524d7dfd)

After
![image](https://github.com/user-attachments/assets/edfdcbf1-b6f8-419f-b59f-53c64769bfd3)
