### PR TITLE
Update Phoenix install example

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/phoenix/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/phoenix/+page.md
@@ -15,10 +15,11 @@ desc: How to install Tailwind CSS and daisyUI in a Elixir Phoenix project
 
 Install Elixir according to the [official Elixir documentation](https://elixir-lang.org/install.html)
 
-Create a new Phoenix project in the current directory.  
+Create a new Phoenix project in the current directory.
 
 ```sh:Terminal
-mix phx.new ./ --no-ecto
+mix phx.new my_app --no-ecto
+cd my_app
 ```
 Here we are using the `--no-ecto` flag to skip the database setup, just for demonstration purposes.
 


### PR DESCRIPTION
The command `mix phx.new ./ --no-ecto` results into:

> ** (Mix) Application name must start with a letter and have only lowercase letters, numbers and underscore, got: "Projects". The application name is inferred from the path, if you'd like to explicitly name the application then use the `--app APP` option.

because my directory is named "Projects" (note the uppercase letter).

This PR updates the command to use an explicit name (`my_app`).