### PR TITLE
fix(countdown): fix safari miss-alignment when zoom does not result in an integer for line height

### DIFF
--- a/packages/daisyui/src/components/countdown.css
+++ b/packages/daisyui/src/components/countdown.css
@@ -1,7 +1,8 @@
 .countdown {
   @apply inline-flex;
   &.countdown {
-    line-height: 1em;
+    --em: round(up, 1em, 1px);
+    line-height: var(--em);
   }
 
   & > * {
@@ -19,7 +20,6 @@
       1
     );
     --first-digits: calc(round(to-zero, var(--value-v) / 10, 1));
-    --em: round(up, calc(1em * 1px), 1);
     height: var(--em);
     width: calc(1ch + var(--show-tens) * 1ch + var(--show-hundreds) * 1ch);
     direction: ltr;


### PR DESCRIPTION
safari rounds 1em when used in height but not when used in top

close #3872
