### PR TITLE
fix: menu disabled visual and docs closes: #4251

### DIFF
--- a/packages/daisyui/src/components/menu.css
+++ b/packages/daisyui/src/components/menu.css
@@ -111,7 +111,22 @@
       }
 
       &.menu-disabled {
-        @apply text-base-content/20 pointer-events-none;
+        @apply text-base-content/20 pointer-events-none cursor-not-allowed;
+
+        & > *:not(ul) {
+          @apply cursor-not-allowed;
+
+          &:hover,
+          &:focus,
+          &:focus-visible,
+          &:active,
+          &.menu-active {
+            @apply outline-hidden bg-transparent;
+            box-shadow: none;
+            color: inherit;
+            cursor: not-allowed;
+          }
+        }
       }
     }
     .dropdown:focus-within {

--- a/packages/docs/src/routes/(routes)/components/menu/+page.md
+++ b/packages/docs/src/routes/(routes)/components/menu/+page.md
@@ -434,6 +434,10 @@ classnames:
 </ul>
 ```
 
+> :INFO:
+>
+> `menu-disabled` provides visual styling only. To prevent keyboard focus, add `inert` attribute or `tabindex="-1"` to the disabled item.
+
 
 ### ~Menu with icons
 <ul class="menu bg-base-200 w-56 rounded-box">


### PR DESCRIPTION
## Problem

Fixes #4251

Disabled menu items (with `menu-disabled` class) only have visual opacity styling but still show focus states when tabbing into them, which is confusing

Also, the CSS cannot prevent keyboard focus, only HTML attributes like `inert` or `tabindex="-1"` can do that, and docs do not mention this

## Fix

1. Added CSS rules to completely remove all interactive visual feedback (hover, focus, active states) from disabled menu items
2. Added documentation note explaining that `menu-disabled` provides visual styling only and users should add `inert` or `tabindex="-1"` for full keyboard accessibility

## Testing

Tested in playground - disabled items no longer show any hover/focus/active visual feedback