### PR TITLE
v5 (Docs): Updated WordPress installation guide

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/wordpress/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/wordpress/+page.md
@@ -37,7 +37,7 @@ Then, click the `main.css` file on the explorer sidebar to open the file editor.
 Add daisyUI at the end of code in the `main.css` file
 
 ```postcss:main.css
-@plugin "https://esm.run/daisyui@5";
+@plugin "daisyui";
 ```
 
 Now you can use daisyUI class names!


### PR DESCRIPTION
Follow-up update of PR #3526

Now we can use the [esm.sh](https://esm.sh) as the default CDN provider