### PR TITLE
docs(dropdown): remove outdated compat info

### DIFF
--- a/packages/docs/src/routes/(routes)/components/dropdown/+page.md
+++ b/packages/docs/src/routes/(routes)/components/dropdown/+page.md
@@ -104,12 +104,6 @@ Anchor positioning is a new CSS standard for positioning elements relative to an
 > `popovertarget` is the unique ID of the popover content.  
 > `anchor-name`/`position-anchor` is the unique name of the anchor.
 
-> :INFO:
->
-> CSS Anchor Positioning is a new standard but isn't yet supported in Firefox and Safari ([caniuse.com](https://caniuse.com/css-anchor-positioning)).  
-> In those browsers, the dropdown will appear centered like a modal.  
-> There's also [this polyfill](https://github.com/oddbird/css-anchor-positioning) that can be helpful.
-
 ### ~Dropdown using popover API and anchor positioning
 <button class="btn" popovertarget="popover-1" style="anchor-name:--anchor-1">
   Button


### PR DESCRIPTION
Two fixes for the dropdown docs:
~1. The browser creates an implicit reference between the two elements when using `popovertarget`, so using `anchor-name`/`position-anchor` isn't necessary so the code can be simplified.~ Using the implicit reference causes [this bug](https://github.com/whatwg/html/issues/11694) so I've removed this change.
2. Firefox and Safari's latest release has support for CSS anchoring, so I've removed the section about compatibility.