### PR TITLE
(docs): Fix neutral-content color description

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/colors/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/colors/+page.md
@@ -112,7 +112,7 @@ _Using semantic color names_
 | <span class="badge bg-accent"></span>            | accent            | `--color-accent`            | Accent brand color, The optional, accent color of your brand       |
 | <span class="badge bg-accent-content"></span>    | accent-content    | `--color-accent-content`    | Foreground content color to use on `accent` color <br/><br/>       |
 | <span class="badge bg-neutral"></span>           | neutral           | `--color-neutral`           | Neutral dark color, For not-saturated parts of UI                  |
-| <span class="badge bg-neutral-content"></span>   | neutral-content   | `--color-neutral-content`   | Foreground content color to use on neutral color <br/><br/>        |
+| <span class="badge bg-neutral-content"></span>   | neutral-content   | `--color-neutral-content`   | Foreground content color to use on `neutral` color <br/><br/>      |
 | <span class="badge bg-base-100"></span>          | base-100          | `--color-base-100`          | Base surface color of page, used for blank backgrounds             |
 | <span class="badge bg-base-200"></span>          | base-200          | `--color-base-200`          | Base color, darker shade, to create elevations                     |
 | <span class="badge bg-base-300"></span>          | base-300          | `--color-base-300`          | Base color, even more darker shade, to create elevations           |


### PR DESCRIPTION
- Fix typo in color documentation.