### PR TITLE
fix: correct spelling typos in indicator CSS variables. closes: #3905

### DIFF
--- a/packages/daisyui/src/components/indicator.css
+++ b/packages/daisyui/src/components/indicator.css
@@ -5,58 +5,58 @@
   :where(.indicator-item) {
     z-index: 1;
     @apply absolute whitespace-nowrap;
-    top: var(--inidicator-t, 0);
-    bottom: var(--inidicator-b, auto);
-    left: var(--inidicator-s, auto);
-    right: var(--inidicator-e, 0);
-    translate: var(--inidicator-x, 50%) var(--indicator-y, -50%);
+    top: var(--indicator-t, 0);
+    bottom: var(--indicator-b, auto);
+    left: var(--indicator-s, auto);
+    right: var(--indicator-e, 0);
+    translate: var(--indicator-x, 50%) var(--indicator-y, -50%);
   }
 }
 .indicator-start {
-  --inidicator-s: 0;
-  --inidicator-e: auto;
-  --inidicator-x: -50%;
+  --indicator-s: 0;
+  --indicator-e: auto;
+  --indicator-x: -50%;
   [dir="rtl"] & {
-    --inidicator-s: auto;
-    --inidicator-e: 0;
-    --inidicator-x: 50%;
+    --indicator-s: auto;
+    --indicator-e: 0;
+    --indicator-x: 50%;
   }
 }
 
 .indicator-center {
-  --inidicator-s: 50%;
-  --inidicator-e: 50%;
-  --inidicator-x: -50%;
+  --indicator-s: 50%;
+  --indicator-e: 50%;
+  --indicator-x: -50%;
   [dir="rtl"] & {
-    --inidicator-x: 50%;
+    --indicator-x: 50%;
   }
 }
 
 .indicator-end {
-  --inidicator-s: auto;
-  --inidicator-e: 0;
-  --inidicator-x: 50%;
+  --indicator-s: auto;
+  --indicator-e: 0;
+  --indicator-x: 50%;
   [dir="rtl"] & {
-    --inidicator-s: 0;
-    --inidicator-e: auto;
-    --inidicator-x: -50%;
+    --indicator-s: 0;
+    --indicator-e: auto;
+    --indicator-x: -50%;
   }
 }
 
 .indicator-bottom {
-  --inidicator-t: auto;
-  --inidicator-b: 0;
+  --indicator-t: auto;
+  --indicator-b: 0;
   --indicator-y: 50%;
 }
 
 .indicator-middle {
-  --inidicator-t: 50%;
-  --inidicator-b: 50%;
+  --indicator-t: 50%;
+  --indicator-b: 50%;
   --indicator-y: -50%;
 }
 
 .indicator-top {
-  --inidicator-t: 0;
-  --inidicator-b: auto;
+  --indicator-t: 0;
+  --indicator-b: auto;
   --indicator-y: -50%;
 }


### PR DESCRIPTION
## Problem

Fixes #3905

The indicator component has consistent spelling typos in CSS variable names throughout the file - "inidicator" instead of "indicator". While this doesn't break functionality since the spelling is consistent, it affects code quality and readability.

## Fix

Corrected all CSS variable names from "inidicator" to "indicator":
- `--inidicator-t` → `--indicator-t`
- `--inidicator-b` → `--indicator-b` 
- `--inidicator-s` → `--indicator-s`
- `--inidicator-e` → `--indicator-e`
- `--inidicator-x` → `--indicator-x`

Updated all references across indicator positioning classes (start, center, end, top, middle, bottom).

## Testing

Tested indicator component positioning in Chrome and Safari. All positioning variants work correctly with the corrected variable names.