### PR TITLE
fix(rootcolor): only apply the background image to :root; improve all root(color|scrolllock|scrollgutter)

### DIFF
--- a/packages/daisyui/src/base/rootcolor.css
+++ b/packages/daisyui/src/base/rootcolor.css
@@ -5,7 +5,7 @@
 }
 
 :root {
-  background: var(--page-scroll-bg, var(--root-bg));
+  background-color: var(--page-scroll-bg, var(--root-bg));
 }
 
 :where(:root, [data-theme]) {

--- a/packages/daisyui/src/base/rootscrollgutter.css
+++ b/packages/daisyui/src/base/rootscrollgutter.css
@@ -1,21 +1,21 @@
 :root {
-  background: var(--page-scroll-bg, var(--root-bg));
-  --page-scroll-bg-on: linear-gradient(var(--root-bg, #0000), var(--root-bg, #0000))
+  --page-has-backdrop: var(--page-scroll-lock) 1;
+  --page-scroll-bg: var(--page-scroll-lock)
     color-mix(in srgb, var(--root-bg, #0000), oklch(0% 0 0) calc(var(--page-has-backdrop, 0) * 40%));
-  --page-scroll-transition-on: background-color 0.3s ease-out;
+  background-image: var(--page-scroll-lock)
+    linear-gradient(var(--root-bg, #0000), var(--root-bg, #0000));
 
-  transition: var(--page-scroll-transition);
+  transition: var(--page-scroll-lock) background-color 0.3s ease-out;
+  animation: var(--page-scroll-lock) set-page-has-scroll forwards;
+  animation-timeline: var(--page-scroll-lock) scroll();
 
-  /* CSS if is not supported */
-  scrollbar-gutter: var(--page-scroll-gutter, unset);
-
-  /* CSS if is supported */
-  scrollbar-gutter: if(style(--page-has-scroll: 1): var(--page-scroll-gutter, unset) ; else: unset);
+  --page-has-scroll: initial;
+  scrollbar-gutter: var(--page-has-scroll) var(--page-scroll-lock) stable;
 }
 
 @keyframes set-page-has-scroll {
   0%,
   to {
-    --page-has-scroll: 1;
+    --page-has-scroll: ;
   }
 }

--- a/packages/daisyui/src/base/rootscrolllock.css
+++ b/packages/daisyui/src/base/rootscrolllock.css
@@ -1,3 +1,8 @@
+:root {
+  --page-scroll-lock: initial;
+  --page-overflow: var(--page-scroll-lock) hidden;
+}
+
 /* force higher specificity */
 :root:not(span) {
   overflow: var(--page-overflow);

--- a/packages/daisyui/src/components/drawer.css
+++ b/packages/daisyui/src/components/drawer.css
@@ -59,13 +59,7 @@
     }
 
     :where(:root:has(&:checked)) {
-      --page-has-backdrop: 1;
-      --page-overflow: hidden;
-      --page-scroll-bg: var(--page-scroll-bg-on);
-      --page-scroll-gutter: stable;
-      --page-scroll-transition: var(--page-scroll-transition-on);
-      animation: set-page-has-scroll forwards;
-      animation-timeline: scroll();
+      --page-scroll-lock: ;
     }
   }
 
@@ -121,13 +115,7 @@
       }
 
       :root:has(&) {
-        --page-overflow: revert-layer;
-        --page-scroll-gutter: revert-layer;
-        --page-scroll-bg: revert-layer;
-        --page-scroll-transition: revert-layer;
-        --page-has-backdrop: revert-layer;
-        animation: revert-layer;
-        animation-timeline: revert-layer;
+        --page-scroll-lock: revert-layer;
       }
     }
   }

--- a/packages/daisyui/src/components/modal.css
+++ b/packages/daisyui/src/components/modal.css
@@ -34,13 +34,7 @@
       }
 
       :root:has(&) {
-        --page-has-backdrop: 1;
-        --page-overflow: hidden;
-        --page-scroll-bg: var(--page-scroll-bg-on);
-        --page-scroll-gutter: stable;
-        --page-scroll-transition: var(--page-scroll-transition-on);
-        animation: set-page-has-scroll forwards;
-        animation-timeline: scroll();
+        --page-scroll-lock: ;
       }
     }
 


### PR DESCRIPTION
- only :root needs to cover the scrollbar gutter
- applying background to data-theme will break background for themes applied in dropdown (see theme generator - CSS viewer)


Implementation:
- use space variables to avoid need for if()
- use background-image and background-color instead of full background
- only apply changed background-color on :root (avoid changing the backgrounds for themed elements)
- move styles from modal and drawer in rootscrollgutter where they belong, and only control if they need to be applied from modal and drawer

By using `--page-scroll-lock` as flag to trigger the whole scrollock contraption it can be easily also used in other components inside the library or in userland. Maybe we should add it to the documentation.

close #4420 

