### PR TITLE
fix: button hover state persisting on mobile screen. closes: #3817

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -187,6 +187,24 @@
     --btn-border: var(--btn-color);
     --btn-noise: none;
   }
+  
+  @media (hover: none) {
+    &:hover:not(
+        .btn-active,
+        :active,
+        :focus-visible,
+        :disabled,
+        [disabled],
+        .btn-disabled,
+        :checked
+      ) {
+      --btn-shadow: "";
+      --btn-bg: #0000;
+      --btn-fg: var(--btn-color);
+      --btn-border: var(--btn-color);
+      --btn-noise: none;
+    }
+  }
 }
 
 .btn-dash {
@@ -207,6 +225,25 @@
     --btn-border: var(--btn-color);
     --btn-noise: none;
   }
+  
+  @media (hover: none) {
+    &:hover:not(
+        .btn-active,
+        :active,
+        :focus-visible,
+        :disabled,
+        [disabled],
+        .btn-disabled,
+        :checked
+      ) {
+      --btn-shadow: "";
+      border-style: dashed;
+      --btn-bg: #0000;
+      --btn-fg: var(--btn-color);
+      --btn-border: var(--btn-color);
+      --btn-noise: none;
+    }
+  }
 }
 
 .btn-soft {
@@ -224,6 +261,31 @@
       var(--color-base-100)
     );
     --btn-noise: none;
+  }
+  
+  @media (hover: none) {
+    &:hover:not(
+        .btn-active,
+        :active,
+        :focus-visible,
+        :disabled,
+        [disabled],
+        .btn-disabled
+      ) {
+      --btn-shadow: "";
+      --btn-fg: var(--btn-color, var(--color-base-content));
+      --btn-bg: color-mix(
+        in oklab,
+        var(--btn-color, var(--color-base-content)) 8%,
+        var(--color-base-100)
+      );
+      --btn-border: color-mix(
+        in oklab,
+        var(--btn-color, var(--color-base-content)) 10%,
+        var(--color-base-100)
+      );
+      --btn-noise: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
Fixes #3817 

On mobile devices (iOS Safari and others), when you tap soft, outline, or dash buttons, they get stuck in hover state. The button stays colored until you tap somewhere else on the screen.

## Fix
I added CSS that targets touch devices (using `hover: none` media query) to fix the three button types:
- soft buttons
- outline buttons
- dash buttons

Now the buttons go back to normal right after you tap them.

## Testing
I tested this on iPhone with Safari and with Chrome's mobile screen mode.