### PR TITLE
fix(btn): hide underline for `.btn` when used in `.prose`

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -4,7 +4,7 @@
   }
 }
 
-.prose :where(.btn-link):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+.prose :where(:not(.btn-link)):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   @apply no-underline;
 }
 


### PR DESCRIPTION
ref https://github.com/saadeghi/daisyui/issues/4400#issuecomment-3795403617

example: https://play.tailwindcss.com/vsfdDqh1x8?file=css

close #4400