### PR TITLE
Fix rules priority for .drawer-end and .drawer-open

### DIFF
--- a/packages/daisyui/src/components/drawer.css
+++ b/packages/daisyui/src/components/drawer.css
@@ -146,18 +146,20 @@
         > .drawer-overlay {
           @apply cursor-default bg-transparent;
         }
-
-        > :not(.drawer-overlay) {
-          translate: 0%;
-
-          [dir="rtl"] & {
-            translate: 0%;
-          }
-        }
       }
 
       &:checked ~ .drawer-side {
         @apply pointer-events-auto visible;
+      }
+    }
+  }
+
+  @layer daisyui.l1 {
+    > .drawer-toggle ~ .drawer-side > :not(.drawer-overlay) {
+      translate: 0%;
+
+      [dir="rtl"] & {
+        translate: 0%;
       }
     }
   }


### PR DESCRIPTION
- move .drawer-open translate in daisyui.l1 layer to increase priority over .drawer-end
- some cleanup on redundant universal selector (*)
- some cleanup on redundant & before > and ~

example: https://play.tailwindcss.com/NyAYWDlRm0

close #4331