### PR TITLE
docs: Add appearance-none example

### DIFF
--- a/packages/docs/src/routes/(routes)/components/select/+page.md
+++ b/packages/docs/src/routes/(routes)/components/select/+page.md
@@ -473,3 +473,30 @@ classnames:
   <option>You can't touch this</option>
 </select>
 ```
+
+### ~AppearanceNone uses OS Native picker
+
+<select class="select appearance-none">
+  <option disabled selected>Pick a color</option>
+  <option>Crimson</option>
+  <option>Amber</option>
+  <option>Velvet</option>
+</select>
+
+```html
+<select class="$$select $$appearance-none">
+  <option disabled selected>Pick a color</option>
+  <option>Crimson</option>
+  <option>Amber</option>
+  <option>Velvet</option>
+</select>
+```
+
+```jsx
+<select defaultValue="Pick a color" className="$$select $$appearance-none">
+  <option disabled={true}>Pick a color</option>
+  <option>Crimson</option>
+  <option>Amber</option>
+  <option>Velvet</option>
+</select>
+```


### PR DESCRIPTION
This may fall under the TailwindCSS category, but I've added an example for using a native picker when using Cordova, Capacitor, etc.

This example uses the TailwindCSS class "appearance-none," so it may not be suitable for the DaisyUI docs.