### PR TITLE
fix: markdown rendering issue with backticks in component headings. closes: #3996

### DIFF
--- a/packages/docs/src/components/Component.svelte
+++ b/packages/docs/src/components/Component.svelte
@@ -85,7 +85,11 @@
   {/if}
   {#if desc}
     <div class="pb-4 text-xs opacity-70">
-      {$t(desc)}
+      {#if desc.includes('<')}
+        {@html desc}
+      {:else}
+        {$t(desc)}
+      {/if}
     </div>
   {/if}
   <div class="tabs tabs-lift">


### PR DESCRIPTION
## Problem
Fixes #3996

Headings in component docs were losing their markdown formatting. For example, the collapse page heading "Use Tailwind CSS `group` and `group-focus` utilities..." was showing up as plain text without the part where backticks starts around `group` and `group-focus`.

## Fix
The original `getHeadingText()` function was only grabbing the first text node and ignoring everything else, rewrote it to handle all the different node types properly.

Added a `nodesToHtml()` function that converts the markdown AST nodes into actual HTML - so `inlineCode` becomes `<code>`, `emphasis` becomes `<em>`, etc. Also had to fix some quote escaping issues where href attributes were breaking because of nested quotes.

Changed the component structure to store both the plain text (for IDs) and the original nodes (for rendering), then updated Component.svelte to detect when there's HTML content and render it instead of just treating everything as plain text.

## Testing
Checked the collapse docs page where the issue was reported and the heading now shows up correctly with proper code styling, see below:

<img width="672" height="444" alt="image" src="https://github.com/user-attachments/assets/b9923b8e-5b05-4960-8744-a2d6881b43f0" />

Added a test case with different markdown combinations to make sure bold, italic, code, and links all work together. Built and tested in the docs to verify everything renders properly:

<img width="667" height="201" alt="image" src="https://github.com/user-attachments/assets/13a7ad89-b4df-49c6-b865-0e6ba59f3201" />
