### PR TITLE
fix(countdown): clip overflow instead of hide - prevents alignment problems when only 1 digit is shown

### DIFF
--- a/packages/daisyui/src/components/countdown.css
+++ b/packages/daisyui/src/components/countdown.css
@@ -5,7 +5,7 @@
   }
 
   & > * {
-    @apply invisible relative inline-block overflow-y-hidden;
+    @apply invisible relative inline-block overflow-y-clip;
     transition: width 0.4s ease-out 0.2s;
     height: 1em;
     --value-v: calc(mod(max(0, var(--value)), 1000));


### PR DESCRIPTION
When the counter only shows one digit the bottom part is cut

Might be related to #3872

Example: https://play.tailwindcss.com/0Cthg7dr6N?file=css