### PR TITLE
feat: add modifier validator-hint-hidden to hide the hint when not visible

### DIFF
--- a/packages/daisyui/src/components/validator.css
+++ b/packages/daisyui/src/components/validator.css
@@ -22,7 +22,7 @@
         --input-color: var(--color-error);
       }
       & ~ .validator-hint {
-        @apply text-error visible block;
+        @apply text-error visible;
       }
     }
   }
@@ -31,5 +31,17 @@
   @layer daisyui.component {
     @apply invisible mt-2;
     font-size: 0.75rem;
+  }
+}
+
+/* This stays in utilities layer so it unhides hidden validator-hints */
+.validator {
+  &:user-invalid,
+  &:has(:user-invalid),
+  &[aria-invalid]:not([aria-invalid="false"]),
+  &:has([aria-invalid]:not([aria-invalid="false"])) {
+    & ~ .validator-hint {
+      display: revert-layer;
+    }
   }
 }


### PR DESCRIPTION
using tw hidden does not work anymore because it has higher priority
example: https://play.tailwindcss.com/0DpbDoVzqO

I could not update the translation for `fa.json`

close #4188
