### PR TITLE
fix(collapse): fix tailwind default .collapse with revert-layer instead of visible

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -1,5 +1,5 @@
 .collapse:not(td, tr, colgroup) {
-  visibility: visible;
+  visibility: revert-layer;
 }
 
 .collapse {


### PR DESCRIPTION
Setting `.collapse` to `visibility: visible` creates lots of problems (one such example is in modal)

Another alternative is to set `visibility: unset`