### PR TITLE
docs: update menu disabled items to W3C recommended pattern closes: #4251

### DIFF
--- a/packages/docs/src/routes/(routes)/components/menu/+page.md
+++ b/packages/docs/src/routes/(routes)/components/menu/+page.md
@@ -421,16 +421,16 @@ classnames:
 
 ### ~Menu with disabled items
 <ul class="menu bg-base-200 w-56 rounded-box">
-  <li><button>Enabled item</button></li>
-  <li class="menu-disabled"><button>disabled item</button></li>
-  <li class="menu-disabled"><button>disabled item</button></li>
+  <li><a href="#enabled">Enabled item</a></li>
+  <li class="menu-disabled"><a role="link" aria-disabled="true">disabled item</a></li>
+  <li class="menu-disabled"><a role="link" aria-disabled="true">disabled item</a></li>
 </ul>
 
 ```html
 <ul class="$$menu bg-base-200 $$rounded-box w-56">
-  <li><a>Enabled item</a></li>
-  <li class="$$menu-disabled"><a>disabled item</a></li>
-  <li class="$$menu-disabled"><a>disabled item</a></li>
+  <li><a href="#enabled">Enabled item</a></li>
+  <li class="$$menu-disabled"><a role="link" aria-disabled="true">disabled item</a></li>
+  <li class="$$menu-disabled"><a role="link" aria-disabled="true">disabled item</a></li>
 </ul>
 ```
 


### PR DESCRIPTION
  ## Problem

  Addresses #4251 

  The previous docs example for disabled menu items didn't follow the W3C recommended pattern for disabled links.

  ## Solution

  Updated menu disabled items documentation to use the W3C ARIA pattern:
  - Remove `href` attribute from disabled links (creates placeholder link)
  - Add `role="link"` to maintain link semantics
  - Add `aria-disabled="true"` to communicate disabled state to assistive technologies

  This matches the official W3C recommendation: https://w3c.github.io/html-aria/#example-communicate-a-disabled-link-with-aria

  ## Changes

  Updated the "Menu with disabled items" example in docs to show:
  ```html
  <li class="menu-disabled"><a role="link" aria-disabled="true">disabled item</a></li>
```
  Instead of:
  ```html
  <li class="menu-disabled"><a>disabled item</a></li>
  ```