### PR TITLE
fix(collapse): add transition for `min-height`

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -184,6 +184,7 @@
         content-visibility 0.2s allow-discrete,
         visibility 0.2s allow-discrete,
         min-height 0.2s ease-out allow-discrete,
+        padding 0.1s ease-out 20ms,
         background-color 0.2s ease-out;
     }
   }
@@ -198,6 +199,7 @@
           content-visibility 0.2s allow-discrete,
           visibility 0.2s allow-discrete,
           min-height 0.2s ease-out allow-discrete,
+          padding 0.1s ease-out 20ms,
           background-color 0.2s ease-out,
           height 0.2s;
         height: 0;


### PR DESCRIPTION
- firefox ignores grid-row height and transitions directly to full min-height
- delay start and shorten the duration of padding transition so that it is not so visible on the end of open/close

example: https://play.tailwindcss.com/9yLVxz7jaE?file=css

close #2615