### PR TITLE
(docs): color picker improve color text representation and make dialog transparent on android

### DIFF
--- a/packages/docs/src/components/ColorPalette.svelte
+++ b/packages/docs/src/components/ColorPalette.svelte
@@ -260,11 +260,9 @@
 
   const reNoDecimals = /\.0+$/
   function toFixed(value, decimals) {
-    if (!value) return '0'
+    if (!value) return "0"
     const text = value.toFixed(decimals)
-    return reNoDecimals.test(text)
-      ? text.split('.')[0]
-      : text
+    return reNoDecimals.test(text) ? text.split(".")[0] : text
   }
 
   // Helper function to generate color value from color state

--- a/packages/docs/src/components/ColorSlider.svelte
+++ b/packages/docs/src/components/ColorSlider.svelte
@@ -411,17 +411,12 @@
   })
 </script>
 
-<div
-  class={[
-    'flex w-full flex-col gap-6 md:col-span-3 md:p-4',
-    isActive ? 'range-is-active' : '',
-  ]}
->
+<div class={["flex w-full flex-col gap-6 md:col-span-3 md:p-4", isActive ? "range-is-active" : ""]}>
   {#each sliderConfigs as config, index (index)}
     <div
       class={[
-        'rounded-box border-base-100/20 h-20 border-2 px-4 pt-8 backdrop-blur-md',
-        isActive ? 'bg-base-100/50' : '',
+        "rounded-box border-base-100/20 h-20 border-2 px-4 pt-8 backdrop-blur-md",
+        isActive ? "bg-base-100/50" : "",
       ]}
     >
       <!-- Moving tooltip above the slider thumb -->
@@ -457,11 +452,21 @@
           config.setter(parseFloat(e.target.value))
           colorState.changed = true
         }}
-        ontouchstart={() => { isActive = true }}
-        ontouchend={() => { isActive = false }}
-        ontouchcancel={() => { isActive = false }}
-        onmousedown={() => { isActive = true }}
-        onmouseup={() => { isActive = false }}
+        ontouchstart={() => {
+          isActive = true
+        }}
+        ontouchend={() => {
+          isActive = false
+        }}
+        ontouchcancel={() => {
+          isActive = false
+        }}
+        onmousedown={() => {
+          isActive = true
+        }}
+        onmouseup={() => {
+          isActive = false
+        }}
         class="range range-xl focus:outline-base-content/10 outline-base-content/10 w-full text-transparent outline [--range-thumb:transparent] focus:outline [&.range::-webkit-slider-thumb]:shadow-[0_0_0_1px_oklch(0_0_0/.3)_inset,0_0_0_2px_oklch(100_0_0)_inset]"
         style={`background: ${generateSliderGradient(config.gradientType, colorState)};`}
       />


### PR DESCRIPTION
- fix ring on selected color in palette on mobiles
- do not add decimals for oklch and hsl if the value is an integer after truncation
- always update hue in oklch (even if chroma is 0)
  - when the color is updated from sliders the hue is not changed when changing chroma
  - when a color is picked from palette the hue slider should reflect selection
  - when text value of the color is changed the hue slider should reflect selection
- make dialog also hide on android when range input is dragged
  - on android the range input loses :active when dragged
  - it needs attaching events for touch and mouse because pointercancel is called on move (even if setPointerCapture is used - probably because svelte re-renders/modifies the control)

 