### PR TITLE
fix(prefix): replace only the variable name, not all content of `var(...)`

### DIFF
--- a/packages/daisyui/functions/addPrefix.js
+++ b/packages/daisyui/functions/addPrefix.js
@@ -154,13 +154,14 @@ const processArrayValue = (value, prefix, excludedPrefixes) => {
   })
 }
 
+const reVariableName = /var\s*\(\s*--([a-zA-Z0-9_-]+)/g
 const processStringValue = (value, prefix, excludedPrefixes) => {
   if (prefix === 0) return value
-  return value.replace(/var\(--([^)]+)\)/g, (match, variableName) => {
+  return value.replace(reVariableName, (match, variableName) => {
     if (shouldExcludeVariable(variableName, excludedPrefixes)) {
       return match
     }
-    return `var(--${prefix}${variableName})`
+    return `var(--${prefix}${variableName}`
   })
 }
 


### PR DESCRIPTION
- existing regex was matching all text after `var(--` until the first `)`
- that solution does not work for `var` in `var` (`var(--a, var(--b))`)
- new implementation will only replace the variable name (`[a-zA-Z0-9_-]+`)
- it also accepts spaces between `var` and `(` and between `(` and `--`
- as this regex is heavily used I extracted it to be only compiled once

close #4372
close #4408