### PR TITLE
fix: calendar disabled hover closes: #4253 

### DIFF
--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -110,6 +110,11 @@
       &:hover {
         background-color: var(--color-base-200);
       }
+      &:disabled:hover,
+      &[aria-disabled="true"]:hover {
+        background-color: transparent;
+        cursor: not-allowed;
+      }
     }
     .rdp-caption_label {
       z-index: 1;


### PR DESCRIPTION
## Problem

Fixes #4253 

Disabled calendar dates in react-day-picker show hover background color, making them appear interactive when they cannot be clicked which creates confusing UX

## Fix

Added CSS rule to remove hover background from disabled date buttons (`:disabled:hover` and `[aria-disabled="true"]:hover`) and set cursor to `not-allowed`

## Testing

Tested in playground at disabled dates no longer show hover background color