### PR TITLE
fix: use --tw-content for before/after content

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -71,7 +71,8 @@
     } */
 
       &::after {
-        content: attr(aria-label);
+        --tw-content: attr(aria-label);
+        content: var(--tw-content);
       }
     }
     &:where(input:checked:not(.filter .btn)) {

--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -408,14 +408,16 @@
       .pika-prev {
         left: 0;
         &:before {
-          content: "‹";
+          --tw-content: "‹";
+          content: var(--tw-content);
         }
       }
 
       .pika-next {
         right: 0;
         &:before {
-          content: "›";
+          --tw-content: "›";
+          content: var(--tw-content);
         }
       }
 

--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -130,7 +130,8 @@
     &[open] {
       &.collapse-plus {
         > .collapse-title:after {
-          content: "−";
+          --tw-content: "−";
+          content: var(--tw-content);
         }
       }
     }
@@ -138,20 +139,23 @@
     &.collapse-open {
       &.collapse-plus {
         > .collapse-title:after {
-          content: "−";
+          --tw-content: "−";
+          content: var(--tw-content);
         }
       }
     }
 
     &[tabindex].collapse-plus:focus:not(.collapse-close) {
       > .collapse-title:after {
-        content: "−";
+        --tw-content: "−";
+        content: var(--tw-content);
       }
     }
 
     &.collapse-plus:not(.collapse-close) {
       > input:is([type="checkbox"], [type="radio"]):checked ~ .collapse-title:after {
-        content: "−";
+        --tw-content: "−";
+        content: var(--tw-content);
       }
     }
   }
@@ -255,7 +259,8 @@
       }
       top: 0.9rem;
       inset-inline-end: 1.4rem;
-      content: "+";
+      --tw-content: "+";
+      content: var(--tw-content);
       pointer-events: none;
     }
   }

--- a/packages/daisyui/src/components/countdown.css
+++ b/packages/daisyui/src/components/countdown.css
@@ -27,7 +27,8 @@
       &:before,
       &:after {
         @apply visible absolute overflow-x-clip;
-        content: "00\A 01\A 02\A 03\A 04\A 05\A 06\A 07\A 08\A 09\A 10\A 11\A 12\A 13\A 14\A 15\A 16\A 17\A 18\A 19\A 20\A 21\A 22\A 23\A 24\A 25\A 26\A 27\A 28\A 29\A 30\A 31\A 32\A 33\A 34\A 35\A 36\A 37\A 38\A 39\A 40\A 41\A 42\A 43\A 44\A 45\A 46\A 47\A 48\A 49\A 50\A 51\A 52\A 53\A 54\A 55\A 56\A 57\A 58\A 59\A 60\A 61\A 62\A 63\A 64\A 65\A 66\A 67\A 68\A 69\A 70\A 71\A 72\A 73\A 74\A 75\A 76\A 77\A 78\A 79\A 80\A 81\A 82\A 83\A 84\A 85\A 86\A 87\A 88\A 89\A 90\A 91\A 92\A 93\A 94\A 95\A 96\A 97\A 98\A 99\A";
+        --tw-content: "00\A 01\A 02\A 03\A 04\A 05\A 06\A 07\A 08\A 09\A 10\A 11\A 12\A 13\A 14\A 15\A 16\A 17\A 18\A 19\A 20\A 21\A 22\A 23\A 24\A 25\A 26\A 27\A 28\A 29\A 30\A 31\A 32\A 33\A 34\A 35\A 36\A 37\A 38\A 39\A 40\A 41\A 42\A 43\A 44\A 45\A 46\A 47\A 48\A 49\A 50\A 51\A 52\A 53\A 54\A 55\A 56\A 57\A 58\A 59\A 60\A 61\A 62\A 63\A 64\A 65\A 66\A 67\A 68\A 69\A 70\A 71\A 72\A 73\A 74\A 75\A 76\A 77\A 78\A 79\A 80\A 81\A 82\A 83\A 84\A 85\A 86\A 87\A 88\A 89\A 90\A 91\A 92\A 93\A 94\A 95\A 96\A 97\A 98\A 99\A";
+        content: var(--tw-content);
         font-variant-numeric: tabular-nums;
         white-space: pre;
         text-align: end;

--- a/packages/daisyui/src/components/diff.css
+++ b/packages/daisyui/src/components/diff.css
@@ -71,7 +71,8 @@
     }
     @supports (-webkit-overflow-scrolling: touch) and (overflow: -webkit-paged-x) {
       &:after {
-        content: none;
+        --tw-content: none;
+        content: var(--tw-content);
       }
     }
   }

--- a/packages/daisyui/src/components/filter.css
+++ b/packages/daisyui/src/components/filter.css
@@ -18,7 +18,8 @@
       &.filter-reset {
         @apply aspect-square;
         &::after {
-          content: "×";
+          --tw-content: "×";
+          content: var(--tw-content);
         }
       }
     }

--- a/packages/daisyui/src/components/menu.css
+++ b/packages/daisyui/src/components/menu.css
@@ -147,7 +147,8 @@
 
     & > li > details > ul {
       &:before {
-        content: none;
+        --tw-content: none;
+        content: var(--tw-content);
       }
     }
 

--- a/packages/daisyui/src/components/mockup.css
+++ b/packages/daisyui/src/components/mockup.css
@@ -23,7 +23,8 @@
 
       &[data-prefix] {
         &:before {
-          content: attr(data-prefix);
+          --tw-content: attr(data-prefix);
+          content: var(--tw-content);
           @apply inline-block w-8 text-right opacity-50;
         }
       }
@@ -49,7 +50,8 @@
 
     pre[data-prefix] {
       &:before {
-        content: attr(data-prefix);
+        --tw-content: attr(data-prefix);
+        content: var(--tw-content);
         @apply inline-block text-right;
       }
     }
@@ -62,7 +64,8 @@
 
     pre[data-prefix] {
       &:before {
-        content: attr(data-prefix);
+        --tw-content: attr(data-prefix);
+        content: var(--tw-content);
         @apply inline-block text-right;
       }
     }

--- a/packages/daisyui/src/components/steps.css
+++ b/packages/daisyui/src/components/steps.css
@@ -16,14 +16,14 @@
         border: 1px solid;
         color: var(--step-bg);
         background-color: var(--step-bg);
-        --tw-content: "";
-        content: var(--tw-content);
+        content: "";
         margin-inline-start: -100%;
       }
 
       > .step-icon,
       &:not(:has(.step-icon)):after {
-        content: counter(step);
+        --tw-content: counter(step);
+        content: var(--tw-content);
         counter-increment: step;
         z-index: 1;
         color: var(--step-fg);
@@ -33,11 +33,13 @@
       }
 
       &:first-child:before {
-        content: none;
+        --tw-content: none;
+        content: var(--tw-content);
       }
 
       &[data-content]:after {
-        content: attr(data-content);
+        --tw-content: attr(data-content);
+        content: var(--tw-content);
       }
     }
   }

--- a/packages/daisyui/src/components/tab.css
+++ b/packages/daisyui/src/components/tab.css
@@ -32,7 +32,8 @@
       @apply min-w-fit;
 
       &:after {
-        content: attr(aria-label);
+        --tw-content: attr(aria-label);
+        content: var(--tw-content);
       }
     }
     &:is(label) {
@@ -121,8 +122,7 @@
       position: relative;
       border-radius: var(--radius-field);
       &:before {
-        --tw-content: "";
-        content: var(--tw-content);
+        content: "";
         background-color: var(--tab-border-color);
         transition: background-color 0.2s ease;
         width: 80%;


### PR DESCRIPTION
tailwind sets by default `content: var(--tw-content)` when classes are appliad with `:before/:after`

as we have moved daisy to use lower priority than utilities, we need to make sure our content is used even when using utility classes

close #4196