### PR TITLE
fix(chat): set explicit grid rows template as min-content to avoid height limitation to height screen on Safari

### DIFF
--- a/packages/daisyui/src/components/chat.css
+++ b/packages/daisyui/src/components/chat.css
@@ -1,6 +1,6 @@
 .chat {
   @layer daisyui.l1.l2.l3 {
-    @apply grid gap-x-3 py-1;
+    @apply grid auto-rows-min gap-x-3 py-1;
     --mask-chat: url("data:image/svg+xml,%3csvg width='13' height='13' xmlns='http://www.w3.org/2000/svg'%3e%3cpath fill='black' d='M0 11.5004C0 13.0004 2 13.0004 2 13.0004H12H13V0.00036329L12.5 0C12.5 0 11.977 2.09572 11.8581 2.50033C11.6075 3.35237 10.9149 4.22374 9 5.50036C6 7.50036 0 10.0004 0 11.5004Z'/%3e%3c/svg%3e");
   }
 }


### PR DESCRIPTION
ref: https://github.com/saadeghi/daisyui/issues/3712#issuecomment-3599503502

example: https://play.tailwindcss.com/WRMtKOy4m3?file=css