### PR TITLE
fix: search icon visible in dark mode (fixes #4006)

### DIFF
--- a/packages/daisyui/src/components/mockup.css
+++ b/packages/daisyui/src/components/mockup.css
@@ -81,8 +81,11 @@
 
       &:before {
         content: "";
-        @apply size-4 opacity-30;
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='currentColor' class='size-4'%3E%3Cpath fill-rule='evenodd' d='M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z' clip-rule='evenodd' /%3E%3C/svg%3E%0A");
+        @apply size-4 opacity-50;
+        background-color: currentColor;
+        mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z' clip-rule='evenodd' /%3E%3C/svg%3E")
+          no-repeat center;
+        mask-size: contain;
       }
     }
   }


### PR DESCRIPTION
This PR fixes [#4006](https://github.com/saadeghi/daisyui/issues/4006) where the search icon appears black in dark mode due to the inline `background-image` SVG.

### ✅ Changes Made:
- Replaced `background-image` SVG with `mask` and `background-color: currentColor`.
- This allows the icon to inherit text color dynamically, solving visibility issues in dark themes.

### 🧪 Compatibility:
- Tested on modern browsers: Chrome, Edge, Firefox.
- Works across all themes as `currentColor` adapts automatically.