### PR TITLE
fix: increase drawer z-index to prevent overlap issues. closes: #3929

### DIFF
--- a/packages/daisyui/src/components/drawer.css
+++ b/packages/daisyui/src/components/drawer.css
@@ -9,7 +9,7 @@
 }
 
 .drawer-side {
-  @apply pointer-events-none invisible fixed start-0 top-0 z-1 col-start-1 row-start-1 grid w-full grid-cols-1 grid-rows-1 items-start justify-items-start overflow-x-hidden overflow-y-hidden overscroll-contain opacity-0;
+  @apply pointer-events-none invisible fixed start-0 top-0 z-10 col-start-1 row-start-1 grid w-full grid-cols-1 grid-rows-1 items-start justify-items-start overflow-x-hidden overflow-y-hidden overscroll-contain opacity-0;
   transition:
     opacity 0.2s ease-out 0.1s allow-discrete,
     visibility 0.3s ease-out 0.1s allow-discrete;


### PR DESCRIPTION
## Problem
Fixes #3929

Drawer component appears behind floating-label and possibly other component with z-index more than 1 this is causing overlay and visibility issues in certain layouts

## Fix
Increased drawer z-index from `z-1` to `z-10` for proper layering and prevent the drawer from being hidden behind other page elements like what happened with floating-label.

## Testing
Verified that drawer now properly appears above floating-label