### PR TITLE
docs:  replace `class` with `className` for JSX when it is first attribute on a line

### DIFF
--- a/packages/docs/src/lib/actions.svelte.js
+++ b/packages/docs/src/lib/actions.svelte.js
@@ -40,6 +40,8 @@ export const htmlToJsx = (node) => {
     '"0"': "{0}",
     "&lt;!--": "{/*",
     "--&gt;": "*/}",
+    '<span style="color:var(--shiki-attr-name)">class</span>':
+      '<span style="color:var(--shiki-attr-name)">className</span>',
     '<span style="color:var(--shiki-attr-name)"> class</span>':
       '<span style="color:var(--shiki-attr-name)"> className</span>',
     '<span style="color:var(--shiki-attr-name)">  class</span>':


### PR DESCRIPTION
close #4349