### PR TITLE
fix: do not show the line before for first step in horizontal orientation

### DIFF
--- a/packages/daisyui/src/components/steps.css
+++ b/packages/daisyui/src/components/steps.css
@@ -131,7 +131,6 @@
       &:before {
         @apply h-2 w-full;
         translate: 0;
-        content: "";
         margin-inline-start: -100%;
       }
       [dir="rtl"] &:before {


### PR DESCRIPTION
Can be observed on https://daisyui.com/components/steps/#responsive-vertical-on-small-screen-horizontal-on-large-screen