### PR TITLE
docs(rails): Update install guide to use .mjs extension

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/rails/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/rails/+page.md
@@ -68,8 +68,8 @@ This works as a Tailwind CSS plugin so only the class names you need will be add
 Run this code to download latest version of daisyUI as a single js file
 
 ```sh:Terminal
-curl -sLo app/assets/tailwind/daisyui.js https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.js
-curl -sLo app/assets/tailwind/daisyui-theme.js https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.js
+curl -sLo app/assets/tailwind/daisyui.mjs https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.mjs
+curl -sLo app/assets/tailwind/daisyui-theme.mjs https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.mjs
 ```
 
 Put Tailwind CSS and daisyUI in your CSS file (and remove old styles)
@@ -81,10 +81,10 @@ Put Tailwind CSS and daisyUI in your CSS file (and remove old styles)
 @source "../../../app/javascript/**/*.js";
 @source "../../../app/views/**/*";
 
-@plugin "./daisyui.js";
+@plugin "./daisyui.mjs";
 
 /* Optional for custom themes – Docs: https://daisyui.com/docs/themes/#how-to-add-a-new-custom-theme */
-@plugin "./daisyui-theme.js"{
+@plugin "./daisyui-theme.mjs"{
   /* custom theme here */
 }
 ```


### PR DESCRIPTION
This PR updates the Ruby on Rails installation guide, changing the daisyUI script references to use the `.mjs` extension.

This fixes an issue for Rails developers where Tailwind CSS IntelliSense would not work in VS Code. The `.mjs` extension ensures compatibility with modern JavaScript tooling, like importmaps, used in Rails 7+.

**Related issues:**
- Fixes https://github.com/saadeghi/daisyui/discussions/4077
- Fixes https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1415

<img width="1503" height="615" alt="Screenshot 2025-09-10 at 10 24 05 AM" src="https://github.com/user-attachments/assets/0e412cc6-281f-44b0-a253-f7c52d060751" />
