### PR TITLE
fix: #3692 provide an unminified bundle for the standalone plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "cd packages/daisyui && bun run build",
     "build:dev": "cd packages/daisyui && bun run build --dev",
+    "build:standalone": "bun run rollup -c",
     "build:docs": "bun run build && cd packages/docs && bun run build",
     "build:docs:dev": "bun run build:dev && cd packages/docs && bun run build",
     "dev": "bun run build:dev && cd packages/docs && bun run dev",
@@ -36,6 +37,8 @@
     "prettier": "3.5.3",
     "prettier-plugin-svelte": "3.3.3",
     "prettier-plugin-tailwindcss": "0.6.11",
-    "tailwindcss": "^4.0.12"
+    "tailwindcss": "^4.0.12",
+    "@rollup/plugin-json": "^6.1.0",
+    "rollup": "^4.36.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,12 @@
+import json from "@rollup/plugin-json";
+
+export default {
+  input: "packages/daisyui/index.js",
+  output: {
+    file: "packages/daisyui/daisyui.js",
+    format: "cjs"
+  },
+  plugins: [
+    json()
+  ]
+}


### PR DESCRIPTION
This adds a new `build:standalone` which builds the plugin using rollup, which is the same tool used by jsDelivr.

The bundle is built to `packages/daisyui/daisyui.js` but has not been included in this PR to make the diff smaller.