### PR TITLE
feat(a11y): add prefers-reduced-motion support

### DIFF
--- a/packages/daisyui/src/components/carousel.css
+++ b/packages/daisyui/src/components/carousel.css
@@ -4,6 +4,10 @@
   scroll-behavior: smooth;
   scrollbar-width: none;
 
+  @media (prefers-reduced-motion: reduce) {
+    scroll-behavior: auto;
+  }
+
   &::-webkit-scrollbar {
     @apply hidden;
   }

--- a/packages/daisyui/src/components/carousel.css
+++ b/packages/daisyui/src/components/carousel.css
@@ -1,11 +1,9 @@
 .carousel {
   @apply inline-flex overflow-x-scroll;
   scroll-snap-type: x mandatory;
-  scroll-behavior: smooth;
   scrollbar-width: none;
-
-  @media (prefers-reduced-motion: reduce) {
-    scroll-behavior: auto;
+  @media (prefers-reduced-motion: no-preference) {
+    scroll-behavior: smooth;
   }
 
   &::-webkit-scrollbar {

--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -9,12 +9,10 @@
   border-radius: var(--radius-box, 1rem);
   width: 100%;
   grid-template-rows: max-content 0fr;
-  transition: grid-template-rows 0.2s;
-
-  @media (prefers-reduced-motion: reduce) {
-    transition: none;
-  }
   isolation: isolate;
+  @media (prefers-reduced-motion: no-preference) {
+    transition: grid-template-rows 0.2s;
+  }
 
   > input:is([type="checkbox"], [type="radio"]) {
     grid-column-start: 1;
@@ -58,22 +56,18 @@
   &:not(.collapse-close)
     > :where(input:is([type="checkbox"], [type="radio"]):checked ~ .collapse-content) {
     padding-bottom: 1rem;
-    transition:
-      padding 0.2s ease-out,
-      background-color 0.2s ease-out;
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    @media (prefers-reduced-motion: no-preference) {
+      transition:
+        padding 0.2s ease-out,
+        background-color 0.2s ease-out;
     }
   }
 
   &:is([open]) {
     &.collapse-arrow {
       > .collapse-title:after {
-        transform: translateY(-50%) rotate(225deg);
-
-        @media (prefers-reduced-motion: reduce) {
-          transform: translateY(-50%) rotate(45deg);
+        @media (prefers-reduced-motion: no-preference) {
+          transform: translateY(-50%) rotate(225deg);
         }
       }
     }
@@ -82,10 +76,8 @@
   &.collapse-open {
     &.collapse-arrow {
       > .collapse-title:after {
-        transform: translateY(-50%) rotate(225deg);
-
-        @media (prefers-reduced-motion: reduce) {
-          transform: translateY(-50%) rotate(45deg);
+        @media (prefers-reduced-motion: no-preference) {
+          transform: translateY(-50%) rotate(225deg);
         }
       }
     }
@@ -155,13 +147,11 @@
   padding-left: 1rem;
   padding-right: 1rem;
   cursor: unset;
-  transition:
-    visibility 0.2s,
-    padding 0.2s ease-out,
-    background-color 0.2s ease-out;
-
-  @media (prefers-reduced-motion: reduce) {
-    transition: none;
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      visibility 0.2s,
+      padding 0.2s ease-out,
+      background-color 0.2s ease-out;
   }
 }
 
@@ -189,12 +179,10 @@
     height: 0.5rem;
     width: 0.5rem;
     transform: translateY(-100%) rotate(45deg);
-    transition-property: all;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 0.2s;
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    @media (prefers-reduced-motion: no-preference) {
+      transition-property: all;
+      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+      transition-duration: 0.2s;
     }
     top: 1.9rem;
     inset-inline-end: 1.4rem;
@@ -211,12 +199,10 @@
     display: block;
     height: 0.5rem;
     width: 0.5rem;
-    transition-property: all;
-    transition-duration: 300ms;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    @media (prefers-reduced-motion: no-preference) {
+      transition-property: all;
+      transition-duration: 300ms;
+      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     }
     top: 0.9rem;
     inset-inline-end: 1.4rem;
@@ -242,12 +228,10 @@
     visibility: visible;
     min-height: fit-content;
     padding-bottom: 1rem;
-    transition:
-      padding 0.2s ease-out,
-      background-color 0.2s ease-out;
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    @media (prefers-reduced-motion: no-preference) {
+      transition:
+        padding 0.2s ease-out,
+        background-color 0.2s ease-out;
     }
   }
 }

--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -10,6 +10,10 @@
   width: 100%;
   grid-template-rows: max-content 0fr;
   transition: grid-template-rows 0.2s;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
   isolation: isolate;
 
   > input:is([type="checkbox"], [type="radio"]) {
@@ -57,12 +61,20 @@
     transition:
       padding 0.2s ease-out,
       background-color 0.2s ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 
   &:is([open]) {
     &.collapse-arrow {
       > .collapse-title:after {
         transform: translateY(-50%) rotate(225deg);
+
+        @media (prefers-reduced-motion: reduce) {
+          transform: translateY(-50%) rotate(45deg);
+        }
       }
     }
   }
@@ -71,6 +83,10 @@
     &.collapse-arrow {
       > .collapse-title:after {
         transform: translateY(-50%) rotate(225deg);
+
+        @media (prefers-reduced-motion: reduce) {
+          transform: translateY(-50%) rotate(45deg);
+        }
       }
     }
   }
@@ -143,6 +159,10 @@
     visibility 0.2s,
     padding 0.2s ease-out,
     background-color 0.2s ease-out;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 .collapse:is(details) {
@@ -172,6 +192,10 @@
     transition-property: all;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 0.2s;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
     top: 1.9rem;
     inset-inline-end: 1.4rem;
     content: "";
@@ -190,6 +214,10 @@
     transition-property: all;
     transition-duration: 300ms;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
     top: 0.9rem;
     inset-inline-end: 1.4rem;
     content: "+";
@@ -217,5 +245,9 @@
     transition:
       padding 0.2s ease-out,
       background-color 0.2s ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 }

--- a/packages/daisyui/src/components/dropdown.css
+++ b/packages/daisyui/src/components/dropdown.css
@@ -23,6 +23,11 @@
     transition-behavior: allow-discrete;
     transition-duration: 0.2s;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+      transition: none;
+    }
   }
   @starting-style {
     &[popover],

--- a/packages/daisyui/src/components/dropdown.css
+++ b/packages/daisyui/src/components/dropdown.css
@@ -18,15 +18,12 @@
   &[popover],
   .dropdown-content {
     z-index: 999;
-    animation: dropdown 0.2s;
-    transition-property: opacity, scale, display;
-    transition-behavior: allow-discrete;
-    transition-duration: 0.2s;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
-      transition: none;
+    @media (prefers-reduced-motion: no-preference) {
+      animation: dropdown 0.2s;
+      transition-property: opacity, scale, display;
+      transition-behavior: allow-discrete;
+      transition-duration: 0.2s;
+      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     }
   }
   @starting-style {

--- a/packages/daisyui/src/components/progress.css
+++ b/packages/daisyui/src/components/progress.css
@@ -12,6 +12,12 @@
     background-position-x: 15%;
     animation: progress 5s ease-in-out infinite;
 
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+      background-image: linear-gradient(90deg, currentColor 0%, currentColor 100%);
+      background-size: 100%;
+    }
+
     @supports (-moz-appearance: none) {
       &::-moz-progress-bar {
         @apply bg-transparent;
@@ -25,6 +31,12 @@
         background-size: 200%;
         background-position-x: 15%;
         animation: progress 5s ease-in-out infinite;
+
+        @media (prefers-reduced-motion: reduce) {
+          animation: none;
+          background-image: linear-gradient(90deg, currentColor 0%, currentColor 100%);
+          background-size: 100%;
+        }
       }
     }
   }

--- a/packages/daisyui/src/components/progress.css
+++ b/packages/daisyui/src/components/progress.css
@@ -10,32 +10,24 @@
     );
     background-size: 200%;
     background-position-x: 15%;
-    animation: progress 5s ease-in-out infinite;
-
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
-      background-image: linear-gradient(90deg, currentColor 0%, currentColor 100%);
-      background-size: 100%;
+    @media (prefers-reduced-motion: no-preference) {
+      animation: progress 5s ease-in-out infinite;
     }
 
     @supports (-moz-appearance: none) {
       &::-moz-progress-bar {
         @apply bg-transparent;
-        background-image: repeating-linear-gradient(
-          90deg,
-          currentColor -1%,
-          currentColor 10%,
-          #0000 10%,
-          #0000 90%
-        );
-        background-size: 200%;
-        background-position-x: 15%;
-        animation: progress 5s ease-in-out infinite;
-
-        @media (prefers-reduced-motion: reduce) {
-          animation: none;
-          background-image: linear-gradient(90deg, currentColor 0%, currentColor 100%);
-          background-size: 100%;
+        @media (prefers-reduced-motion: no-preference) {
+          animation: progress 5s ease-in-out infinite;
+          background-image: repeating-linear-gradient(
+            90deg,
+            currentColor -1%,
+            currentColor 10%,
+            #0000 10%,
+            #0000 90%
+          );
+          background-size: 200%;
+          background-position-x: 15%;
         }
       }
     }

--- a/packages/daisyui/src/components/radio.css
+++ b/packages/daisyui/src/components/radio.css
@@ -23,6 +23,10 @@
     animation: radio 0.2s ease-out;
     @apply bg-base-100 border-current;
 
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+
     &:before {
       @apply bg-current;
       box-shadow:

--- a/packages/daisyui/src/components/radio.css
+++ b/packages/daisyui/src/components/radio.css
@@ -20,11 +20,9 @@
 
   &:checked,
   &[aria-checked="true"] {
-    animation: radio 0.2s ease-out;
     @apply bg-base-100 border-current;
-
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
+    @media (prefers-reduced-motion: no-preference) {
+      animation: radio 0.2s ease-out;
     }
 
     &:before {

--- a/packages/daisyui/src/components/rating.css
+++ b/packages/daisyui/src/components/rating.css
@@ -9,6 +9,10 @@
   :where(*) {
     animation: rating 0.25s ease-out;
     @apply bg-base-content h-6 w-6 rounded-none opacity-20;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
     &:is(input) {
       @apply cursor-pointer;
     }
@@ -33,6 +37,10 @@
     &:focus-visible {
       transition: scale 0.2s ease-out;
       scale: 1.1;
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
     }
   }
 

--- a/packages/daisyui/src/components/rating.css
+++ b/packages/daisyui/src/components/rating.css
@@ -7,11 +7,9 @@
   }
 
   :where(*) {
-    animation: rating 0.25s ease-out;
     @apply bg-base-content h-6 w-6 rounded-none opacity-20;
-
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
+    @media (prefers-reduced-motion: no-preference) {
+      animation: rating 0.25s ease-out;
     }
     &:is(input) {
       @apply cursor-pointer;
@@ -35,11 +33,9 @@
     }
 
     &:focus-visible {
-      transition: scale 0.2s ease-out;
       scale: 1.1;
-
-      @media (prefers-reduced-motion: reduce) {
-        transition: none;
+      @media (prefers-reduced-motion: no-preference) {
+        transition: scale 0.2s ease-out;
       }
     }
   }

--- a/packages/daisyui/src/components/skeleton.css
+++ b/packages/daisyui/src/components/skeleton.css
@@ -11,6 +11,11 @@
   background-size: 200% auto;
   background-repeat: no-repeat;
   background-position-x: -50%;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background-image: none;
+  }
 }
 @keyframes skeleton {
   0% {

--- a/packages/daisyui/src/components/skeleton.css
+++ b/packages/daisyui/src/components/skeleton.css
@@ -1,7 +1,6 @@
 .skeleton {
   @apply bg-base-300 rounded-box motion-reduce:[transition-duration:15s];
   will-change: background-position;
-  animation: skeleton 1.8s ease-in-out infinite;
   background-image: linear-gradient(
     105deg,
     #0000 0% 40%,
@@ -12,9 +11,8 @@
   background-repeat: no-repeat;
   background-position-x: -50%;
 
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    background-image: none;
+  @media (prefers-reduced-motion: no-preference) {
+    animation: skeleton 1.8s ease-in-out infinite;
   }
 }
 @keyframes skeleton {

--- a/packages/daisyui/src/components/swap.css
+++ b/packages/daisyui/src/components/swap.css
@@ -8,12 +8,10 @@
 
   > * {
     @apply col-start-1 row-start-1;
-    transition-property: transform, rotate, opacity;
-    transition-duration: 0.2s;
-    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    @media (prefers-reduced-motion: no-preference) {
+      transition-property: transform, rotate, opacity;
+      transition-duration: 0.2s;
+      transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
     }
   }
 

--- a/packages/daisyui/src/components/swap.css
+++ b/packages/daisyui/src/components/swap.css
@@ -11,6 +11,10 @@
     transition-property: transform, rotate, opacity;
     transition-duration: 0.2s;
     transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 
   .swap-on,

--- a/packages/daisyui/src/components/toast.css
+++ b/packages/daisyui/src/components/toast.css
@@ -6,6 +6,10 @@
 
   & > * {
     animation: toast 0.25s ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   }
 
   &:where(.toast-start) {

--- a/packages/daisyui/src/components/toast.css
+++ b/packages/daisyui/src/components/toast.css
@@ -5,10 +5,8 @@
   max-width: calc(100vw - 2rem);
 
   & > * {
-    animation: toast 0.25s ease-out;
-
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
+    @media (prefers-reduced-motion: no-preference) {
+      animation: toast 0.25s ease-out;
     }
   }
 

--- a/packages/daisyui/src/components/tooltip.css
+++ b/packages/daisyui/src/components/tooltip.css
@@ -9,32 +9,22 @@
     @apply text-neutral-content rounded-field absolute max-w-[20rem] px-2 py-1 text-center whitespace-normal opacity-0;
     font-size: 0.875rem;
     line-height: 1.25;
-    transition:
-      opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms,
-      transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms;
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
-      transform: translateX(-50%);
-    }
     background-color: var(--tt-bg);
     width: max-content;
     pointer-events: none;
     z-index: 2;
     --tw-content: attr(data-tip);
     content: var(--tw-content);
+    @media (prefers-reduced-motion: no-preference) {
+      transition:
+        opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms,
+        transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms;
+    }
   }
 
   &:after {
     @apply absolute opacity-0;
     background-color: var(--tt-bg);
-    transition:
-      opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms,
-      transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms;
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
-    }
     content: "";
     pointer-events: none;
     width: 0.625rem;
@@ -45,6 +35,11 @@
     mask-position: -1px 0;
     --mask-tooltip: url("data:image/svg+xml,%3Csvg width='10' height='4' viewBox='0 0 8 4' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 4 5.00001 4C7 4 6.5 1 9.5 1C10 1 10 0.499897 10 0H0C-1.99338e-08 0.5 0 1 0.500009 1Z' fill='black'/%3E%3C/svg%3E%0A");
     mask-image: var(--mask-tooltip);
+    @media (prefers-reduced-motion: no-preference) {
+      transition:
+        opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms,
+        transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms;
+    }
   }
 }
 
@@ -91,13 +86,10 @@
     &:after {
       @apply opacity-100;
       --tt-pos: 0rem;
-      transition:
-        opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0s,
-        transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-
-      @media (prefers-reduced-motion: reduce) {
-        transition: none;
-        --tt-pos: 0rem;
+      @media (prefers-reduced-motion: no-preference) {
+        transition:
+          opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0s,
+          transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0ms;
       }
     }
   }

--- a/packages/daisyui/src/components/tooltip.css
+++ b/packages/daisyui/src/components/tooltip.css
@@ -12,6 +12,11 @@
     transition:
       opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms,
       transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+      transform: translateX(-50%);
+    }
     background-color: var(--tt-bg);
     width: max-content;
     pointer-events: none;
@@ -26,6 +31,10 @@
     transition:
       opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms,
       transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 75ms;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
     content: "";
     pointer-events: none;
     width: 0.625rem;
@@ -85,6 +94,11 @@
       transition:
         opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0s,
         transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+        --tt-pos: 0rem;
+      }
     }
   }
 }


### PR DESCRIPTION
Disable animations when users prefer reduced motion:

- skeleton: remove shimmer animation
- progress: use solid fill instead of moving stripes
- collapse: disable grid transitions and rotations
- toast, dropdown, rating, radio: disable entry animations
- swap, tooltip: disable transform transitions
- carousel: disable smooth scroll (already implemented)

Improves accessibility for users with vestibular disorders

NOTE: I wasn't able to test this because the current animations
makes me feel sick, so I was making these changes just by
code inspection.
