### PR TITLE
Fix responsive dropdown rendering under content

### DIFF
--- a/packages/docs/src/routes/(routes)/components/navbar/+page.md
+++ b/packages/docs/src/routes/(routes)/components/navbar/+page.md
@@ -431,7 +431,7 @@ classnames:
       <li>
         <details>
           <summary>Parent</summary>
-          <ul class="p-2">
+          <ul class="p-2 bg-base-100 w-40 z-1">
             <li><a>Submenu 1</a></li>
             <li><a>Submenu 2</a></li>
           </ul>


### PR DESCRIPTION
# What does this commit do
 - Update docs example to include `z-1` so it will render dropdown over content instead of under