### PR TITLE
fix(dropdown): do not open dropdown on click (but open it on kbd focus)

### DIFF
--- a/packages/daisyui/src/components/dropdown.css
+++ b/packages/daisyui/src/components/dropdown.css
@@ -8,11 +8,10 @@
   .dropdown-content {
     @apply absolute;
   }
-  &:not(details, .dropdown-open, .dropdown-hover:hover, :focus-within) {
-    .dropdown-content {
-      @apply hidden origin-top opacity-0;
-      scale: 95%;
-    }
+  &:not(details, .dropdown-open, .dropdown-hover:hover, :focus-within) .dropdown-content,
+  &.dropdown-hover:not(:hover) [tabindex]:first-child:focus:not(:focus-visible) ~ .dropdown-content {
+    @apply hidden origin-top opacity-0;
+    scale: 95%;
   }
 
   &[popover],


### PR DESCRIPTION
Ref #3880 

Preview: https://play.tailwindcss.com/8bpcDY2JpW?file=css

I'm not sure if this would count as a breaking change or as a fix (I mean does it make sense to have something like `.dropdown-hover-only`)