### PR TITLE
feat(rating): make rating size modifiers responsive

### DIFF
--- a/packages/daisyui/src/components/rating.css
+++ b/packages/daisyui/src/components/rating.css
@@ -2,106 +2,89 @@
   @layer daisyui.l1.l2.l3 {
     @apply relative inline-flex align-middle;
 
-    & input {
-      border: none;
-      @apply appearance-none;
-    }
+    --size: var(--size-selector, 0.25rem) * var(--size-mul);
 
-    :where(*) {
-      @apply bg-base-content h-6 w-6 rounded-none opacity-20;
-      @media (prefers-reduced-motion: no-preference) {
-        animation: rating 0.25s ease-out;
-      }
-      &:is(input) {
-        @apply cursor-pointer;
-      }
-    }
-
-    & .rating-hidden {
-      @apply w-2 bg-transparent;
-    }
-
-    input[type="radio"]:checked {
-      background-image: none;
+    input {
+      @apply appearance-none cursor-pointer;
     }
 
     * {
-      &:checked,
-      &[aria-checked="true"],
-      &[aria-current="true"],
-      &:has(~ *:checked, ~ *[aria-checked="true"], ~ *[aria-current="true"]) {
-        @apply opacity-100;
-      }
+      @apply bg-base-content rounded-none opacity-20;
 
-      &:focus-visible {
-        scale: 1.1;
-        @media (prefers-reduced-motion: no-preference) {
-          transition: scale 0.2s ease-out;
-        }
+      width: calc(var(--size) * var(--size-w-mul));
+      height: calc(var(--size));
+
+      @media (prefers-reduced-motion: no-preference) {
+        animation: rating 0.25s ease-out;
       }
     }
 
-    & *:active:focus {
+    .rating-hidden {
+      @apply w-2 bg-transparent;
+    }
+
+    :checked,
+    [aria-checked="true"],
+    [aria-current="true"],
+    :has(~ :checked, ~ [aria-checked="true"], ~ [aria-current="true"]) {
+      @apply opacity-100;
+    }
+
+    :focus-visible {
+      scale: 1.1;
+      @media (prefers-reduced-motion: no-preference) {
+        transition: scale 0.2s ease-out;
+      }
+    }
+
+    :active:focus {
       animation: none;
-    }
-
-    & *:active:focus {
       scale: 1.1;
     }
   }
-
-  @layer daisyui.l1.l2 {
-    &.rating-xs :where(*:not(.rating-hidden)) {
-      @apply size-4;
-    }
-
-    &.rating-sm :where(*:not(.rating-hidden)) {
-      @apply size-5;
-    }
-
-    &.rating-md :where(*:not(.rating-hidden)) {
-      @apply size-6;
-    }
-
-    &.rating-lg :where(*:not(.rating-hidden)) {
-      @apply size-7;
-    }
-
-    &.rating-xl :where(*:not(.rating-hidden)) {
-      @apply size-8;
-    }
-  }
 }
 
 .rating-half {
   @layer daisyui.l1.l2 {
-    :where(*:not(.rating-hidden)) {
-      @apply w-3;
-    }
+    --size-w-mul: 0.5;
   }
 }
 
-.rating-half {
+.rating,
+.rating-full {
   @layer daisyui.l1.l2 {
-    &.rating-xs *:not(.rating-hidden) {
-      @apply w-2;
-    }
+    --size-w-mul: 1;
+  }
+}
 
-    &.rating-sm *:not(.rating-hidden) {
-      @apply w-2.5;
-    }
+.rating-xs {
+  @layer daisyui.l1.l2 {
+    --size-mul: 4;
+  }
+}
 
-    &.rating-md *:not(.rating-hidden) {
-      @apply w-3;
-    }
+.rating-sm {
+  @layer daisyui.l1.l2 {
+    --size-mul: 5;
+  }
+}
 
-    &.rating-lg *:not(.rating-hidden) {
-      @apply w-[.875rem];
-    }
+.rating,
+.rating-md {
+  @layer daisyui.l1.l2 {
+    --size-mul: 6;
+  }
+}
 
-    &.rating-xl *:not(.rating-hidden) {
-      @apply w-4;
-    }
+.rating-lg {
+  @layer daisyui.l1.l2 {
+    --size-mul: 7;
+  }
+}
+
+.rating-xl {
+  @layer daisyui.l1.l2 {
+    --size-mul: 8;
   }
 }
 

--- a/packages/daisyui/src/components/rating.css
+++ b/packages/daisyui/src/components/rating.css
@@ -5,7 +5,7 @@
     --size: var(--size-selector, 0.25rem) * var(--rt-size-mul);
 
     input {
-      @apply appearance-none cursor-pointer;
+      @apply cursor-pointer appearance-none;
     }
 
     * {

--- a/packages/daisyui/src/components/rating.css
+++ b/packages/daisyui/src/components/rating.css
@@ -2,7 +2,7 @@
   @layer daisyui.l1.l2.l3 {
     @apply relative inline-flex align-middle;
 
-    --size: var(--size-selector, 0.25rem) * var(--size-mul);
+    --size: var(--size-selector, 0.25rem) * var(--rt-size-mul);
 
     input {
       @apply appearance-none cursor-pointer;
@@ -11,7 +11,7 @@
     * {
       @apply bg-base-content rounded-none opacity-20;
 
-      width: calc(var(--size) * var(--size-w-mul));
+      width: calc(var(--size) * var(--rt-size-w-mul));
       height: calc(var(--size));
 
       @media (prefers-reduced-motion: no-preference) {
@@ -46,45 +46,45 @@
 
 .rating-half {
   @layer daisyui.l1.l2 {
-    --size-w-mul: 0.5;
+    --rt-size-w-mul: 0.5;
   }
 }
 
 .rating,
 .rating-full {
   @layer daisyui.l1.l2 {
-    --size-w-mul: 1;
+    --rt-size-w-mul: 1;
   }
 }
 
 .rating-xs {
   @layer daisyui.l1.l2 {
-    --size-mul: 4;
+    --rt-size-mul: 4;
   }
 }
 
 .rating-sm {
   @layer daisyui.l1.l2 {
-    --size-mul: 5;
+    --rt-size-mul: 5;
   }
 }
 
 .rating,
 .rating-md {
   @layer daisyui.l1.l2 {
-    --size-mul: 6;
+    --rt-size-mul: 6;
   }
 }
 
 .rating-lg {
   @layer daisyui.l1.l2 {
-    --size-mul: 7;
+    --rt-size-mul: 7;
   }
 }
 
 .rating-xl {
   @layer daisyui.l1.l2 {
-    --size-mul: 8;
+    --rt-size-mul: 8;
   }
 }
 

--- a/packages/docs/src/routes/(routes)/components/rating/+page.md
+++ b/packages/docs/src/routes/(routes)/components/rating/+page.md
@@ -10,6 +10,8 @@ classnames:
   modifier:
   - class: rating-half
     desc: To shows half of the shapes. Useful for half star ratings
+  - class: rating-full
+    desc: To shows full shapes. Useful to override half star ratings
   - class: rating-hidden
     desc: For the first radio to make it hidden so user can clear the rating
   size:
@@ -38,7 +40,7 @@ classnames:
 ### ~Rating
 <div class="rating">
   <input type="radio" name="rating-1" class="mask mask-star" aria-label="1 star" />
-  <input type="radio" name="rating-1" class="mask mask-star" aria-label="2 star" />
+  <input type="radio" name="rating-1" class="mask mask-star" aria-label="2 star" checked="checked" />
   <input type="radio" name="rating-1" class="mask mask-star" aria-label="3 star" />
   <input type="radio" name="rating-1" class="mask mask-star" aria-label="4 star" />
   <input type="radio" name="rating-1" class="mask mask-star" aria-label="5 star" />

--- a/packages/docs/src/routes/(routes)/docs/utilities/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/utilities/+page.md
@@ -178,6 +178,7 @@ If you are using a prefix for daisyUI, these CSS variables will be prefixed with
 |                 | `--range-fill`                | binary, whether to fill the range slider progress or not |
 |                 | `--range-p`                   | padding of the range slider thumb                        |
 |                 | `--size`                      | size of the range slider                                 |
+| Rating          | `--size`                      | size of the rating element                               |
 | Select          | `--input-color`               | color of the input                                       |
 |                 | `--size`                      | size of the select                                       |
 | Tab             | `--tabs-height`               | height of the tabs                                       |


### PR DESCRIPTION
- simplify the CSS code to be based on size variables
- all sizes are based on --size-selector
- added rating-full (to override rating-half)

example: https://play.tailwindcss.com/GOQFYBDAnI?file=css

close #4367