### PR TITLE
Color SVG fills the base content color by default

### DIFF
--- a/packages/daisyui/src/base/rootcolor.css
+++ b/packages/daisyui/src/base/rootcolor.css
@@ -2,4 +2,5 @@
 [data-theme] {
   background-color: var(--root-bg, var(--color-base-100));
   color: var(--color-base-content);
+  fill: var(--color-base-content);
 }


### PR DESCRIPTION
DaisyUI sets "color" to --color-base-content on all elements. In addition to all text, this colors SVGs, but only the stroke part, not the fill. The SVG fill in icons, like an icon from rails_icons (https://github.com/Rails-Designer/rails_icons) isn't colored.

This can be surprising when injecting icons anywhere in buttons or input forms, for example. I was working on a password form, and a path-only icon was colored correctly, but a fill-only icon wasn't, and I needed to set the color myself.

It might actually be a good idea to set "fill" whenever "color" gets set, too... but I figured I'd bring up the idea here.