### PR TITLE
Update Tailwind CSS installation command

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/vue/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/vue/+page.md
@@ -18,7 +18,7 @@ npm create vite@latest ./ -- --template vue
 ### 2. Install Tailwind CSS and daisyUI
 
 ```sh:Terminal
-npm install tailwindcss@latest @tailwindcss/vite@latest daisyui@latest
+npm install -D tailwindcss@latest @tailwindcss/vite@latest daisyui@latest
 ```
 
 Add Tailwind CSS to Vite config


### PR DESCRIPTION
I updated the installation command to include the -D flag because TailwindCSS, its Vite plugin, and DaisyUI (as I understood) run only during the build process and are not required at runtime.