### PR TITLE
fix: tooltip showing when data-tip or tooltip-content is empty. closes: #3819

### DIFF
--- a/packages/daisyui/src/components/tooltip.css
+++ b/packages/daisyui/src/components/tooltip.css
@@ -74,8 +74,8 @@
 
 .tooltip {
   &.tooltip-open,
-  &[data-tip]:hover,
-  &:hover,
+  &[data-tip]:not([data-tip=""]):hover,
+  &:not(:has(.tooltip-content:empty)):has(.tooltip-content):hover,
   &:has(:focus-visible) {
     > .tooltip-content,
     &[data-tip]:before,


### PR DESCRIPTION
## Problem
Fixes #3819

When a tooltip has an empty data-tip attribute or empty tooltip-content, it still shows a small artifact on hover. This looks like a UI bug.

## Fix
I added CSS rules to hide the tooltip when:
- data-tip attribute is missing
- data-tip attribute is empty
- tooltip-content is empty
- tooltip-content only has empty children

Now empty tooltips don't show up at all, which is what users would expect.

## Testing
I tested this with examples from the issue:
- Tooltip with empty data-tip=""
- Tooltip with empty tooltip-content

Before: Empty tooltips showed a strange artifact
After: Empty tooltips stay completely hidden