### PR TITLE
Add `aria-invalid` to the validator error selectors

### DIFF
--- a/packages/daisyui/src/components/validator.css
+++ b/packages/daisyui/src/components/validator.css
@@ -10,7 +10,8 @@
     }
   }
   &:user-invalid,
-  &:has(:user-invalid) {
+  &:has(:user-invalid),
+  &[aria-invalid] {
     &,
     &:focus,
     &:checked,


### PR DESCRIPTION
This change would allow users to set their own validator states not based on native HTML validation (which can be limited), while not adding any additional classes.
It also encourages using the existing `aria-invalid` property, increasing accessibility.