### PR TITLE
fix: apply theme-aware hover styling to Cally day buttons. closes: #3991

### DIFF
--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -29,6 +29,9 @@
     border-radius: var(--radius-field);
     font-size: 0.7rem;
   }
+  ::part(day):hover {
+  background: var(--color-base-200);
+  }
   ::part(button day today) {
     background: var(--color-primary);
     color: var(--color-primary-content);


### PR DESCRIPTION
## Problem
Fixes #3991

Cally calendar day buttons were using the component's default hover background (`rgba(0, 0, 0, 0.05)`) instead of the theme-aware daisyUI color. This created visual inconsistency where navigation buttons (prev/next) correctly used `var(--color-base-200)` on hover, but day buttons did not match the theme colors.

## Fix
Added missing `::part(day):hover` CSS selector with `background: var(--color-base-200)` to ensure day buttons use the same theme-aware hover styling as navigation buttons.

## Testing
Verified that day buttons now properly match the theme hover color across different daisyUI themes in the playground.