### PR TITLE
fix: prevent CSS variable bleeding in nested tabs

### DIFF
--- a/packages/daisyui/src/components/tab.css
+++ b/packages/daisyui/src/components/tab.css
@@ -1,9 +1,12 @@
 .tabs {
   @layer daisyui.l1.l2.l3 {
     @apply flex flex-wrap;
+    /* Reset inheritable properties to prevent bleeding from parent .tabs */
     --tabs-height: auto;
     --tabs-direction: row;
     --tab-height: calc(var(--size-field, 0.25rem) * 10);
+    --tab-p: 0.75rem;
+    --tab-radius-min: calc(0.75rem - var(--border));
     height: var(--tabs-height);
     flex-direction: var(--tabs-direction);
   }
@@ -23,10 +26,8 @@
     --tab-radius-min: calc(0.75rem - var(--border));
     --tab-radius-limit: min(var(--radius-field), var(--tab-radius-min));
     --tab-radius-grad:
-      #0000 calc(69% - var(--border)),
-      var(--tab-border-color) calc(69% - var(--border) + 0.25px),
-      var(--tab-border-color) 69%,
-      var(--tab-bg) calc(69% + 0.25px);
+      #0000 calc(69% - var(--border)), var(--tab-border-color) calc(69% - var(--border) + 0.25px),
+      var(--tab-border-color) 69%, var(--tab-bg) calc(69% + 0.25px);
     border-color: #0000;
     order: var(--tab-order);
     height: var(--tab-height);
@@ -491,8 +492,8 @@
       /* Compensate for p-1 */
       height: calc(100% - var(--tab-height) + var(--border) - 0.5rem);
       border-radius: calc(
-        min(var(--tab-height) / 2, var(--radius-field)) +
-          min(0.25rem, var(--tabs-box-radius)) - var(--border)
+        min(var(--tab-height) / 2, var(--radius-field)) + min(0.25rem, var(--tabs-box-radius)) -
+          var(--border)
       );
     }
   }


### PR DESCRIPTION
## Summary

Fixes #4200 - Nested tabs inherit styles from parent tabs

## Problem

When nesting `.tabs` components inside each other, CSS custom properties like `--tab-p` and `--tab-radius-min` were inheriting from parent `.tabs` elements to nested `.tabs` elements. This caused style bleeding where nested tabs would incorrectly inherit sizing and styling from their parent tabs.

For example, if a parent tab was `.tabs-lg`, the nested tabs would also become large because they inherited the `--tab-height` value from the parent.

## Solution

Reset all inheritable CSS variables in the base `.tabs` class so that each `.tabs` element starts with its own default values instead of potentially inheriting from a parent `.tabs`:

```css
.tabs {
  @layer daisyui.l1.l2.l3 {
    @apply flex flex-wrap;
    /* Reset inheritable properties to prevent bleeding from parent .tabs */
    --tabs-height: auto;
    --tabs-direction: row;
    --tab-height: calc(var(--size-field, 0.25rem) * 10);
    --tab-p: 0.75rem;
    --tab-radius-min: calc(0.75rem - var(--border));
    height: var(--tabs-height);
    flex-direction: var(--tabs-direction);
  }
}
```

## Testing

- All existing tests pass
- Added specific tests for the nested tabs fix that verify CSS variable resets exist
- Build succeeds without any errors

## Related

- Discussion: #4200
- Related PR: #4213 (draft by @pdanpdan with different approach)