### PR TITLE
feat: button improvements and cleanup

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -210,7 +210,8 @@
   }
 }
 
-.btn-outline {
+.btn-outline,
+.btn-dash {
   @layer daisyui.modifier {
     &:not(
       .btn-active,
@@ -242,36 +243,7 @@
 }
 
 .btn-dash {
-  @layer daisyui.modifier {
-    &:not(
-      .btn-active,
-      :hover,
-      :active:focus,
-      :focus-visible,
-      input:checked:not(.filter .btn),
-      :disabled,
-      [disabled],
-      .btn-disabled
-    ) {
-      --btn-shadow: "";
-      --btn-bg: #0000;
-      --btn-fg: var(--btn-color);
-      --btn-border: var(--btn-color);
-      --btn-noise: none;
-      border-style: dashed;
-    }
-
-    @media (hover: none) {
-      &:not(.btn-active, :active, :focus-visible, input:checked:not(.filter .btn)):hover {
-        --btn-shadow: "";
-        --btn-bg: #0000;
-        --btn-fg: var(--btn-color);
-        --btn-border: var(--btn-color);
-        --btn-noise: none;
-        border-style: dashed;
-      }
-    }
-  }
+  border-style: dashed;
 }
 
 .btn-soft {


### PR DESCRIPTION
feat: unify styles for btn-outline and btn-dash
  - from my tests tailwind accepts this and creates classes modified with variants as required **!!! if you think this is not a good ideea please let me know !!!**

feat: respect input:checked for btn-soft, cleanup
feat: respect input:checked for btn-ghost
feat: cleanup btn-dash
feat: cleanup btn-outline
feat: use color defined by modifier for btn-ghost
feat: remove rules for :hover on disabled button because it already has pointer-events-none
  - disabled btn cannot have hover because of pointer-events-none
  - disabled btn cannot have hover because of pointer-events-none
  - disabled btn cannot have hover because of pointer-events-none
  - disabled btn cannot have hover because of pointer-events-none

feat: use color defined by modifier for btn-link, do not color disabled links, do not remove underline
  - I think removing underline on mobile on hover was introduced by mistake - there is nothing else to suggest that underline should be removed

feat: do not remove underline from btn-link when it is in `prose not-prose`


example: https://play.tailwindcss.com/Gk9Jv0Vs6v?file=css