### PR TITLE
fix(card): outline should be visible when card has focus-visible

### DIFF
--- a/packages/daisyui/src/components/card.css
+++ b/packages/daisyui/src/components/card.css
@@ -10,6 +10,11 @@
     &:has(> :checked, > :is([type="checkbox"], [type="radio"]):focus-visible) {
       outline-color: currentColor;
     }
+    &:has(> :checked:focus-visible),
+    &[aria-checked="true"]:focus-visible,
+    &[aria-checked="true"]:has(> :is([type="checkbox"], [type="radio"]):focus-visible) {
+      outline-width: 4px;
+    }
 
     :where(figure:first-child) {
       @apply overflow-hidden;

--- a/packages/daisyui/src/components/card.css
+++ b/packages/daisyui/src/components/card.css
@@ -6,6 +6,7 @@
     outline-offset: 2px;
 
     &:focus-visible,
+    &[aria-checked="true"],
     &:has(> :checked, > :is([type="checkbox"], [type="radio"]):focus-visible) {
       outline-color: currentColor;
     }

--- a/packages/daisyui/src/components/card.css
+++ b/packages/daisyui/src/components/card.css
@@ -1,15 +1,12 @@
 .card {
   @layer daisyui.l1.l2.l3 {
     @apply rounded-box relative flex flex-col;
-    outline-width: 2px;
     transition: outline 0.2s ease-in-out;
-    outline: 0 solid #0000;
+    outline: 2px solid #0000;
     outline-offset: 2px;
-    &:focus {
-      @apply outline-hidden;
-    }
 
-    &:focus-visible {
+    &:focus-visible,
+    &:has(> :checked, > :is([type="checkbox"], [type="radio"]):focus-visible) {
       outline-color: currentColor;
     }
 
@@ -32,12 +29,12 @@
     figure {
       @apply flex items-center justify-center;
     }
-    &:has(> input:is(input[type="checkbox"], input[type="radio"])) {
+    &:has(> :is([type="checkbox"], [type="radio"])) {
       @apply cursor-pointer;
       user-select: none;
     }
-    &:has(> :checked) {
-      outline: 2px solid currentColor;
+    > :is([type="checkbox"], [type="radio"]) {
+      @apply appearance-none;
     }
   }
 }

--- a/packages/docs/src/routes/(routes)/components/card/+page.md
+++ b/packages/docs/src/routes/(routes)/components/card/+page.md
@@ -596,3 +596,78 @@ classnames:
   </div>
 </div>
 ```
+
+### ~Selectable cards
+<div class="flex flex-wrap items-start gap-3">
+  <label class="card bg-accent text-accent-content">
+    <input type="checkbox" name="card-urgent-1" />
+    <div class="card-body">
+      <h2 class="card-title">Urgent</h2>
+      <p>Same day delivery</p>
+    </div>
+  </label>
+
+  <div class="join bg-base-300 rounded-selector">
+    <label class="join-item card">
+      <input type="radio" value="sm" name="card-size-1" />
+      <div class="card-body">
+        <h2 class="card-title">Size SM</h2>
+        <p>Available</p>
+      </div>
+    </label>
+
+    <label class="join-item card">
+      <input type="radio" value="md" name="card-size-1" disabled />
+      <div class="card-body opacity-60">
+        <h2 class="card-title">Size MD</h2>
+        <p>Not available</p>
+      </div>
+    </label>
+
+    <label class="join-item card">
+      <input type="radio" value="lg" name="card-size-1" />
+      <div class="card-body">
+        <h2 class="card-title">Size LG</h2>
+        <p>Short supply</p>
+      </div>
+    </label>
+  </div>
+</div>
+
+```html
+<div class="flex flex-wrap items-start gap-3">
+  <label class="$$card bg-accent text-accent-content">
+    <input type="checkbox" name="card-urgent-1" />
+    <div class="$$card-body">
+      <h2 class="$$card-title">Urgent</h2>
+      <p>Same day delivery</p>
+    </div>
+  </label>
+
+  <div class="$$join bg-base-300 rounded-selector">
+    <label class="$$join-item $$card">
+      <input type="radio" value="sm" name="card-size-1" />
+      <div class="$$card-body">
+        <h2 class="$$card-title">Size SM</h2>
+        <p>Available</p>
+      </div>
+    </label>
+
+    <label class="$$join-item $$card">
+      <input type="radio" value="md" name="card-size-1" disabled />
+      <div class="$$card-body opacity-60">
+        <h2 class="$$card-title">Size MD</h2>
+        <p>Not available</p>
+      </div>
+    </label>
+
+    <label class="$$join-item $$card">
+      <input type="radio" value="lg" name="card-size-1" />
+      <div class="$$card-body">
+        <h2 class="$$card-title">Size LG</h2>
+        <p>Short supply</p>
+      </div>
+    </label>
+  </div>
+</div>
+```


### PR DESCRIPTION
- also improves card as label for radio/checkbox

!!! there is a problem with differentiating between checked card and focus-visible card

I tried to differentiate checked card and focus-visible card with the outline width - I'm not sure about this decission - please check

example: https://play.tailwindcss.com/BQizZyuAT6?file=css

close #4421