### PR TITLE
fix: sync margin inline start of select in label after change of padding inline start (ref #4114)

### DIFF
--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -32,7 +32,7 @@
       calc(0% + 16px) calc(1px + 50%);
   }
   select {
-    @apply -ms-4 -me-7 w-[calc(100%+2.75rem)] appearance-none ps-3 pe-7;
+    @apply -ms-3 -me-7 w-[calc(100%+2.75rem)] appearance-none ps-3 pe-7;
     height: calc(100% - calc(var(--border) * 2));
     align-items: center;
     background: inherit;


### PR DESCRIPTION
After the change of padding-inline start of .select  from ps-4 to ps-3 in 449378e93adba1fb71aba2c26515f4b9643244f9 the margin-inline-start was forgotten.