### PR TITLE
fix: #3708 input type date inside input class on chromium-based

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -28,6 +28,10 @@
     }
   }
 
+  :where(input[type="date"])  {
+    @apply inline-block;
+  }
+
   &:focus,
   &:focus-within {
     --input-color: var(--color-base-content);


### PR DESCRIPTION
I noticed that this component was using the inline-block utility but had been changed to inline-flex to address an issue in Safari.
I decided to keep inline-flex as the default and revert only the date input back to inline-block.

Let me know if you need any adjustments!