### PR TITLE
docs: fix code example differs from the actual HTML code

### DIFF
--- a/packages/docs/src/routes/(routes)/components/table/+page.md
+++ b/packages/docs/src/routes/(routes)/components/table/+page.md
@@ -1694,7 +1694,7 @@ classnames:
 </div>
 
 ```html
-<div class="overflow-x-auto">
+<div class="overflow-x-auto h-96 w-96">
   <table class="$$table $$table-xs $$table-pin-rows $$table-pin-cols">
     <thead>
       <tr>


### PR DESCRIPTION
I noticed that the code for "Table with pinned-rows and pinned-cols" in the table documentation differs from the HTML code displayed on the page. The fixed width and height are important for the `position: sticky;` (used by `table-pin-rows` and `table-pin-cols`) to work properly.