### PR TITLE
fix: react-day-picker disableNavigation not styling properly. closes: #3990

### DIFF
--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -139,9 +139,16 @@
     padding: 0;
     display: inline-flex;
     position: relative;
-    &:disabled {
+
+    &:disabled,
+    &[aria-disabled="true"] {
       cursor: revert;
       opacity: 0.5;
+    }
+
+    &:disabled:hover,
+    &[aria-disabled="true"]:hover {
+      background-color: transparent;
     }
   }
   .rdp-chevron {


### PR DESCRIPTION
## Problem
Fixes #3990

When using `react-day-picker` with the `disableNavigation` prop, the navigation buttons (previous/next) are not properly styled as disabled. They remain clickable-looking instead of being greyed out.

This happens because `react-day-picker` uses `aria-disabled="true"` instead of the actual `disabled` attribute, but daisyUI's CSS only targets `:disabled`.

## Fix
Added CSS selectors to handle both `:disabled` and `[aria-disabled="true"]` states for navigation buttons:

- Added `&[aria-disabled="true"]` selector alongside existing `&:disabled`
- Disabled hover effects for disabled navigation buttons

## Testing
Created test page in playground comparing normal vs disabled navigation