### PR TITLE
docs: mention workspace attachment in grok doc

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/editor/grok/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/editor/grok/+page.md
@@ -13,6 +13,8 @@ desc: Setup Grok to correctly generate daisyUI code based on your prompt.
 
 [daisyui.com/llms.txt](https://daisyui.com/llms.txt) file is a compact, text version of daisyUI docs to help AI generate accurate daisyUI code based on your prompt.
 
+#### Through Deep Search
+
 In Chat window, enable `꩜ Deep Search` feature, and add this before your prompt:
 
 ```md:prompt
@@ -24,3 +26,11 @@ For example:
 ```md:prompt
 https://daisyui.com/llms.txt give me a light daisyUI 5 theme with tropical color palette
 ```
+
+#### Through Workspace (SuperGrok Only)
+
+This method gives much faster result as you don't need the `꩜ Deep Search` feature.
+
+You can create a dedicated `Workspace` where you can upload the `llms.txt` file. To download the file, visit [https://daisyui.com/llms.txt](https://daisyui.com/llms.txt), right-click, and select "Save As...". Once downloaded, upload the file as an attachment in the Grok Workspace.
+
+From then on, every conversation in this Workspace will have access to the daisyUI documentation.


### PR DESCRIPTION
Hello,

This PR mention the possibility to use the doc for LLM through grok workspace instead of deepsearch. This is what I do and it works well. This make the process easier as there's no need to copy a link everytime, and much faster as deepsearch is not needed, for very similar result.

As this is a minor PR, I did not create an issue. I can totally do it if you prefer. 

Also I had trouble building the website. Here's the error I encountered with bun
```
$ : bun run build
$ NODE_ENV=production vite build --logLevel error
✗ Build failed in 3.96s
error during build:
[vite]: Rollup failed to resolve import "daisyui/theme/object" from "/home/noah/Documents/daisyui/packages/docs/src/routes/(routes)/theme-generator/+page.server.js".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at viteLog (/home/noah/Documents/daisyui/node_modules/vite/dist/node/chunks/dep-DrOo5SEf.js:51615:19)
    at onRollupLog (/home/noah/Documents/daisyui/node_modules/vite/dist/node/chunks/dep-DrOo5SEf.js:51665:5)
    at onLog (/home/noah/Documents/daisyui/node_modules/vite/dist/node/chunks/dep-DrOo5SEf.js:51313:7)
    at logger (/home/noah/Documents/daisyui/node_modules/rollup/dist/es/shared/node-entry.js:22588:9)
    at handleInvalidResolvedId (/home/noah/Documents/daisyui/node_modules/rollup/dist/es/shared/node-entry.js:21335:26)
    at <anonymous> (/home/noah/Documents/daisyui/node_modules/rollup/dist/es/shared/node-entry.js:21293:26)
    at processTicksAndRejections (native:7:39)
error: script "build" exited with code 1
```

The change being minimal I prefered to create the PR directly without spending time an issue that's mostly a problem on my side. If it is not and someone can reproduce the error, I would be glad to open an issue for that.