### PR TITLE
fix: use semantic fallbacks for checkbox states, improve indeterminate visibility. closes: #3979

### DIFF
--- a/packages/daisyui/src/components/checkbox.css
+++ b/packages/daisyui/src/components/checkbox.css
@@ -37,7 +37,7 @@
 
   &:checked,
   &[aria-checked="true"] {
-    background-color: var(--input-color, #0000);
+    background-color: var(--input-color, color-mix(in oklab, var(--color-base-content) 20%, #0000));
     box-shadow:
       0 0 #0000 inset,
       0 8px 0 -4px oklch(100% 0 0 / calc(var(--depth) * 0.1)) inset,
@@ -62,6 +62,7 @@
   }
 
   &:indeterminate {
+    background-color: var(--input-color, color-mix(in oklab, var(--color-base-content) 20%, #0000));
     &:before {
       @apply rotate-0 opacity-100;
       translate: 0 -35%;


### PR DESCRIPTION
## Problem
Fixes #3979

Indeterminate checkboxes with color variants (checkbox-primary, checkbox-secondary, etc.) have nearly invisible dash marks due to poor contrast. The issue occurs when color content is similar to the background, making the dash blend invisibly.

Additionally, the codebase has an inconsistency where borders use semantic fallbacks (`color-mix(in oklab, var(--color-base-content) 20%, #0000)`) but the checked state uses a hardcoded `#0000` fallback.

## Fix
Applied a solution using semantic fallbacks consistent with daisyUI's established patterns:

**1. Updated checked state background-color:**
```css
// Before
background-color: var(--input-color, #0000);

// After  
background-color: var(--input-color, color-mix(in oklab, var(--color-base-content) 20%, #0000));
```

**2. Added indeterminate state background-color:**
```css
&:indeterminate {
  background-color: var(--input-color, color-mix(in oklab, var(--color-base-content) 20%, #0000));
  &:before { ...
```

## Testing
Verified all color variants (primary, secondary, accent, neutral, info, success, warning, error) in playground