### PR TITLE
fix(docs/seo): Remove VITE_ROOT prefix from SEO image paths

### DIFF
--- a/packages/docs/src/components/SEO.svelte
+++ b/packages/docs/src/components/SEO.svelte
@@ -1,8 +1,6 @@
 <script>
   import { t } from "$lib/i18n.svelte.js"
 
-  import { readEnv } from "$lib/util"
-
   let siteData = {
     title: "Tailwind CSS Components ( version 5 update is here )",
     desc: "Free Tailwind Components",
@@ -25,9 +23,9 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content={formattedTitle} />
   <meta name="twitter:description" content={desc} />
-  <meta name="twitter:image" content={readEnv("VITE_ROOT") + img} />
+  <meta name="twitter:image" content={img} />
   <meta name="twitter:image:alt" content={formattedTitle} />
   <meta property="og:title" content={formattedTitle} />
   <meta property="og:description" content={desc} />
-  <meta property="og:image" content={readEnv("VITE_ROOT") + img} />
+  <meta property="og:image" content={img} />
 </svelte:head>


### PR DESCRIPTION
Fixed the image URL generation logic for `og:image` and `twitter:image` tags in the documentation site's SEO component.

Removed the call to `readEnv("VITE_ROOT")` because the value of `$props().img` is always passed as an absolute path URL.
