### PR TITLE
fix(select): prevent line breaks on long text

### DIFF
--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -19,6 +19,8 @@
     4px 4px,
     4px 4px;
   background-repeat: no-repeat;
+  white-space: nowrap;
+  overflow: hidden;
   text-overflow: ellipsis;
   box-shadow:
     0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000) inset,
@@ -79,6 +81,7 @@
     &::picker(select) {
       color: inherit;
       max-height: min(24rem, 70dvh);
+      max-width: anchor-size(width);
       border: var(--border) solid var(--color-base-200);
       @apply rounded-box my-2 p-2;
       background-color: inherit;
@@ -111,6 +114,8 @@
       transition-property: color, background-color;
       transition-duration: 0.2s;
       transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+      white-space: nowrap;
+      overflow: hidden;
       &:not(:disabled) {
         &:hover,
         &:focus-visible {

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -81,7 +81,8 @@
     &::picker(select) {
       color: inherit;
       max-height: min(24rem, 70dvh);
-      max-width: anchor-size(width);
+      margin-inline: 0.5rem;
+      translate: -0.5rem 0;
       border: var(--border) solid var(--color-base-200);
       @apply rounded-box my-2 p-2;
       background-color: inherit;
@@ -114,8 +115,7 @@
       transition-property: color, background-color;
       transition-duration: 0.2s;
       transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-      white-space: nowrap;
-      overflow: hidden;
+      white-space: normal;
       &:not(:disabled) {
         &:hover,
         &:focus-visible {
@@ -126,6 +126,12 @@
           box-shadow: 0 2px calc(var(--depth) * 3px) -2px var(--color-neutral);
         }
       }
+    }
+  }
+  [dir="rtl"] & {
+    &::picker(select),
+    select::picker(select) {
+      translate: 0.5rem 0;
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #4105 

> Long select options now wrap in v5.1.9. If this was an intentional design change, it should probably be documented on the Select component in the docs. Otherwise, it is a regression.

## Changes

- Truncate text in `<select>`
- Changed the options container width to same width of `<select>`
- Truncate text in `<option>`

## Screenshots (Chrome)
| Before | After|
| --- | --- |
| <img width="935" height="163" alt="Screenshot 2025-09-30 at 22 54 48" src="https://github.com/user-attachments/assets/e2b142e2-0d94-4bf7-9645-e704d71d2adc" /> | <img width="717" height="158" alt="Screenshot 2025-09-30 at 22 55 32" src="https://github.com/user-attachments/assets/4414538d-83d1-4c91-a9b6-a21d7f820d3d" /> |

## Considerations

I initially attempted to implement `text-overflow: ellipsis` to add a `...` indicator for truncated text. However, to make `text-overflow: ellipsis` work, I needed to use `-webkit-appearance: none;`.

This approach caused a significant side-effect: it stripped the custom styling from the `<option>` elements, making them revert to the default OS appearance. To avoid this styling regression and preserve the component's design, I opted for the current solution of hiding the overflow without an ellipsis.
