### PR TITLE
fix: steps component text overlap on mobile. closes: #4043

### DIFF
--- a/packages/daisyui/src/components/steps.css
+++ b/packages/daisyui/src/components/steps.css
@@ -10,6 +10,16 @@
     min-width: 4rem;
     --step-bg: var(--color-base-300);
     --step-fg: var(--color-base-content);
+
+    @media (max-width: 768px) {
+      min-width: 3rem;
+      font-size: 0.75rem;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      hyphens: auto;
+      padding: 0 0.25rem;
+    }
+
     &:before {
       @apply top-0 col-start-1 row-start-1 h-2 w-full;
       border: 1px solid;
@@ -122,6 +132,15 @@
     grid-template-columns: auto;
     min-width: 4rem;
 
+    @media (max-width: 768px) {
+      min-width: 3rem;
+      font-size: 0.75rem;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      hyphens: auto;
+      padding: 0 0.25rem;
+    }
+
     &:before {
       @apply h-2 w-full;
       translate: 0;
@@ -145,6 +164,13 @@
     grid-template-rows: auto;
     min-height: 4rem;
     justify-items: start;
+
+    @media (max-width: 768px) {
+      font-size: 0.875rem;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      hyphens: auto;
+    }
 
     &:before {
       @apply h-full w-2;


### PR DESCRIPTION
## Problem
Fixes #4043

The steps component text overlaps on mobile devices when using long text content. This occurs because `grid-auto-columns: 1fr` forces equal width distribution, causing text to overflow horizontally into other steps.

## Fix

- added `overflow-wrap: break-word`, `word-break: break-word`, and `hyphens: auto`
- changed font size to `0.75rem` and min-width to `3rem` on screens ≤768px  
- changed padding to `0 0.25rem` for text fit

## Testing
Tested in playground with original Spanish text example and extended English text:
<img width="372" height="130" alt="image" src="https://github.com/user-attachments/assets/ffb39f1c-1640-4e17-a7f9-c3fd7e2f359f" />
<img width="374" height="205" alt="image" src="https://github.com/user-attachments/assets/a256c688-1a3c-4736-a235-a584b5565d79" />

However it's better to use vertical steps on mobile screen anyways