### PR TITLE
fix: collapse-content transition duplicate, transition typo

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -135,11 +135,11 @@
   grid-column-start: 1;
   grid-row-start: 2;
   min-height: 0;
-  transition: visibility 0.2s;
   padding-left: 1rem;
   padding-right: 1rem;
   cursor: unset;
   transition:
+    visibility 0.2s,
     padding 0.2s ease-out,
     background-color 0.2s ease-out;
 }
@@ -215,6 +215,6 @@
     padding-bottom: 1rem;
     transition:
       padding 0.2s ease-out,
-      background-color 0.2sease-out;
+      background-color 0.2s ease-out;
   }
 }


### PR DESCRIPTION
After the update to latest version, still one of the line has a typo that I changed with this PR + an additional duplicate key