### PR TITLE
feat(mockup-code): add optional .mockup-code-btn part class

### DIFF
--- a/packages/daisyui/src/components/mockup.css
+++ b/packages/daisyui/src/components/mockup.css
@@ -13,6 +13,13 @@
         4.2em 0;
     }
 
+    .mockup-code-btn {
+      @apply absolute top-2 right-2 z-10 cursor-pointer rounded-md border-none bg-current/10 px-2 py-1 text-xs text-current opacity-60 transition-opacity;
+      &:hover {
+        @apply opacity-100;
+      }
+    }
+
     pre {
       @apply pr-5;
 

--- a/packages/docs/src/routes/(routes)/components/mockup-code/+page.md
+++ b/packages/docs/src/routes/(routes)/components/mockup-code/+page.md
@@ -7,6 +7,9 @@ classnames:
   component:
     - class: mockup-code
       desc: Code terminal mockup
+  part:
+    - class: mockup-code-btn
+      desc: Optional button for code mockup
 ---
 
 <script>
@@ -79,6 +82,20 @@ classnames:
 ```html
 <div class="$$mockup-code w-full">
   <pre><code>without prefix</code></pre>
+</div>
+```
+
+
+### ~With button
+<div class="mockup-code w-full">
+  <button class="mockup-code-btn">Copy</button>
+  <pre data-prefix="$"><code>npm i daisyui</code></pre>
+</div>
+
+```html
+<div class="$$mockup-code w-full">
+  <button class="$$mockup-code-btn">Copy</button>
+  <pre data-prefix="$"><code>npm i daisyui</code></pre>
 </div>
 ```
 


### PR DESCRIPTION
Adds optional `.mockup-code-btn` part class for `.mockup-code`. Useful for copy buttons or other actions.

- Absolute positioned top-right with `z-10`
- Inherits parent text color with subtle `bg-current/10` background
- 60% opacity, transitions to 100% on hover
- CSS Only - Users have provide their own click handler.
- Docs updated with "With button" example and `part` classname entry

Example: https://play.tailwindcss.com/FIPJooQLyR?file=css

<img width="571" height="440" alt="image" src="https://github.com/user-attachments/assets/53d23230-49b8-49d9-b06c-92af25833894" />
