### PR TITLE
fix: modal scrollbar slide on close. closes: #3946 and #3942

### DIFF
--- a/packages/daisyui/src/components/modal.css
+++ b/packages/daisyui/src/components/modal.css
@@ -9,6 +9,7 @@
   overflow-y: hidden;
   overscroll-behavior: contain;
   z-index: 999;
+  scrollbar-gutter: auto;
   &::backdrop {
     @apply hidden;
   }


### PR DESCRIPTION
## Problem
Fixes #3946
Fixes #3942

Modal closing animation has a weird sliding animation when the page has a scrollbar. This occurs because the scrollbar disappears/appears during modal state changes, causing layout shift that creates an unpleasant user experience.

## Fix
Adding `scrollbar-gutter: auto` to the `.modal` class in `packages/daisyui/src/components/modal.css`. This property automatically manages scrollbar space reservation only when needed, preventing layout shift during modal transitions.

```css
.modal {
  /* existing properties... */
  scrollbar-gutter: auto; /* ← add this line */
}
```

## Testing
Verified fix works across all modal types except legacy checkboxes