### PR TITLE
fix: Firefox Noise Effect

### DIFF
--- a/packages/daisyui/src/base/svg.css
+++ b/packages/daisyui/src/base/svg.css
@@ -1,3 +1,3 @@
 :root {
-  --fx-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='a'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.34' numOctaves='4' stitchTiles='stitch'%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23a)' opacity='0.2'%3E%3C/rect%3E%3C/svg%3E");
+  --fx-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='a'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.34' numOctaves='4' stitchTiles='stitch'%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23a)' opacity='0.2'%3E%3C/rect%3E%3C/svg%3E");
 }


### PR DESCRIPTION
## Description

Fixes #3583

> The noise effect does not work properly on Firefox when compared to Chrome and Safari, only displaying in the corner rather than over the entire element.

## Changes

1. Added a `viewBox` to fix the `--fx-noise` SVG rendering on Firefox.
2. Changed width and height on the `rect` to be static. This fixes rendering on Chromium after adding the `viewBox`.

## Screenshots

### Firefox

| Before | After |
|---|---|
| <img width="570" height="623" alt="firefox-before" src="https://github.com/user-attachments/assets/87eda994-7056-48f3-9b06-03edcaeb845a" /> | <img width="570" height="623" alt="firefox-after" src="https://github.com/user-attachments/assets/3829a713-9032-4c82-b221-412eb2c53ad1" /> |

### Chromium

| Before | After |
|---|---|
| <img width="515" height="623" alt="chromium-before" src="https://github.com/user-attachments/assets/beb703e2-c151-4659-a993-552ac7f19154" /> | <img width="515" height="623" alt="chromium-after" src="https://github.com/user-attachments/assets/0ab72af9-d0bd-49f4-9876-51619560d05f" /> |