### PR TITLE
fix: URL and email inputs maintain LTR direction in RTL context. closes: #3886

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -28,6 +28,11 @@
     }
   }
 
+  :where(input[type="url"]),
+  :where(input[type="email"]) {
+    direction: ltr;
+  }
+
   :where(input[type="date"]) {
     @apply inline-block;
   }


### PR DESCRIPTION
## Problem
Fixes #3886

URL and email inputs with icons don't maintain their LTR direction when used in RTL contexts. Since URLs and email addresses are universally written with Latin characters, they should always be displayed left-to-right, regardless of the page's text direction.

## Fix
Added a CSS rule that explicitly sets `direction: ltr;` for URL and email input types.

## Testing
Tested with URL and email inputs with icons on the daisyUI demo site with Arabic language (RTL) enabled, confirming correct left-to-right text direction and proper icon placement.