### PR TITLE
fix: scope prose underline rule to a.btn only (fixes #4414)

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -4,7 +4,7 @@
   }
 }
 
-.prose :where(:not(.btn-link)):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+.prose :where(a.btn:not(.btn-link)):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   @apply no-underline;
 }
 


### PR DESCRIPTION
Example: https://play.tailwindcss.com/NKJY7QNJZV?file=css