### PR TITLE
fix: tooltip overlay by input:focused. closes: #3836

### DIFF
--- a/packages/daisyui/src/components/tooltip.css
+++ b/packages/daisyui/src/components/tooltip.css
@@ -15,7 +15,7 @@
     background-color: var(--tt-bg);
     width: max-content;
     pointer-events: none;
-    z-index: 1;
+    z-index: 2;
     --tw-content: attr(data-tip);
     content: var(--tw-content);
   }


### PR DESCRIPTION
## Problem

Fixes #3836

When an input is focused, tooltips are hidden behind the input element instead of showing properly above it. This affects tooltips that should be visible on hover over information icons.

## Fix

Increased z-index of tooltip from 1 to 2 to ensure tooltips appear above focused inputs, maintaining proper positioning.

## Testing

Tested using the playground Component.astro in Chrome and Safari.