### PR TITLE
fix: button link and ghost hover states persisting on mobile devices. closes: #3888

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -154,6 +154,16 @@
       --btn-fg: currentColor;
     }
   }
+
+  @media (hover: none) {
+    &:hover:not(.btn-active, :active, :focus-visible, :disabled, [disabled], .btn-disabled) {
+      --btn-shadow: "";
+      --btn-bg: #0000;
+      --btn-border: #0000;
+      --btn-noise: none;
+      --btn-fg: currentColor;
+    }
+  }
 }
 
 .btn-link {
@@ -168,6 +178,12 @@
     @apply underline;
     --btn-border: #0000;
     --btn-bg: #0000;
+  }
+
+  @media (hover: none) {
+    &:hover:not(.btn-active, :active, :focus-visible, :disabled, [disabled], .btn-disabled) {
+      @apply no-underline;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
Fixes #3888

Link and ghost buttons remain "stuck" in hover state after being touched on mobile devices until users tap elsewhere. Similar to issue #3817 that was fixed for other button types in PR #3820.

## Fix
Added proper @media (hover: none) queries for both button types to reset hover styles on touch devices:
- For link buttons: Applied no-underline on hover
- For ghost buttons: Reset background, border and shadow properties

## Testing
Verified on iOS Safari and Chrome mobile that buttons no longer maintain hover states after being tapped.