### PR TITLE
fix: indicator direction not reflecting on RTL. closes: #3851

### DIFF
--- a/packages/daisyui/src/components/indicator.css
+++ b/packages/daisyui/src/components/indicator.css
@@ -16,6 +16,11 @@
   --inidicator-s: 0;
   --inidicator-e: auto;
   --inidicator-x: -50%;
+  [dir="rtl"] & {
+    --inidicator-s: auto;
+    --inidicator-e: 0;
+    --inidicator-x: 50%;
+  }
 }
 
 .indicator-center {
@@ -31,6 +36,11 @@
   --inidicator-s: auto;
   --inidicator-e: 0;
   --inidicator-x: 50%;
+  [dir="rtl"] & {
+    --inidicator-s: 0;
+    --inidicator-e: auto;
+    --inidicator-x: -50%;
+  }
 }
 
 .indicator-bottom {


### PR DESCRIPTION
## Problem
Fixes #3851

RTL is ignored when using `indicator-start`, it always positions the indicator on the left regardless of text direction.

## Fix
Added RTL-specific CSS rules to properly flip indicator positioning when `dir="rtl"` is present. This ensures indicators respect the text direction.

## Testing
Tested with the all indicator placements.