### PR TITLE
fix: correct Error constructor syntax in copyFile function. closes: #3907

### DIFF
--- a/packages/daisyui/functions/copyFile.js
+++ b/packages/daisyui/functions/copyFile.js
@@ -13,6 +13,6 @@ export const copyFile = async (from, to, newName = null) => {
 
     await fs.copyFile(from, destPath)
   } catch (error) {
-    throw new Error(`Error copying file from ${from} to ${to}:`, error)
+    throw new Error(`Error copying file from ${from} to ${to}: ${error.message}`)  
   }
 }


### PR DESCRIPTION
## Problem

Fixes #3907

Error constructor syntax in copyFile function loses original error details, making debugging build failures hard.

## Fix

Corrected Error constructor to properly include original error message:
```javascript
throw new Error(`Error copying file from ${from} to ${to}: ${error.message}`)
```

## Testing

Tested with non-existent source files. Error messages now include complete diagnostic information instead of truncated messages ending with colons.