### PR TITLE
feat(countdown): cycle last digit between 0-100, allow setting the min number of digits, prevent RTL bug

### DIFF
--- a/packages/daisyui/src/components/countdown.css
+++ b/packages/daisyui/src/components/countdown.css
@@ -12,8 +12,12 @@
     --value-hundreds: calc(round(to-zero, var(--value-v) / 100, 1));
     --value-tens: calc(round(to-zero, mod(var(--value-v), 100) / 10, 1));
     --value-ones: calc(mod(var(--value-v), 100));
-    --show-hundreds: clamp(clamp(0, var(--value-pad, 1) - 2, 1), var(--value-hundreds), 1);
-    --show-tens: clamp(clamp(0, var(--value-pad, 1) - 1, 1), var(--value-tens) + var(--show-hundreds), 1);
+    --show-hundreds: clamp(clamp(0, var(--digits, 1) - 2, 1), var(--value-hundreds), 1);
+    --show-tens: clamp(
+      clamp(0, var(--digits, 1) - 1, 1),
+      var(--value-tens) + var(--show-hundreds),
+      1
+    );
     --first-digits: calc(round(to-zero, var(--value-v) / 10, 1));
     width: calc(1ch + var(--show-tens) * 1ch + var(--show-hundreds) * 1ch);
     direction: ltr;

--- a/packages/docs/src/routes/(routes)/components/countdown/+page.md
+++ b/packages/docs/src/routes/(routes)/components/countdown/+page.md
@@ -35,7 +35,7 @@ classnames:
 
 > :INFO:
 >
-> you can set the minimum number of digits to display to 2 or 3 with `--value-pad: 2` or `--value-pad: 3` CSS variable.
+> you can set the minimum number of digits to display to 2 or 3 with `--digits: 2` or `--digits: 3` CSS variable.
 
 ### ~Countdown
 <span class="countdown">
@@ -55,9 +55,9 @@ classnames:
 ```
 
 
-### ~Large text with padding
+### ~Large text with 2 digits
 <span class="countdown font-mono text-6xl">
-  <span style="--value:{counter}; --value-pad: 2;" aria-live="polite" aria-label="{counter}">{counter}</span>
+  <span style="--value:{counter}; --digits: 2;" aria-live="polite" aria-label="{counter}">{counter}</span>
 </span>
 
 ```html
@@ -103,8 +103,8 @@ classnames:
 ### ~Clock countdown with colons
 <span class="font-mono text-2xl countdown">
   <span style="--value:10;" aria-live="polite" aria-label="10">10</span>:
-  <span style="--value:24; --value-pad: 2;" aria-live="polite" aria-label="24">24</span>:
-  <span style="--value:{counter}; --value-pad: 2;" aria-live="polite" aria-label="{counter}">{counter}</span>
+  <span style="--value:24; --digits: 2;" aria-live="polite" aria-label="24">24</span>:
+  <span style="--value:{counter}; --digits: 2;" aria-live="polite" aria-label="{counter}">{counter}</span>
 </span>
 
 ```html

--- a/packages/docs/src/routes/(routes)/docs/utilities/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/utilities/+page.md
@@ -138,7 +138,7 @@ If you are using a prefix for daisyUI, these CSS variables will be prefixed with
 |                 | `--cardtitle-fs`              | font size of the card title                              |
 | Checkbox        | `--size`                      | size of the checkbox                                     |
 | Countdown       | `--value`                     | value of the countdown                                   |
-|                 | `--value-pad`                 | minimum number of digits for countdown                   |
+|                 | `--digits`                    | minimum number of digits for countdown                   |
 | Divider         | `--divider-m`                 | margin of the divider                                    |
 | Dropdown        | `--anchor-v`                  | vertical position of the anchor                          |
 |                 | `--anchor-h`                  | horizontal position of the anchor                        |


### PR DESCRIPTION
To force a minimum number of digits (use `--value-pad: 2` or `--value-pad: 3`)
Updates the docs to show 2 digits in clock-style examples

Example: https://play.tailwindcss.com/m8wgZ4ATz3?file=css
