### PR TITLE
Refactor: Use transparent keyword for background-color in glass.css

### DIFF
--- a/packages/daisyui/src/utilities/glass.css
+++ b/packages/daisyui/src/utilities/glass.css
@@ -1,7 +1,7 @@
 .glass {
   border: none;
   backdrop-filter: blur(var(--glass-blur, 40px));
-  background-color: #0000;
+  background-color: transparent;
   background-image:
     linear-gradient(
       135deg,


### PR DESCRIPTION
This PR refactors the background-color property in glass.css to use the transparent keyword instead of #0000. While #0000 is functionally equivalent, transparent is more explicit, readable, and idiomatic in CSS. This change improves code clarity and maintainability without altering the visual output.