### PR TITLE
fix(collapse): min-height 1lh if supported

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -120,12 +120,8 @@
     width: 100%;
     padding: 1rem;
     padding-inline-end: 3rem;
-    min-height: 3.75rem;
+    min-height: 1lh;
     transition: background-color 0.2s ease-out;
-
-    @supports (min-height: 1lh) {
-      min-height: 1lh;
-    }
   }
 }
 
@@ -209,12 +205,8 @@
   width: 100%;
   padding: 1rem;
   padding-inline-end: 3rem;
-  min-height: 3.75rem;
+  min-height: 1lh;
   transition: background-color 0.2s ease-out;
-
-  @supports (min-height: 1lh) {
-    min-height: 1lh;
-  }
 }
 .collapse-open {
   grid-template-rows: max-content 1fr;

--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -122,6 +122,10 @@
     padding-inline-end: 3rem;
     min-height: 3.75rem;
     transition: background-color 0.2s ease-out;
+
+    @supports (min-height: 1lh) {
+      min-height: 1lh;
+    }
   }
 }
 
@@ -207,6 +211,10 @@
   padding-inline-end: 3rem;
   min-height: 3.75rem;
   transition: background-color 0.2s ease-out;
+
+  @supports (min-height: 1lh) {
+    min-height: 1lh;
+  }
 }
 .collapse-open {
   grid-template-rows: max-content 1fr;


### PR DESCRIPTION
Fixes #3885 

I believe the `3.75rem` min-height was set for safety reasons. However, this makes it impractical to use smaller font sizes, such as the default `text-xs`, and requires strong overrides.

The `1lh` value is supported by all browsers targeted as the minimum by TailwindCSS v4. Since DaisyUI also relies on TailwindCSS v4, I believe using `1lh` is justified. Moreover, if it's not supported, the fallback value of `3.75rem` still works well.