### PR TITLE
docs: fix self-closing tag for input

### DIFF
--- a/packages/docs/src/routes/(routes)/components/theme-controller/+page.md
+++ b/packages/docs/src/routes/(routes)/components/theme-controller/+page.md
@@ -140,7 +140,7 @@ browserSupport:
 
 ### ~Theme Controller using a toggle with icons inside
 <label class="toggle text-base-content">
-  <input type="checkbox" value="synthwave" bind:checked={checkbox} class="theme-controller">
+  <input type="checkbox" value="synthwave" bind:checked={checkbox} class="theme-controller" />
 
   <svg aria-label="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2"></path><path d="M12 20v2"></path><path d="m4.93 4.93 1.41 1.41"></path><path d="m17.66 17.66 1.41 1.41"></path><path d="M2 12h2"></path><path d="M20 12h2"></path><path d="m6.34 17.66-1.41 1.41"></path><path d="m19.07 4.93-1.41 1.41"></path></g></svg>
 
@@ -150,7 +150,7 @@ browserSupport:
 
 ```html
 <label class="$$toggle text-base-content">
-  <input type="checkbox" value="synthwave" class="theme-controller">
+  <input type="checkbox" value="synthwave" class="theme-controller" />
 
   <svg aria-label="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2"></path><path d="M12 20v2"></path><path d="m4.93 4.93 1.41 1.41"></path><path d="m17.66 17.66 1.41 1.41"></path><path d="M2 12h2"></path><path d="M20 12h2"></path><path d="m6.34 17.66-1.41 1.41"></path><path d="m19.07 4.93-1.41 1.41"></path></g></svg>
 


### PR DESCRIPTION
Fix element 'input' has no corresponding closing tag at section [Theme Controller using a toggle with icons inside](https://daisyui.com/components/theme-controller/#theme-controller-using-a-toggle-with-icons-inside).
![problem-jsx](https://github.com/user-attachments/assets/f2672280-cf8f-4073-a88a-6412455535a9)
![problem-html](https://github.com/user-attachments/assets/ccc4dd9a-b2eb-49e2-be14-d398d06e1cd7)
