### PR TITLE
fix: correct CSS syntax error in variables.css. closes: #3909

### DIFF
--- a/packages/daisyui/functions/variables.css
+++ b/packages/daisyui/functions/variables.css
@@ -22,8 +22,8 @@
   --radius-selector: ;
   --radius-field: ;
   --radius-box: ;
-  --size-selector: ,
-  --size-field: ,
+  --size-selector: ;
+  --size-field: ;
   --border: ;
   --depth: ;
   --noise: ;


### PR DESCRIPTION
## Problem

Fixes #3909

CSS syntax error in variables.css uses commas instead of semicolons.

## Fix

Corrected CSS property syntax in `packages/daisyui/functions/variables.css`:

- `--size-selector: ,` → `--size-selector: ;`
- `--size-field: ,` → `--size-field: ;`

## Testing

No tests required