### PR TITLE
fix: scope [data-theme] selectors to root option. closes: #3854

### DIFF
--- a/packages/daisyui/functions/pluginOptionsHandler.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.js
@@ -22,7 +22,7 @@ export const pluginOptionsHandler = (() => {
     const applyTheme = (themeName, flags) => {
       const theme = themesObject[themeName]
       if (theme) {
-        let selector = `${root}:has(input.theme-controller[value=${themeName}]:checked),[data-theme=${themeName}]`
+        let selector = `${root}:has(input.theme-controller[value=${themeName}]:checked),${root !== ":root" ? `${root} ` : ""}[data-theme=${themeName}]`
         if (flags.includes("--default")) {
           selector = `:where(${root}),${selector}`
         }

--- a/packages/daisyui/functions/themePlugin.js
+++ b/packages/daisyui/functions/themePlugin.js
@@ -12,7 +12,7 @@ export default plugin.withOptions((options = {}) => {
       ...customThemeTokens
     } = options
 
-    let selector = `${root}:has(input.theme-controller[value=${name}]:checked),[data-theme="${name}"]`
+    let selector = `${root}:has(input.theme-controller[value=${name}]:checked),${root !== ":root" ? `${root} ` : ""}[data-theme="${name}"]`
     if (isDefault) {
       selector = `:where(${root}),${selector}`
     }


### PR DESCRIPTION
## Problem
Fixes #3854

When using a custom root option, elements with data-theme attributes outside the root still receive theme styles. This causes unexpected styling when embedding daisyUI themes in different parts of an application.

## Fix
Changed the selector construction to properly scope data-theme selectors to the specified root element, preventing theme styles from leaking outside the root.

## Testing
Tested with the reproduction case from issue #3854 in multiple browsers.