### PR TITLE
Docs: Fix disabled button HTML differing from preview.

### DIFF
--- a/packages/docs/src/routes/(routes)/components/button/+page.md
+++ b/packages/docs/src/routes/(routes)/components/button/+page.md
@@ -243,7 +243,6 @@ classnames:
 
 
 ### ~Disabled buttons
-<button class="btn btn-outline" disabled="disabled">Disabled using attribute</button>
 <button class="btn" disabled="disabled">Disabled using attribute</button>
 <button class="btn btn-disabled" tabindex="-1" aria-disabled="true">Disabled using class name</button>
 


### PR DESCRIPTION
Removed the extra shown disabled button with btn-outline instead of adding it to the shown HTML, as btn-outline does not change how the disabled button looks.