### PR TITLE
fix: prevent empty tooltips from showing on focus closes #4254

### DIFF
--- a/packages/daisyui/src/components/tooltip.css
+++ b/packages/daisyui/src/components/tooltip.css
@@ -46,7 +46,7 @@
     &.tooltip-open,
     &[data-tip]:not([data-tip=""]):hover,
     &:not(:has(.tooltip-content:empty)):has(.tooltip-content):hover,
-    &:has(:focus-visible) {
+    &[data-tip]:not([data-tip=""]):has(:focus-visible) {
       > .tooltip-content,
       &[data-tip]:before,
       &:after {


### PR DESCRIPTION
  ## Problem

  Fixes #4254

  Empty tooltips (with `data-tip=""`) appear as small boxes when child elements gain focus via Tab navigation. The hover selector correctly checks for empty strings, but the focus-visible selector does not.

  ## Fix

  Added empty check to the focus-visible selector: changed `&:has(:focus-visible)` to `&[data-tip]:not([data-tip=""]):has(:focus-visible)` to match the hover behavior.

  ## Testing

  Tested in playground at empty tooltips no longer appear when tabbing through elements