### PR TITLE
fix: allow outline on all activators for dropdown, not only summary

### DIFF
--- a/packages/daisyui/src/components/dropdown.css
+++ b/packages/daisyui/src/components/dropdown.css
@@ -3,7 +3,7 @@
     @apply relative inline-block;
     position-area: var(--anchor-v, bottom) var(--anchor-h, span-right);
 
-    & > *:not(:has(~ .dropdown-content)):focus {
+    & > *:not(:has(~ [class*="dropdown-content"])):focus {
       @apply outline-hidden;
     }
     .dropdown-content {


### PR DESCRIPTION
All direct children of dropdown before a dropdown-content should show focus indicators

example not working: https://play.tailwindcss.com/AoGt1QaprX