### PR TITLE
fix(button): move color classes in layer l3 (component)

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -110,56 +110,56 @@
 }
 
 .btn-primary {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-primary);
     --btn-fg: var(--color-primary-content);
   }
 }
 
 .btn-secondary {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-secondary);
     --btn-fg: var(--color-secondary-content);
   }
 }
 
 .btn-accent {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-accent);
     --btn-fg: var(--color-accent-content);
   }
 }
 
 .btn-neutral {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-neutral);
     --btn-fg: var(--color-neutral-content);
   }
 }
 
 .btn-info {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-info);
     --btn-fg: var(--color-info-content);
   }
 }
 
 .btn-success {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-success);
     --btn-fg: var(--color-success-content);
   }
 }
 
 .btn-warning {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-warning);
     --btn-fg: var(--color-warning-content);
   }
 }
 
 .btn-error {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-error);
     --btn-fg: var(--color-error-content);
   }


### PR DESCRIPTION
- only set tw-content if aria-label is present to keep tw-content from filter reset button (does not check if aria-label is empty - but I would say it's a user decision)

example: https://play.tailwindcss.com/uM3Yd12gIl
please let me know if some combination does not look as expected

close #4288