### PR TITLE
fix(join): borders and outline for elements inside join

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -46,7 +46,6 @@
       outline: 2px solid var(--input-color);
       outline-offset: 2px;
       isolation: isolate;
-      z-index: 1;
     }
 
     /* increase font size in iOS so the page won't zoom */

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -62,7 +62,6 @@
       outline: 2px solid var(--input-color);
       outline-offset: 2px;
       isolation: isolate;
-      z-index: 1;
     }
 
     &:has(> select[disabled]),

--- a/packages/daisyui/src/utilities/join.css
+++ b/packages/daisyui/src/utilities/join.css
@@ -65,6 +65,16 @@
       --join-ee: var(--radius-field);
     }
   }
+
+  > :where(:focus, :has(:focus)) {
+    z-index: 1;
+  }
+
+  @media (hover: hover) {
+    > :where(.btn:hover, :has(.btn:hover)) {
+      isolation: isolate;
+    }
+  }
 }
 
 .join-item {


### PR DESCRIPTION
- revert `z-index: 1` on input and select
- use the approach of increasing z-index for all direct children of `.join` that have focus inside. That way `.indicator` also works as expected (https://play.tailwindcss.com/LIjTRtOUTm?file=css).

The other approach was to increase z-index for `.join-item` that has focus inside, but it will break when using `.indicator` (https://play.tailwindcss.com/G9kR2UpdSr?file=css).

close #4320