### PR TITLE
Fix password input attribute from 'minlength' to 'minLength'

### DIFF
--- a/packages/docs/src/routes/(routes)/components/validator/+page.md
+++ b/packages/docs/src/routes/(routes)/components/validator/+page.md
@@ -54,7 +54,7 @@ classnames:
 ### ~Password requirement validator
 
 <form class="w-full max-w-xs">
-  <input type="password" class="input validator" required placeholder="Password" minlength="8" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).&#123;8,}" title="Must be more than 8 characters, including number, lowercase letter, uppercase letter" />
+  <input type="password" class="input validator" required placeholder="Password" minLength="8" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).&#123;8,}" title="Must be more than 8 characters, including number, lowercase letter, uppercase letter" />
   <p class="validator-hint">
     Must be more than 8 characters, including
     <br/>At least one number


### PR DESCRIPTION
What was changed
- Fixed invalid JSX attribute by replacing `minlength` with `minLength`.

Why
- JSX requires camelCase DOM attributes.
- Using `minlength` in JSX is ignored by React and breaks validation.
