### PR TITLE
fix: improve text contrast for selected cally dates on hover closes: #4042

### DIFF
--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -30,7 +30,7 @@
     font-size: 0.7rem;
   }
   ::part(day):hover {
-  background: var(--color-base-200);
+    background: var(--color-base-200);
   }
   ::part(button day today) {
     background: var(--color-primary);
@@ -40,6 +40,10 @@
     color: var(--color-base-100);
     background: var(--color-base-content);
     border-radius: var(--radius-field);
+  }
+  ::part(selected):hover {
+    color: var(--color-base-content);
+    background: var(--color-base-200);
   }
   ::part(range-inner) {
     border-radius: 0;


### PR DESCRIPTION
## Problem
Fixes #4042

Hovering over selected dates in cally calendars makes text hard to read due to poor contrast
Selected dates have light text (var(--color-base-100)) that becomes unreadable when the hover state applies a light background (var(--color-base-200)).

## Fix
Added specific CSS rule for selected dates on hover that changes text color to var(--color-base-content) while keeping the var(--color-base-200) background

## Testing
Tested in playground with both single date and date range calendars