### PR TITLE
fix(mockup-phone): make layout responsive with aspect-ratio

### DIFF
--- a/packages/daisyui/src/components/mockup.css
+++ b/packages/daisyui/src/components/mockup.css
@@ -93,36 +93,43 @@
 
 .mockup-phone {
   @apply inline-grid justify-items-center;
-  aspect-ratio: 390 / 845;
-  border: 6px solid #6b6b6b;
+  border: 5px solid #6b6b6b;
   border-radius: 65px;
   background-color: #000;
-  padding: 11px;
+  padding: 6px;
   overflow: hidden;
+  width: 100%;
+  max-width: 462px;
+  aspect-ratio: 462 / 978;
+  @supports (corner-shape: superellipse(1.45)) {
+    border-radius: 90px;
+    corner-shape: superellipse(1.45);
+  }
 }
-.mockup-phone > * {
-  grid-area: 1 / 1;
-}
-
 .mockup-phone-camera {
-  border-radius: 9999px; /* pill */
+  grid-column: 1/1;
+  grid-row: 1/1;
   background: #000;
-  width: 32.3%;
-  height: 3.8%;
-  border-radius: 9999px;
+  height: 3.7%;
+  width: 28%;
+  border-radius: 17px;
   z-index: 1;
-  margin-top: 0.7%;
+  margin-top: 3%;
 }
 .mockup-phone-display {
-  width: 100%;
-  height: 100%;
+  border-radius: 54px;
+  grid-column: 1/1;
+  grid-row: 1/1;
   overflow: hidden;
-  border-radius: 49px;
-}
-
-.mockup-phone-display > img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  display: block;
+  @supports (corner-shape: superellipse(1.87)) {
+    border-radius: 101px;
+    corner-shape: superellipse(1.87);
+  }
+  & > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }

--- a/packages/daisyui/src/components/mockup.css
+++ b/packages/daisyui/src/components/mockup.css
@@ -93,27 +93,36 @@
 
 .mockup-phone {
   @apply inline-grid justify-items-center;
+  aspect-ratio: 390 / 845;
   border: 6px solid #6b6b6b;
   border-radius: 65px;
   background-color: #000;
   padding: 11px;
   overflow: hidden;
 }
+.mockup-phone > * {
+  grid-area: 1 / 1;
+}
+
 .mockup-phone-camera {
-  grid-column: 1/1;
-  grid-row: 1/1;
+  border-radius: 9999px; /* pill */
   background: #000;
-  height: 32px;
-  width: 126px;
-  border-radius: 17px;
+  width: 32.3%;
+  height: 3.8%;
+  border-radius: 9999px;
   z-index: 1;
-  margin-top: 6px;
+  margin-top: 0.7%;
 }
 .mockup-phone-display {
-  grid-column: 1/1;
-  grid-row: 1/1;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
   border-radius: 49px;
-  width: 390px;
-  height: 845px;
+}
+
+.mockup-phone-display > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }

--- a/packages/docs/src/routes/(routes)/components/mockup-phone/+page.md
+++ b/packages/docs/src/routes/(routes)/components/mockup-phone/+page.md
@@ -19,14 +19,21 @@ classnames:
   import Translate from "$components/Translate.svelte"
 </script>
 
+> :INFO:
+>
+> The `mockup-phone` component does not set its own width.
+> You must control the width from the wrapper (e.g., `w-full`, `w-[320px]`, or `max-w-sm`).
+> The component will then maintain the correct `390 / 845` aspect ratio automatically.  
+> This design keeps the component flexible: it adapts to any wrapper width while preserving the phone’s proportions and styling.
+
 ### ~iPhone mockup
-<div class="mockup-phone">
+<div class="mockup-phone w-[390px]">
   <div class="mockup-phone-camera"></div>
   <div class="mockup-phone-display text-white grid place-content-center">It's Glowtime.</div>
 </div>
 
 ```html
-<div class="$$mockup-phone">
+<div class="$$mockup-phone w-[390px]">
   <div class="$$mockup-phone-camera"></div>
   <div class="$$mockup-phone-display text-white grid place-content-center">It's Glowtime.</div>
 </div>
@@ -34,7 +41,7 @@ classnames:
 
 
 ### ~With color and wallpaper
-<div class="mockup-phone border-primary">
+<div class="mockup-phone border-primary w-[390px]">
   <div class="mockup-phone-camera"></div>
   <div class="mockup-phone-display">
     <img alt="wallpaper" src="https://img.daisyui.com/images/stock/453966.webp"/>
@@ -42,7 +49,7 @@ classnames:
 </div>
 
 ```html
-<div class="$$mockup-phone border-primary">
+<div class="$$mockup-phone border-primary w-[390px]">
   <div class="$$mockup-phone-camera"></div>
   <div class="$$mockup-phone-display">
     <img alt="wallpaper" src="https://img.daisyui.com/images/stock/453966.webp"/>

--- a/packages/docs/src/routes/(routes)/components/mockup-phone/+page.md
+++ b/packages/docs/src/routes/(routes)/components/mockup-phone/+page.md
@@ -19,40 +19,36 @@ classnames:
   import Translate from "$components/Translate.svelte"
 </script>
 
-> :INFO:
->
-> The `mockup-phone` component does not set its own width.
-> You must control the width from the wrapper (e.g., `w-full`, `w-[320px]`, or `max-w-sm`).
-> The component will then maintain the correct `390 / 845` aspect ratio automatically.  
-> This design keeps the component flexible: it adapts to any wrapper width while preserving the phone’s proportions and styling.
-
 ### ~iPhone mockup
-<div class="mockup-phone w-[390px]">
+
+<div class="mockup-phone">
   <div class="mockup-phone-camera"></div>
-  <div class="mockup-phone-display text-white grid place-content-center">It's Glowtime.</div>
+  <div class="mockup-phone-display text-white bg-neutral-900 grid place-content-center">It's Glowtime.</div>
 </div>
 
 ```html
-<div class="$$mockup-phone w-[390px]">
+<div class="$$mockup-phone">
   <div class="$$mockup-phone-camera"></div>
-  <div class="$$mockup-phone-display text-white grid place-content-center">It's Glowtime.</div>
+  <div class="$$mockup-phone-display text-whi0e grid place-content-center bg-neutral-900">
+    It's Glowtime.
+  </div>
 </div>
 ```
 
-
 ### ~With color and wallpaper
-<div class="mockup-phone border-primary w-[390px]">
+
+<div class="mockup-phone border-[#ff8938]">
   <div class="mockup-phone-camera"></div>
   <div class="mockup-phone-display">
-    <img alt="wallpaper" src="https://img.daisyui.com/images/stock/453966.webp"/>
+    <img alt="wallpaper" src="https://img.daisyui.com/images/stock/453966.webp?1"/>
   </div>
 </div>
 
 ```html
-<div class="$$mockup-phone border-primary w-[390px]">
+<div class="$$mockup-phone border-[#ff8938]">
   <div class="$$mockup-phone-camera"></div>
   <div class="$$mockup-phone-display">
-    <img alt="wallpaper" src="https://img.daisyui.com/images/stock/453966.webp"/>
+    <img alt="wallpaper" src="https://img.daisyui.com/images/stock/453966.webp" />
   </div>
 </div>
 ```


### PR DESCRIPTION
## Description

This PR refactors the mockup-phone component to be responsive and consistent across viewports and browsers.
It removes hard-coded pixel dimensions and invalid grid definitions, replacing them with scalable, ratio-based sizing while preserving the original phone silhouette, notch, and display styling.
fixed #1063 


### Changes
#### Wrapper (.mockup-phone)
- Added aspect-ratio: 390 / 845 for natural scaling without fixed width/height.
- Children unified via grid-area: 1 / 1 for reliable overlay stacking.

#### Camera notch (.mockup-phone-camera)
- Converted fixed px sizing (126×32px) to proportional values (32.3% × 3.8%).
- Simplified with border-radius: 9999px to always render a pill shape.

#### Display (.mockup-phone-display)
- Removed fixed 390×845px; now width: 100%; height: 100% with responsive scaling.
- Retains rounded corners (border-radius: 49px) for visual integrity.

#### Image handling
- Ensures child <img> fills container with object-fit: cover.


## Motivation

- Responsive integrity: Prevent layout breakage on small viewports (<390px).
- Cross-browser correctness: Fixes invalid grid-column: 1/1 definitions that caused inconsistent rendering in Safari vs Chrome.
- Design fidelity: Maintains the intended rounded display and notch regardless of scaling.
- Minimal risk: Pure CSS update; no markup or API changes required.

## Screenshots
> iphone SE 

| ASIS        | TOBE                  |
| ----------- | ----------- | 
| <img width="429" height="740" alt="스크린샷 2025-09-10 오후 6 59 58" src="https://github.com/user-attachments/assets/25f94cd2-c0bf-41f5-9bf9-9f3503179031" />       |  <img width="437" height="738" alt="스크린샷 2025-09-10 오후 7 00 13" src="https://github.com/user-attachments/assets/91508b3d-bd86-4b93-ac2e-e363c7f8005b" /> | 


