### PR TITLE
docs: Add a fix to a common warning in code editor

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/astro/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/astro/+page.md
@@ -42,9 +42,9 @@ Put Tailwind CSS and daisyUI in your CSS file (and remove old styles)
 @plugin "daisyui";
 ```
 
-> If you are using VS Code as your editor and you get an error (`Unknown at rule @plugin`), then update your file association for `.css` files.
+> If you are using VS Code as your editor and you get a warning (`Unknown at rule @plugin`), then update your file association for `.css` files.
 >
-> To do so, you have to (1) go to settings, (2) search for 'associations', and (3) under `Files:Associations` add a new entry with item being `*.css` and value being `tailwindcss`. This should remove the error for you.
+> To do so, you have to (1) go to settings, (2) search for 'associations', and (3) under `Files:Associations` add a new entry with item being `*.css` and value being `tailwindcss`. This should remove the warning for you.
 
 Import the CSS file on top of your astro Layout file
 ```js:src/layouts/Layout.astro


### PR DESCRIPTION
Sometimes, the `@plugin` rule in `.css` files is not being recognized and a warning is raised by the editor (e.g. VS Code). This creates some confusion when devs are trying to install daisyui and then adding it to a new project (e.g. AstroJS).

As proposed by [@BennyCarlsson](https://github.com/tailwindlabs/tailwindcss/discussions/15828#discussioncomment-13301022), updating the file associations for `.css` files removes this warning.

This PR adds a clarification text in the docs for that particular step.