### PR TITLE
fix: disabled button border inconsistency in join component. closes: #3877

### DIFF
--- a/packages/daisyui/src/utilities/join.css
+++ b/packages/daisyui/src/utilities/join.css
@@ -68,7 +68,7 @@
 }
 
 .join-item {
-  &:where(*:not(:first-child, :disabled, [disabled], .btn-disabled)) {
+  &:where(*:not(:first-child)) {
     margin-inline-start: calc(var(--border, 1px) * -1);
     margin-block-start: 0;
   }

--- a/packages/daisyui/src/utilities/join.css
+++ b/packages/daisyui/src/utilities/join.css
@@ -68,9 +68,13 @@
 }
 
 .join-item {
-  &:where(*:not(:first-child)) {
+  &:where(*:not(:first-child, :disabled, [disabled], .btn-disabled)) {
     margin-inline-start: calc(var(--border, 1px) * -1);
     margin-block-start: 0;
+  }
+
+  &:where(*:is(:disabled, [disabled], .btn-disabled)) {
+    border-width: var(--border, 1px) 0 var(--border, 1px) var(--border, 1px);
   }
 }
 


### PR DESCRIPTION
## Problem
Fixes #3877

Disabled buttons in join components don't maintain consistent border styling because they're excluded from receiving the negative margins applied to regular buttons.

## Fix
Removed the disabled button exclusions (`:disabled`, `[disabled]`, `.btn-disabled`) from the CSS selector in join.css so all buttons receive the same negative margin treatment.

## Testing
Tested with various join component configurations including both enabled and disabled buttons.