### PR TITLE
fix(card): only style figure if direct child of .card-body

### DIFF
--- a/packages/daisyui/src/components/card.css
+++ b/packages/daisyui/src/components/card.css
@@ -13,7 +13,7 @@
       outline-color: currentColor;
     }
 
-    :where(figure:first-child) {
+    > :where(figure:first-child) {
       @apply overflow-hidden;
       border-start-start-radius: inherit;
       border-start-end-radius: inherit;
@@ -21,7 +21,7 @@
       border-end-end-radius: unset;
     }
 
-    :where(figure:last-child) {
+    > :where(figure:last-child) {
       @apply overflow-hidden;
       border-start-start-radius: unset;
       border-start-end-radius: unset;
@@ -29,7 +29,7 @@
       border-end-end-radius: inherit;
     }
 
-    figure {
+    > figure {
       @apply flex items-center justify-center;
     }
     &:has(> input:is(input[type="checkbox"], input[type="radio"])) {
@@ -66,7 +66,7 @@
       @apply text-neutral-content relative;
     }
 
-    :where(figure) {
+    > :where(figure) {
       @apply overflow-hidden;
       border-radius: inherit;
     }
@@ -174,7 +174,7 @@
     align-items: stretch;
     flex-direction: row;
 
-    :where(figure:first-child) {
+    > :where(figure:first-child) {
       @apply overflow-hidden;
       border-start-start-radius: inherit;
       border-start-end-radius: unset;
@@ -182,7 +182,7 @@
       border-end-end-radius: unset;
     }
 
-    :where(figure:last-child) {
+    > :where(figure:last-child) {
       @apply overflow-hidden;
       border-start-start-radius: unset;
       border-start-end-radius: inherit;
@@ -190,11 +190,11 @@
       border-end-end-radius: inherit;
     }
 
-    figure > * {
+    > figure > * {
       max-width: unset;
     }
 
-    :where(figure > *) {
+    > :where(figure > *) {
       width: 100%;
       height: 100%;
       object-fit: cover;


### PR DESCRIPTION
Initial approach, to be refined after further discussion (only style `figure` direct child of `.card`):

It looks like in card we apply styles to all `figure` inside, but all examples are with the images as direct child of `card` (and it woul make sense).

So I would say we should scope the style applied in card only to direct children of `card`.

https://play.tailwindcss.com/nZVaZs1bUq?file=css (has the example with the problem in #4416 and also all cards with image from docs)

What I am unsure about is the below, where my logic would say that `p` should also be only direct child of `card-body` (`> :where(p)`), but I am afraid that there are people that rely on the current behavior.

```css
card-body {
  @layer daisyui.l1.l2.l3 {
    @apply flex flex-auto flex-col gap-2;
    padding: var(--card-p, 1.5rem);
    font-size: var(--card-fs, 0.875rem);

    :where(p) {
      @apply grow;
    }
  }
}
```

close #4416