### PR TITLE
(feat): Add validator token to prevent success color

### DIFF
--- a/packages/daisyui/src/components/validator.css
+++ b/packages/daisyui/src/components/validator.css
@@ -1,12 +1,14 @@
 .validator {
-  &:user-valid,
-  &:has(:user-valid) {
-    &,
-    &:focus,
-    &:checked,
-    &[aria-checked="true"],
-    &:focus-within {
-      --input-color: var(--color-success);
+  &:not(.validator-invalid) {
+    &:user-valid,
+    &:has(:user-valid) {
+      &,
+      &:focus,
+      &:checked,
+      &[aria-checked="true"],
+      &:focus-within {
+        --input-color: var(--color-success);
+      }
     }
   }
   &:user-invalid,

--- a/packages/docs/src/routes/(routes)/components/validator/+page.md
+++ b/packages/docs/src/routes/(routes)/components/validator/+page.md
@@ -6,6 +6,9 @@ classnames:
   component:
   - class: validator
     desc: For input, select, textarea
+  style:
+  - class: validator-invalid
+    desc: Only shows error color
   part:
   - class: validator-hint
     desc: for the hint text that appears after the input if it's invalid
@@ -25,6 +28,17 @@ classnames:
 
 ```html
 <input class="$$input $$validator" type="email" required placeholder="mail@site.com" />
+```
+
+### ~Validator and validator-invalid
+#### writing an invalid email address only applies error color to the input.
+
+<form class="w-full max-w-xs">
+  <input class="input validator validator-invalid" type="email" required placeholder="mail@site.com" autocomplete="false" />
+</form>
+
+```html
+<input class="$$input $$validator $$validator-invalid" type="email" required placeholder="mail@site.com" />
 ```
 
 ### ~Validator and validator-hint

--- a/packages/docs/src/routes/(routes)/components/validator/+page.md
+++ b/packages/docs/src/routes/(routes)/components/validator/+page.md
@@ -31,7 +31,7 @@ classnames:
 ```
 
 ### ~Validator and validator-invalid
-#### writing an invalid email address only applies error color to the input.
+#### writing a valid email address does not apply success color to the input.
 
 <form class="w-full max-w-xs">
   <input class="input validator validator-invalid" type="email" required placeholder="mail@site.com" autocomplete="false" />


### PR DESCRIPTION
The purpose is to support a modifier token in the `validator` component that allows developers to opt-out the success color for valid inputs.

Behavior:
<img width="881" alt="image" src="https://github.com/user-attachments/assets/0b74464b-eb2b-43ea-b437-63f2eefa3f95" />


Solves: #3668 