### PR TITLE
feat: detect if page has vertical scrollbar visible and set scrollbar-gutter

### DIFF
--- a/packages/daisyui/src/base/rootscrollgutter.css
+++ b/packages/daisyui/src/base/rootscrollgutter.css
@@ -14,3 +14,28 @@
 :where(.modal[open], .modal-open, .modal-toggle:checked + .modal):not(.modal-start, .modal-end) {
   scrollbar-gutter: stable;
 }
+
+@supports (width: if(else: 1px)) and (animation-timeline: scroll()) {
+  :root {
+    animation: set-page-has-scroll forwards;
+    animation-timeline: scroll();
+  }
+
+  @keyframes set-page-has-scroll {
+    0%, to {
+      --page-has-scroll: 1;
+    }
+  }
+
+  :where(
+    :root:has(
+      .modal-open,
+      .modal[open],
+      .modal:target,
+      .modal-toggle:checked,
+      .drawer:not(.drawer-open) > .drawer-toggle:checked
+    )
+  ) {
+    scrollbar-gutter: if(style(--page-has-scroll: 1): stable; else: unset);
+  }
+}


### PR DESCRIPTION
It works only in Chrome+derivatives, but Safari has overlay scrollbars by default - and that leaves out only Firefox (which falls back to normal rootscrollgutter).

The related issues I could find:
- https://github.com/saadeghi/daisyui/issues/4086 OPEN
- https://github.com/saadeghi/daisyui/issues/4140
- https://github.com/saadeghi/daisyui/issues/4020
- https://github.com/saadeghi/daisyui/issues/3961
- https://github.com/saadeghi/daisyui/issues/3946
- https://github.com/saadeghi/daisyui/issues/3826
- https://github.com/saadeghi/daisyui/issues/3813
- https://github.com/saadeghi/daisyui/issues/3040

Required changes in docs:
- change the wording of all info blocks about `...you can exclude rootscrollgutter...`
- document the new variable/flag `--page-has-scroll` available in `:root`

Credits: https://css-tip.com/overflow-detection/