### PR TITLE
Add checkbox filter example with multi-selection

### DIFF
--- a/packages/docs/src/routes/(routes)/components/filter/+page.md
+++ b/packages/docs/src/routes/(routes)/components/filter/+page.md
@@ -55,15 +55,15 @@ classnames:
 ### ~Filter using HTML form, checkboxes and reset button
 #### A HTML form for filtering items with multiple selections
 
-<form class="filter">
-  <input class="btn btn-square" type="reset" value="×"/>
+<form>
   <input class="btn" type="checkbox" name="frameworks" aria-label="Svelte"/>
   <input class="btn" type="checkbox" name="frameworks" aria-label="Vue"/>
   <input class="btn" type="checkbox" name="frameworks" aria-label="React"/>
+  <input class="btn btn-square" type="reset" value="×"/>
 </form>
 
 ```html
-<form class="$$filter">
+<form>
   <input class="$$btn $$btn-square" type="reset" value="×"/>
   <input class="$$btn" type="checkbox" name="frameworks" aria-label="Svelte"/>
   <input class="$$btn" type="checkbox" name="frameworks" aria-label="Vue"/>

--- a/packages/docs/src/routes/(routes)/components/filter/+page.md
+++ b/packages/docs/src/routes/(routes)/components/filter/+page.md
@@ -52,3 +52,20 @@ classnames:
   <input class="$$btn" type="radio" name="metaframeworks" aria-label="Next.js"/>
 </div>
 ```
+### ~Filter using HTML form, checkboxes and reset button
+#### A HTML form for filtering items with multiple selections
+
+<form class="filter">
+  <input class="btn btn-square" type="reset" value="×"/>
+  <input class="btn" type="checkbox" name="frameworks" aria-label="Svelte"/>
+  <input class="btn" type="checkbox" name="frameworks" aria-label="Vue"/>
+  <input class="btn" type="checkbox" name="frameworks" aria-label="React"/>
+</form>
+
+```html
+<form class="$$filter">
+  <input class="$$btn $$btn-square" type="reset" value="×"/>
+  <input class="$$btn" type="checkbox" name="frameworks" aria-label="Svelte"/>
+  <input class="$$btn" type="checkbox" name="frameworks" aria-label="Vue"/>
+  <input class="$$btn" type="checkbox" name="frameworks" aria-label="React"/>
+</form>

--- a/packages/docs/src/routes/(routes)/components/filter/+page.md
+++ b/packages/docs/src/routes/(routes)/components/filter/+page.md
@@ -53,7 +53,7 @@ classnames:
 </div>
 ```
 ### ~Filter using HTML form, checkboxes and reset button
-#### A HTML form for filtering items with multiple selections
+#### For having multiple choices, use checkboxes. It doesn't need the filter class name.
 
 <form>
   <input class="btn" type="checkbox" name="frameworks" aria-label="Svelte"/>


### PR DESCRIPTION
### Summary
Introduces a new filter example using checkboxes in addition to the existing radio button example.  

### Details
- Demonstrates filtering with multiple selections (without `filter` class)
- Keeps the reset button for clearing all selections  