### PR TITLE
fix(tab): apply `z-1` on box tab when focus-visible

### DIFF
--- a/packages/daisyui/src/components/tab.css
+++ b/packages/daisyui/src/components/tab.css
@@ -469,6 +469,9 @@
       &:is(label:has(:checked:focus-visible)) {
         outline-offset: 2px;
       }
+      &:focus-visible {
+        @apply z-1;
+      }
     }
 
     > :is(.tab-active, [aria-selected="true"], [aria-current="true"], [aria-current="page"]):not(


### PR DESCRIPTION
when the left tab has focus-visible the outline is below the next tab which is active all other tab designs have inside outlines, so there is no problem

ref #4424