### PR TITLE
fix: enable tailwind conditional classes on menu-active

### DIFF
--- a/packages/daisyui/src/components/menu.css
+++ b/packages/daisyui/src/components/menu.css
@@ -221,3 +221,11 @@
     @apply px-6 py-3;
   }
 }
+
+:where(:not(ul, details, .menu-title, .btn)).menu-active {
+  @apply outline-hidden;
+  color: var(--menu-active-fg);
+  background-color: var(--menu-active-bg);
+  background-size: auto, calc(var(--noise) * 100%);
+  background-image: none, var(--fx-noise);
+}


### PR DESCRIPTION
Fixes #3786 

> It looks like Tailwind CSS state variants (e.g., hover, focus, disabled), attribute variants (e.g., aria-, data-), and custom variants (e.g., data-[custom]) don't currently work with menu-active. I've included a simple Tailwind Play page as reference:

| Before this PR group-hover: doesn't works | After |
|--------|-------|
| ![497910032-3afcbc8a-3e78-4e2a-9d72-dbc9d559b0dc](https://github.com/user-attachments/assets/0ee95ec4-f3d2-4348-85cc-24350d02069e) | ![Screen Recording 2025-10-06 at 13 42 50](https://github.com/user-attachments/assets/69c91fc7-904f-48ed-ad71-4f30a0fd0d05) |

## Considerations

I'm open to suggestions on this implementation. If you have a better approach in mind, please let me know and I'm ready to refactor.