### PR TITLE
fix(root color): try to better split the concerns about background color

### DIFF
--- a/packages/daisyui/src/base/rootcolor.css
+++ b/packages/daisyui/src/base/rootcolor.css
@@ -1,6 +1,6 @@
 :root,
 [data-theme] {
-  background-color: var(--root-bg, var(--color-base-100));
+  background: var(--page-scroll-bg, var(--root-bg));
   color: var(--color-base-content);
 }
 

--- a/packages/daisyui/src/base/rootscrollgutter.css
+++ b/packages/daisyui/src/base/rootscrollgutter.css
@@ -1,6 +1,7 @@
 :root {
-  --page-scroll-bg-on: linear-gradient(var(--root-bg), var(--root-bg))
-    color-mix(in srgb, var(--root-bg), oklch(0% 0 0) calc(var(--page-has-backdrop, 0) * 40%));
+  background: var(--page-scroll-bg, var(--root-bg));
+  --page-scroll-bg-on: linear-gradient(var(--root-bg, #0000), var(--root-bg, #0000))
+    color-mix(in srgb, var(--root-bg, #0000), oklch(0% 0 0) calc(var(--page-has-backdrop, 0) * 40%));
   --page-scroll-transition-on: background-color 0.3s ease-out;
 
   transition: var(--page-scroll-transition);
@@ -10,11 +11,6 @@
 
   /* CSS if is supported */
   scrollbar-gutter: if(style(--page-has-scroll: 1): var(--page-scroll-gutter, unset) ; else: unset);
-}
-
-/* force higher specificity to override rootcolor */
-:root:root {
-  background: var(--page-scroll-bg, var(--root-bg, var(--color-base-100)));
 }
 
 @keyframes set-page-has-scroll {


### PR DESCRIPTION
- apply the same background in both rootcolor and rootscrollgutter
- removed fallback to --color-base-100 in rootcolor because it is set in the same included file
- if rootcolor is not included then --root-bg is not set so by default background will be transparent, and when we have scroll gutter the scrollbar will be gray
- if rootscrollgutter is not included then we will not have grey on scroll gutter

This is not a fix for the issue, it's just a better separation of concerns between the 2 files

The issue is self-inflicted by setting the bg color in the base layer instead of setting `--root-bg` or setting the background color in a higher priority layer.

ref #4294