### PR TITLE
feat(form elements): improve input, textarea, select

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -211,6 +211,11 @@
     --in-size-mul: 6;
     --font-size-min: 0.6875rem;
     --spin-my: -1;
+
+    .floating-label:has(&) {
+      --top-mul: 3;
+      --font-size: 0.6875rem;
+    }
   }
 }
 
@@ -219,6 +224,11 @@
     --in-size-mul: 8;
     --font-size-min: 0.75rem;
     --spin-my: -2;
+
+    .floating-label:has(&) {
+      --top-mul: 4;
+      --font-size: 0.75rem;
+    }
   }
 }
 
@@ -228,6 +238,11 @@
     --in-size-mul: 10;
     --font-size-min: 0.875rem;
     --spin-my: -3;
+
+    .floating-label:has(&) {
+      --top-mul: 5;
+      --font-size: 0.875rem;
+    }
   }
 }
 
@@ -236,6 +251,11 @@
     --in-size-mul: 12;
     --font-size-min: 1.125rem;
     --spin-my: -3;
+
+    .floating-label:has(&) {
+      --top-mul: 6;
+      --font-size: 1.125rem;
+    }
   }
 }
 
@@ -244,5 +264,10 @@
     --in-size-mul: 14;
     --font-size-min: 1.375rem;
     --spin-my: -4;
+
+    .floating-label:has(&) {
+      --top-mul: 7;
+      --font-size: 1.375rem;
+    }
   }
 }

--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -1,42 +1,76 @@
 .input {
   @layer daisyui.l1.l2.l3 {
-    cursor: text;
-    border: var(--border) solid #0000;
     @apply bg-base-100 relative inline-flex shrink appearance-none items-center gap-2 px-3 align-middle whitespace-nowrap;
+
+    --size: calc(var(--size-field, 0.25rem) * var(--size-mul));
+    --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
+
+    cursor: text;
     width: clamp(3rem, 20rem, 100%);
     height: var(--size);
-    font-size: max(var(--font-size, 0.875rem), 0.875rem);
+    font-size: max(var(--font-size, 0rem), var(--font-size-min));
     touch-action: manipulation;
     border-start-start-radius: var(--join-ss, var(--radius-field));
     border-start-end-radius: var(--join-se, var(--radius-field));
     border-end-start-radius: var(--join-es, var(--radius-field));
     border-end-end-radius: var(--join-ee, var(--radius-field));
-    border-color: var(--input-color);
+    border: var(--border) solid var(--input-color, #0000);
     box-shadow:
       0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000) inset,
       0 -1px oklch(100% 0 0 / calc(var(--depth) * 0.1)) inset;
-    --size: calc(var(--size-field, 0.25rem) * 10);
-    --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
-    &:where(input) {
-      @apply inline-flex;
-    }
-    :where(input) {
-      @apply inline-flex h-full w-full appearance-none bg-transparent;
+
+    input {
+      @apply h-full w-full appearance-none bg-transparent;
       border: none;
+
+      &::placeholder {
+        /* color and opacity to work with safari */
+        @apply text-base-content opacity-50;
+      }
 
       &:focus,
       &:focus-within {
         @apply outline-hidden;
       }
+
+      &::-webkit-calendar-picker-indicator {
+        inset-inline-end: -0.15em;
+      }
+
+      &::-webkit-inner-spin-button {
+        margin-inline-end: -0.15em;
+      }
     }
 
-    :where(input[type="url"]),
-    :where(input[type="email"]) {
-      direction: ltr;
-    }
+    input&,
+    input {
+      @apply relative inline-flex;
 
-    :where(input[type="date"]) {
-      @apply inline-flex;
+      &[type="url"],
+      &[type="email"] {
+        direction: ltr;
+      }
+
+      &::-webkit-date-and-time-value {
+        text-align: inherit;
+      }
+
+      &::-webkit-inner-spin-button {
+        @apply -me-3;
+        margin-block: calc(var(--spacing) * var(--spin-my));
+      }
+
+      &::-webkit-calendar-picker-indicator {
+        position: absolute;
+        inset-inline-end: 0.75em;
+        width: 1em;
+        height: 1em;
+        cursor: pointer;
+      }
+
+      &::-webkit-color-swatch-wrapper {
+        @apply py-1;
+      }
     }
 
     &:focus,
@@ -61,43 +95,18 @@
     &:has(> input[disabled]),
     &:is(:disabled, [disabled]),
     fieldset:disabled & {
-      @apply border-base-200 bg-base-200 placeholder-base-content text-base-content/40 placeholder-base-content/20 cursor-not-allowed;
+      @apply border-base-200 bg-base-200 text-base-content/40 cursor-not-allowed;
       box-shadow: none;
+
+      &::placeholder,
+      ::placeholder {
+        /* color and opacity to work with safari */
+        @apply text-base-content opacity-20;
+      }
     }
 
     &:has(> input[disabled]) > input[disabled] {
       @apply cursor-not-allowed;
-    }
-
-    &::-webkit-date-and-time-value {
-      text-align: inherit;
-    }
-
-    &[type="number"] {
-      &::-webkit-inner-spin-button {
-        @apply -my-3 -me-3;
-      }
-    }
-
-    &::-webkit-calendar-picker-indicator {
-      position: absolute;
-      inset-inline-end: 0.75em;
-    }
-
-    &:has(> input[type="date"]) {
-      :where(input[type="date"]) {
-        @apply inline-flex;
-        -webkit-appearance: none;
-        appearance: none;
-      }
-
-      input[type="date"]::-webkit-calendar-picker-indicator {
-        position: absolute;
-        inset-inline-end: 0.75em;
-        width: 1em;
-        height: 1em;
-        cursor: pointer;
-      }
     }
   }
 }
@@ -199,65 +208,41 @@
 
 .input-xs {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 6);
-    font-size: max(var(--font-size, 0.6875rem), 0.6875rem);
-
-    &[type="number"] {
-      &::-webkit-inner-spin-button {
-        @apply -my-1 -me-3;
-      }
-    }
+    --size-mul: 6;
+    --font-size-min: 0.6875rem;
+    --spin-my: -1;
   }
 }
 
 .input-sm {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 8);
-    font-size: max(var(--font-size, 0.75rem), 0.75rem);
-
-    &[type="number"] {
-      &::-webkit-inner-spin-button {
-        @apply -my-2 -me-3;
-      }
-    }
+    --size-mul: 8;
+    --font-size-min: 0.75rem;
+    --spin-my: -2;
   }
 }
 
+.input,
 .input-md {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 10);
-    font-size: max(var(--font-size, 0.875rem), 0.875rem);
-
-    &[type="number"] {
-      &::-webkit-inner-spin-button {
-        @apply -my-3 -me-3;
-      }
-    }
+    --size-mul: 10;
+    --font-size-min: 0.875rem;
+    --spin-my: -3;
   }
 }
 
 .input-lg {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 12);
-    font-size: max(var(--font-size, 1.125rem), 1.125rem);
-
-    &[type="number"] {
-      &::-webkit-inner-spin-button {
-        @apply -my-3 -me-3;
-      }
-    }
+    --size-mul: 12;
+    --font-size-min: 1.125rem;
+    --spin-my: -3;
   }
 }
 
 .input-xl {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 14);
-    font-size: max(var(--font-size, 1.375rem), 1.375rem);
-
-    &[type="number"] {
-      &::-webkit-inner-spin-button {
-        @apply -my-4 -me-3;
-      }
-    }
+    --size-mul: 14;
+    --font-size-min: 1.375rem;
+    --spin-my: -4;
   }
 }

--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -2,7 +2,7 @@
   @layer daisyui.l1.l2.l3 {
     @apply bg-base-100 relative inline-flex shrink appearance-none items-center gap-2 px-3 align-middle whitespace-nowrap;
 
-    --size: calc(var(--size-field, 0.25rem) * var(--size-mul));
+    --size: calc(var(--size-field, 0.25rem) * var(--in-size-mul));
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
 
     cursor: text;
@@ -208,7 +208,7 @@
 
 .input-xs {
   @layer daisyui.l1.l2 {
-    --size-mul: 6;
+    --in-size-mul: 6;
     --font-size-min: 0.6875rem;
     --spin-my: -1;
   }
@@ -216,7 +216,7 @@
 
 .input-sm {
   @layer daisyui.l1.l2 {
-    --size-mul: 8;
+    --in-size-mul: 8;
     --font-size-min: 0.75rem;
     --spin-my: -2;
   }
@@ -225,7 +225,7 @@
 .input,
 .input-md {
   @layer daisyui.l1.l2 {
-    --size-mul: 10;
+    --in-size-mul: 10;
     --font-size-min: 0.875rem;
     --spin-my: -3;
   }
@@ -233,7 +233,7 @@
 
 .input-lg {
   @layer daisyui.l1.l2 {
-    --size-mul: 12;
+    --in-size-mul: 12;
     --font-size-min: 1.125rem;
     --spin-my: -3;
   }
@@ -241,7 +241,7 @@
 
 .input-xl {
   @layer daisyui.l1.l2 {
-    --size-mul: 14;
+    --in-size-mul: 14;
     --font-size-min: 1.375rem;
     --spin-my: -4;
   }

--- a/packages/daisyui/src/components/label.css
+++ b/packages/daisyui/src/components/label.css
@@ -20,25 +20,13 @@
 }
 .floating-label {
   @layer daisyui.l1.l2.l3 {
-    @apply relative block;
-    input {
-      @apply block;
-      &::placeholder {
-        transition:
-          top 0.1s ease-out,
-          translate 0.1s ease-out,
-          scale 0.1s ease-out,
-          opacity 0.1s ease-out;
-      }
-    }
-    textarea {
-      &::placeholder {
-        transition:
-          top 0.1s ease-out,
-          translate 0.1s ease-out,
-          scale 0.1s ease-out,
-          opacity 0.1s ease-out;
-      }
+    @apply relative flex;
+    ::placeholder {
+      transition:
+        top 0.1s ease-out,
+        translate 0.1s ease-out,
+        scale 0.1s ease-out,
+        opacity 0.1s ease-out;
     }
     > span {
       @apply bg-base-100 absolute start-3 z-1 px-1 opacity-0;

--- a/packages/daisyui/src/components/label.css
+++ b/packages/daisyui/src/components/label.css
@@ -30,8 +30,8 @@
     }
     > span {
       @apply bg-base-100 absolute start-3 z-1 px-1 opacity-0;
-      font-size: 0.875rem;
-      top: calc(var(--size-field, 0.25rem) * 10 / 2);
+      font-size: var(--font-size, 0.875rem);
+      top: calc(var(--size-field, 0.25rem) * var(--top-mul, 5));
       line-height: 1;
       border-radius: 2px;
       pointer-events: none;
@@ -64,26 +64,6 @@
       > span {
         @apply opacity-0;
       }
-    }
-    &:has(.input-xs, .select-xs, .textarea-xs) span {
-      font-size: 0.6875rem;
-      top: calc(var(--size-field, 0.25rem) * 6 / 2);
-    }
-    &:has(.input-sm, .select-sm, .textarea-sm) span {
-      font-size: 0.75rem;
-      top: calc(var(--size-field, 0.25rem) * 8 / 2);
-    }
-    &:has(.input-md, .select-md, .textarea-md) span {
-      font-size: 0.875rem;
-      top: calc(var(--size-field, 0.25rem) * 10 / 2);
-    }
-    &:has(.input-lg, .select-lg, .textarea-lg) span {
-      font-size: 1.125rem;
-      top: calc(var(--size-field, 0.25rem) * 12 / 2);
-    }
-    &:has(.input-xl, .select-xl, .textarea-xl) span {
-      font-size: 1.375rem;
-      top: calc(var(--size-field, 0.25rem) * 14 / 2);
     }
   }
 }

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -255,6 +255,11 @@
     --sl-size-mul: 6;
     --font-size-min: 0.6875rem;
     --option-px: 2;
+
+    .floating-label:has(&) {
+      --top-mul: 3;
+      --font-size: 0.6875rem;
+    }
   }
 }
 
@@ -263,6 +268,11 @@
     --sl-size-mul: 8;
     --font-size-min: 0.75rem;
     --option-px: 2.5;
+
+    .floating-label:has(&) {
+      --top-mul: 4;
+      --font-size: 0.75rem;
+    }
   }
 }
 
@@ -272,6 +282,11 @@
     --sl-size-mul: 10;
     --font-size-min: 0.875rem;
     --option-px: 3;
+
+    .floating-label:has(&) {
+      --top-mul: 5;
+      --font-size: 0.875rem;
+    }
   }
 }
 
@@ -280,6 +295,11 @@
     --sl-size-mul: 12;
     --font-size-min: 1.125rem;
     --option-px: 4;
+
+    .floating-label:has(&) {
+      --top-mul: 6;
+      --font-size: 1.125rem;
+    }
   }
 }
 
@@ -288,5 +308,10 @@
     --sl-size-mul: 14;
     --font-size-min: 1.375rem;
     --option-px: 5;
+
+    .floating-label:has(&) {
+      --top-mul: 7;
+      --font-size: 1.375rem;
+    }
   }
 }

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -2,7 +2,7 @@
   @layer daisyui.l1.l2.l3 {
     @apply bg-base-100 relative inline-flex shrink appearance-none items-center gap-1.5 ps-3 pe-7 align-middle;
 
-    --size: calc(var(--size-field, 0.25rem) * var(--size-mul));
+    --size: calc(var(--size-field, 0.25rem) * var(--sl-size-mul));
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
 
     width: clamp(3rem, 20rem, 100%);
@@ -252,7 +252,7 @@
 
 .select-xs {
   @layer daisyui.l1.l2 {
-    --size-mul: 6;
+    --sl-size-mul: 6;
     --font-size-min: 0.6875rem;
     --option-px: 2;
   }
@@ -260,7 +260,7 @@
 
 .select-sm {
   @layer daisyui.l1.l2 {
-    --size-mul: 8;
+    --sl-size-mul: 8;
     --font-size-min: 0.75rem;
     --option-px: 2.5;
   }
@@ -269,7 +269,7 @@
 .select,
 .select-md {
   @layer daisyui.l1.l2 {
-    --size-mul: 10;
+    --sl-size-mul: 10;
     --font-size-min: 0.875rem;
     --option-px: 3;
   }
@@ -277,7 +277,7 @@
 
 .select-lg {
   @layer daisyui.l1.l2 {
-    --size-mul: 12;
+    --sl-size-mul: 12;
     --font-size-min: 1.125rem;
     --option-px: 4;
   }
@@ -285,7 +285,7 @@
 
 .select-xl {
   @layer daisyui.l1.l2 {
-    --size-mul: 14;
+    --sl-size-mul: 14;
     --font-size-min: 1.375rem;
     --option-px: 5;
   }

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -1,10 +1,13 @@
 .select {
   @layer daisyui.l1.l2.l3 {
-    border: var(--border) solid #0000;
     @apply bg-base-100 relative inline-flex shrink appearance-none items-center gap-1.5 ps-3 pe-7 align-middle;
+
+    --size: calc(var(--size-field, 0.25rem) * var(--size-mul));
+    --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
+
     width: clamp(3rem, 20rem, 100%);
     height: var(--size);
-    font-size: 0.875rem;
+    font-size: max(var(--font-size, 0rem), var(--font-size-min));
     touch-action: manipulation;
     border-start-start-radius: var(--join-ss, var(--radius-field));
     border-start-end-radius: var(--join-se, var(--radius-field));
@@ -23,12 +26,11 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    border: var(--border) solid var(--input-color, #0000);
     box-shadow:
       0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000) inset,
       0 -1px oklch(100% 0 0 / calc(var(--depth) * 0.1)) inset;
-    border-color: var(--input-color);
-    --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
-    --size: calc(var(--size-field, 0.25rem) * 10);
+
     [dir="rtl"] & {
       background-position:
         calc(0% + 12px) calc(1px + 50%),
@@ -38,6 +40,7 @@
       @apply h-auto overflow-auto py-3 pe-3;
       background-image: none;
     }
+
     select {
       @apply -ms-3 -me-7 w-[calc(100%+2.75rem)] appearance-none ps-3 pe-7;
       height: calc(100% - calc(var(--border) * 2));
@@ -45,10 +48,17 @@
       background: inherit;
       border-radius: inherit;
       border-style: none;
+
+      &::placeholder {
+        /* color and opacity to work with safari */
+        @apply text-base-content opacity-50;
+      }
+
       &:focus,
       &:focus-within {
         @apply outline-hidden;
       }
+
       &:not(:last-child) {
         @apply -me-5.5;
         background-image: none;
@@ -67,7 +77,13 @@
     &:has(> select[disabled]),
     &:is(:disabled, [disabled]),
     fieldset:disabled & {
-      @apply border-base-200 bg-base-200 placeholder-base-content text-base-content/40 placeholder-base-content/20 cursor-not-allowed;
+      @apply border-base-200 bg-base-200 text-base-content/40 cursor-not-allowed;
+
+      &::placeholder,
+      ::placeholder {
+        /* color and opacity to work with safari */
+        @apply text-base-content opacity-20;
+      }
     }
 
     &:has(> select[disabled]) > select[disabled] {
@@ -100,8 +116,8 @@
         @apply hidden;
       }
       /* option::checkmark {
-      @apply hidden;
-    } */
+        @apply hidden;
+      } */
       optgroup {
         @apply pt-[0.5em];
         option {
@@ -111,7 +127,8 @@
         }
       }
       option {
-        @apply rounded-field px-3 py-1.5;
+        @apply rounded-field py-1.5;
+        padding-inline: calc(var(--spacing) * var(--option-px));
         transition-property: color, background-color;
         transition-duration: 0.2s;
         transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
@@ -235,50 +252,41 @@
 
 .select-xs {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 6);
-    font-size: 0.6875rem;
-    option {
-      @apply px-2 py-1;
-    }
+    --size-mul: 6;
+    --font-size-min: 0.6875rem;
+    --option-px: 2;
   }
 }
 
 .select-sm {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 8);
-    font-size: 0.75rem;
-    option {
-      @apply px-2.5 py-1;
-    }
+    --size-mul: 8;
+    --font-size-min: 0.75rem;
+    --option-px: 2.5;
   }
 }
 
+.select,
 .select-md {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 10);
-    font-size: 0.875rem;
-    option {
-      @apply px-3 py-1.5;
-    }
+    --size-mul: 10;
+    --font-size-min: 0.875rem;
+    --option-px: 3;
   }
 }
 
 .select-lg {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 12);
-    font-size: 1.125rem;
-    option {
-      @apply px-4 py-1.5;
-    }
+    --size-mul: 12;
+    --font-size-min: 1.125rem;
+    --option-px: 4;
   }
 }
 
 .select-xl {
   @layer daisyui.l1.l2 {
-    --size: calc(var(--size-field, 0.25rem) * 14);
-    font-size: 1.375rem;
-    option {
-      @apply px-5 py-1.5;
-    }
+    --size-mul: 14;
+    --font-size-min: 1.375rem;
+    --option-px: 5;
   }
 }

--- a/packages/daisyui/src/components/textarea.css
+++ b/packages/daisyui/src/components/textarea.css
@@ -162,12 +162,22 @@
 .textarea-xs {
   @layer daisyui.l1.l2 {
     --font-size-min: 0.6875rem;
+
+    .floating-label:has(&) {
+      --top-mul: 3;
+      --font-size: 0.6875rem;
+    }
   }
 }
 
 .textarea-sm {
   @layer daisyui.l1.l2 {
     --font-size-min: 0.75rem;
+
+    .floating-label:has(&) {
+      --top-mul: 4;
+      --font-size: 0.75rem;
+    }
   }
 }
 
@@ -175,17 +185,32 @@
 .textarea-md {
   @layer daisyui.l1.l2 {
     --font-size-min: 0.875rem;
+
+    .floating-label:has(&) {
+      --top-mul: 5;
+      --font-size: 0.875rem;
+    }
   }
 }
 
 .textarea-lg {
   @layer daisyui.l1.l2 {
     --font-size-min: 1.125rem;
+
+    .floating-label:has(&) {
+      --top-mul: 6;
+      --font-size: 1.125rem;
+    }
   }
 }
 
 .textarea-xl {
   @layer daisyui.l1.l2 {
     --font-size-min: 1.375rem;
+
+    .floating-label:has(&) {
+      --top-mul: 7;
+      --font-size: 1.375rem;
+    }
   }
 }

--- a/packages/daisyui/src/components/textarea.css
+++ b/packages/daisyui/src/components/textarea.css
@@ -1,20 +1,25 @@
 .textarea {
   @layer daisyui.l1.l2.l3 {
-    border: var(--border) solid #0000;
-    @apply bg-base-100 rounded-field min-h-20 shrink appearance-none py-2 align-middle;
+    @apply bg-base-100 rounded-field min-h-20 shrink appearance-none px-3 py-2 align-middle;
+
+    --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
+
     width: clamp(3rem, 20rem, 100%);
-    padding-inline-start: 0.75rem;
-    padding-inline-end: 0.75rem;
-    font-size: max(var(--font-size, 0.875rem), 0.875rem);
+    font-size: max(var(--font-size, 0rem), var(--font-size-min));
     touch-action: manipulation;
-    border-color: var(--input-color);
+    border: var(--border) solid var(--input-color, #0000);
     box-shadow:
       0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000) inset,
       0 -1px oklch(100% 0 0 / calc(var(--depth) * 0.1)) inset;
-    --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
+
     textarea {
       @apply appearance-none bg-transparent;
       border: none;
+
+      &::placeholder {
+        /* color and opacity to work with safari */
+        @apply text-base-content opacity-50;
+      }
 
       &:focus,
       &:focus-within {
@@ -43,8 +48,14 @@
 
     &:has(> textarea[disabled]),
     &:is(:disabled, [disabled]) {
-      @apply border-base-200 bg-base-200 placeholder-base-content text-base-content/40 placeholder-base-content/20 cursor-not-allowed;
+      @apply border-base-200 bg-base-200 text-base-content/40 cursor-not-allowed;
       box-shadow: none;
+
+      &::placeholder,
+      ::placeholder {
+        /* color and opacity to work with safari */
+        @apply text-base-content opacity-20;
+      }
     }
 
     &:has(> textarea[disabled]) > textarea[disabled] {
@@ -150,30 +161,31 @@
 
 .textarea-xs {
   @layer daisyui.l1.l2 {
-    font-size: max(var(--font-size, 0.6875rem), 0.6875rem);
+    --font-size-min: 0.6875rem;
   }
 }
 
 .textarea-sm {
   @layer daisyui.l1.l2 {
-    font-size: max(var(--font-size, 0.75rem), 0.75rem);
+    --font-size-min: 0.75rem;
   }
 }
 
+.textarea,
 .textarea-md {
   @layer daisyui.l1.l2 {
-    font-size: max(var(--font-size, 0.875rem), 0.875rem);
+    --font-size-min: 0.875rem;
   }
 }
 
 .textarea-lg {
   @layer daisyui.l1.l2 {
-    font-size: max(var(--font-size, 1.125rem), 1.125rem);
+    --font-size-min: 1.125rem;
   }
 }
 
 .textarea-xl {
   @layer daisyui.l1.l2 {
-    font-size: max(var(--font-size, 1.375rem), 1.375rem);
+    --font-size-min: 1.375rem;
   }
 }

--- a/packages/docs/src/routes/(routes)/components/label/+page.md
+++ b/packages/docs/src/routes/(routes)/components/label/+page.md
@@ -134,3 +134,44 @@ classnames:
   <span>Extra Large</span>
 </label>
 ```
+
+### ~Responsive Size Floating Label
+<div class="grid gap-4 w-xs">
+  <label class="floating-label">
+    <input type="text" placeholder="Input" class="input input-xs sm:input-sm md:input-md lg:input-lg xl:input-xl" value="Placeholder" />
+    <span>Input</span>
+  </label>
+
+  <label class="floating-label">
+    <textarea placeholder="Textarea" class="textarea textarea-xs sm:textarea-sm md:textarea-md lg:textarea-lg xl:textarea-xl">Placeholder</textarea>
+    <span>Textarea</span>
+  </label>
+
+  <label class="floating-label">
+    <select class="select select-xs sm:select-sm md:select-md lg:select-lg xl:select-xl">
+      <option disabled selected>Placeholder</option>
+      <option>Option</option>
+    </select>
+    <span>Select</span>
+  </label>
+</div>
+
+```html
+<label class="$$floating-label">
+  <input type="text" placeholder="Input" class="$$input $$input-xs $$sm:input-sm $$md:input-md $$lg:input-lg $$xl:input-xl" value="Placeholder" />
+  <span>Input</span>
+</label>
+
+<label class="$$floating-label">
+  <textarea placeholder="Textarea" class="$$textarea $$textarea-xs $$sm:textarea-sm $$md:textarea-md $$lg:textarea-lg $$xl:textarea-xl">Placeholder</textarea>
+  <span>Textarea</span>
+</label>
+
+<label class="$$floating-label">
+  <select class="$$select $$select-xs $$sm:select-sm $$md:select-md $$lg:select-lg $$xl:select-xl">
+    <option disabled selected>Placeholder</option>
+    <option>Option</option>
+  </select>
+  <span>Select</span>
+</label>
+```


### PR DESCRIPTION
- use size and font based on variables
- remove redundant rules
- fix input shadow element settings to work when using `.input input` and `input.input`
- fix placeholder color for safari
- make `.floating-label` respect responsive size modifiers on child `.input`, `.select`, `.textarea`

**Notable changes:**
- `.floating-label` is `flex` instead of `block` so that we can keep input `inline-flex` and avoid white space generated spacing
- input is `relative` so that the `::-webkit-calendar-picker-indicator` is correctly positioned when using `.input input`

**Not solved:**
- ~`.floating-label` does not adapt to responsive size classes of content (TODO in future PR)~

example (only for input): https://play.tailwindcss.com/s2xaEB1VZw?file=css

close #4370