### PR TITLE
fix: date input alignment in labels on iOS Safari. closes: #3952

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -35,7 +35,7 @@
   }
 
   :where(input[type="date"]) {
-    @apply inline-block;
+    @apply inline-flex;
   }
 
   &:focus,
@@ -71,6 +71,22 @@
   &::-webkit-calendar-picker-indicator {
     position: absolute;
     inset-inline-end: 0.75em;
+  }
+  
+  &:has(> input[type="date"]) {
+    :where(input[type="date"]) {
+      @apply inline-flex;
+      -webkit-appearance: none;
+      appearance: none;
+    }
+    
+    input[type="date"]::-webkit-calendar-picker-indicator {
+      position: absolute;
+      inset-inline-end: 0.75em;
+      width: 1em;
+      height: 1em;
+      cursor: pointer;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
Fixes #3952

Date input fields with labels are misaligned on iOS Safari, causing a visual layout issue. The problem occurs when using `input[type="date"]` inside label containers where the date input appears vertically misaligned compared to the label text. 

btw this affects both regular labels and floating labels.

## Fix
Changed the CSS for `input[type="date"]` from `@apply inline-block` to `@apply inline-flex` to maintain consistent flexbox alignment within label containers. Also added specific iOS Safari fixes:

1. **Main fix**: Updated `:where(input[type="date"])` to use `inline-flex` instead of `inline-block`
2. **Safari-specific fix**: Added `&:has(> input[type="date"])` selector with improved webkit appearance handling  

## Testing
Tested on playground running on local network, verified fix on my iOS Safari

![IMG_2859](https://github.com/user-attachments/assets/5c7a4701-b421-4376-a788-d1fd899a338f)
