### PR TITLE
docs: Removed out of scope text from codeblock

### DIFF
--- a/packages/docs/src/routes/(routes)/components/dropdown/+page.md
+++ b/packages/docs/src/routes/(routes)/components/dropdown/+page.md
@@ -612,7 +612,6 @@ The content gets displayed when the button is focused.
 </div>
 
 ```html
-A normal text and a helper dropdown
 <div class="$$dropdown $$dropdown-end">
   <div tabindex="0" role="button" class="$$btn $$btn-circle $$btn-ghost $$btn-xs text-info">
     <svg


### PR DESCRIPTION
When copying the JSX code from the "[Helper Dropdown](https://daisyui.com/components/dropdown/#helper-dropdown)" section, the text "A normal text and a helper dropdown" is incorrectly added at the top, causing a syntax error when pasted. This pull request simply removes that text.