### PR TITLE
feat(btn): full rewrite of button styles

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -8,7 +8,6 @@
   @apply no-underline;
 }
 
-/* 1. BASE STRUCTURE */
 .btn {
   @layer daisyui.l1.l2.l3 {
     /* User-facing defaults */
@@ -19,7 +18,6 @@
     --btn-fg: var(--color-base-content);
     --btn-noise: var(--fx-noise);
 
-    /* Non-changing styles */
     @apply inline-flex shrink-0 cursor-pointer flex-nowrap items-center justify-center gap-1.5 text-center align-middle outline-offset-2 select-none;
     font-weight: 600;
     border-start-start-radius: var(--join-ss, var(--radius-field));
@@ -32,7 +30,6 @@
     transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
     transition-duration: 0.2s;
 
-    /* Internal logic */
     --int-bg: var(--btn-color, var(--color-base-200));
     --int-fg: var(--btn-fg);
     --int-border: color-mix(
@@ -51,7 +48,6 @@
     --int-inset-def: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
     --int-inset: var(--int-inset-def);
 
-    /* Apply internals */
     height: var(--size);
     padding-inline: var(--btn-p);
     font-size: var(--fontsize, 0.875rem);
@@ -62,7 +58,6 @@
     outline-color: var(--btn-color, var(--color-base-content));
     --tw-prose-links: var(--int-fg);
 
-    /* Effects */
     background-image: none, var(--int-noise);
     background-size: auto, calc(var(--noise, 0) * 100%);
     text-shadow: 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 0.15));
@@ -70,7 +65,6 @@
       var(--int-inset) inset,
       var(--int-shadow);
 
-    /* Checkable label */
     &:is([type="checkbox"], [type="radio"]) {
       @apply appearance-none;
 
@@ -80,13 +74,62 @@
       }
     }
   }
+
+  @layer daisyui.l1.l2 {
+    &:where(:checked:not(.filter [type="radio"].btn), .btn-active) {
+      --btn-color: var(--color-primary);
+      --btn-fg: var(--color-primary-content);
+      isolation: isolate;
+    }
+
+    @media (hover: hover) {
+      &:hover {
+        --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
+        --int-fg: var(--btn-fg);
+        --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
+        --int-noise: var(--fx-noise);
+        --int-inset: var(--int-inset-def);
+        --int-shadow: var(--int-shadow-def);
+      }
+    }
+
+    &:active:not(.btn-active) {
+      translate: 0 0.5px;
+      --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
+      --int-fg: var(--btn-fg, var(--color-base-content));
+      --int-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
+      --int-border-style: solid;
+      --int-inset: var(--int-no-shadow);
+      --int-shadow: var(--int-no-shadow);
+    }
+
+    &:where(
+      :checked:not(.filter [type="radio"].btn),
+      .btn-active,
+      :not([type="radio"], [type="checkbox"]):focus-visible
+    ) {
+      --int-bg: var(--btn-color, var(--color-base-200));
+      --int-fg: var(--btn-fg, var(--color-base-content));
+      --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
+      --int-border-style: solid;
+      --int-noise: var(--fx-noise);
+      --int-inset: var(--int-inset-def);
+      --int-shadow: var(--int-shadow-def);
+      isolation: isolate;
+    }
+
+    &:focus-visible,
+    &:has(:focus-visible) {
+      outline-width: 2px;
+      outline-style: solid;
+      isolation: isolate;
+    }
+  }
 }
 
-/* 2. MODIFIERS */
-/* 2a. Style modifiers */
 .btn-outline,
 .btn-dash {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --int-bg: #0000;
     --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
     --int-border: var(--btn-color, var(--color-base-content));
@@ -98,13 +141,13 @@
 }
 
 .btn-dash {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --int-border-style: dashed;
   }
 }
 
 .btn-ghost {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --int-bg: #0000;
     --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content, currentColor)));
     --int-border: #0000;
@@ -115,7 +158,7 @@
 }
 
 .btn-soft {
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1.l2.l3 {
     --int-bg: color-mix(
       in oklab,
       var(--btn-color, var(--color-base-content)) 8%,
@@ -134,7 +177,6 @@
   }
 }
 
-/* Link is a special case, it goes in higher layer */
 .btn-link {
   @layer daisyui.l1 {
     @apply underline;
@@ -147,16 +189,6 @@
   }
 }
 
-/* 2b. Checked/active defaults (must be first to be overridden by specific colors) */
-.btn:where(:checked:not(.filter [type="radio"].btn), .btn-active) {
-  @layer daisyui.l1.l2 {
-    --btn-color: var(--color-primary);
-    --btn-fg: var(--color-primary-content);
-    isolation: isolate;
-  }
-}
-
-/* 2c. Color modifiers */
 .btn-primary {
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-primary);
@@ -222,7 +254,6 @@
   }
 }
 
-/* 2d. Sizes */
 .btn-xs {
   @layer daisyui.l1.l2 {
     --fontsize: 0.6875rem;
@@ -291,56 +322,6 @@
   }
 }
 
-/* 3. INTERACTION & STATE */
-.btn {
-  @layer daisyui.l1.l2 {
-    @media (hover: hover) {
-      &:hover {
-        --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-        --int-fg: var(--btn-fg);
-        --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
-        --int-noise: var(--fx-noise);
-        --int-inset: var(--int-inset-def);
-        --int-shadow: var(--int-shadow-def);
-      }
-    }
-
-    &:active:not(.btn-active) {
-      translate: 0 0.5px;
-      --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
-      --int-fg: var(--btn-fg, var(--color-base-content));
-      --int-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-      --int-border-style: solid;
-      --int-inset: var(--int-no-shadow);
-      --int-shadow: var(--int-no-shadow);
-    }
-
-    /* Force solid state (checked/active/focus-visible if not checkable) */
-    &:where(
-      :checked:not(.filter [type="radio"].btn),
-      .btn-active,
-      :not([type="radio"], [type="checkbox"]):focus-visible
-    ) {
-      --int-bg: var(--btn-color, var(--color-base-200));
-      --int-fg: var(--btn-fg, var(--color-base-content));
-      --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
-      --int-border-style: solid;
-      --int-noise: var(--fx-noise);
-      --int-inset: var(--int-inset-def);
-      --int-shadow: var(--int-shadow-def);
-      isolation: isolate;
-    }
-
-    &:focus-visible,
-    &:has(:focus-visible) {
-      outline-width: 2px;
-      outline-style: solid;
-      isolation: isolate;
-    }
-  }
-}
-
-/* Disabled State */
 .btn-disabled,
 .btn:is(:disabled, [disabled], [aria-disabled="true"]) {
   @layer daisyui {

--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -87,14 +87,14 @@
 
 .btn-disabled,
 .btn:disabled,
-.btn[disabled] {
+.btn[disabled],
+.btn[aria-disabled="true"] {
   @layer daisyui.l1.l2 {
     &:not(.btn-link, .btn-ghost) {
       @apply bg-base-content/10;
-      box-shadow: none;
     }
 
-    @apply pointer-events-none;
+    @apply pointer-events-none shadow-none;
     --btn-border: #0000;
     --btn-noise: none;
     --btn-fg: color-mix(in oklch, var(--color-base-content) 20%, #0000);
@@ -113,6 +113,7 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-primary);
     --btn-fg: var(--color-primary-content);
+    --btn-soft-bg: initial;
   }
 }
 
@@ -120,6 +121,7 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-secondary);
     --btn-fg: var(--color-secondary-content);
+    --btn-soft-bg: initial;
   }
 }
 
@@ -127,6 +129,7 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-accent);
     --btn-fg: var(--color-accent-content);
+    --btn-soft-bg: initial;
   }
 }
 
@@ -134,6 +137,8 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-neutral);
     --btn-fg: var(--color-neutral-content);
+    --btn-soft-bg: var(--color-neutral-content) 80%;
+    --btn-rest-fg: initial;
   }
 }
 
@@ -141,6 +146,7 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-info);
     --btn-fg: var(--color-info-content);
+    --btn-soft-bg: initial;
   }
 }
 
@@ -148,6 +154,7 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-success);
     --btn-fg: var(--color-success-content);
+    --btn-soft-bg: initial;
   }
 }
 
@@ -155,6 +162,7 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-warning);
     --btn-fg: var(--color-warning-content);
+    --btn-soft-bg: initial;
   }
 }
 
@@ -162,6 +170,7 @@
   @layer daisyui.l1.l2.l3 {
     --btn-color: var(--color-error);
     --btn-fg: var(--color-error-content);
+    --btn-soft-bg: initial;
   }
 }
 
@@ -178,9 +187,9 @@
       --btn-bg: #0000;
       --btn-border: #0000;
       --btn-noise: none;
-      &:not(:disabled, [disabled], .btn-disabled) {
+      &:not(:disabled, [disabled], .btn-disabled, [aria-disabled="true"]) {
         @apply outline-current;
-        --btn-fg: var(--btn-color, currentColor);
+        --btn-fg: var(--btn-rest-fg, var(--btn-color, currentColor));
       }
     }
 
@@ -189,7 +198,7 @@
         @apply outline-current;
         --btn-shadow: "";
         --btn-bg: #0000;
-        --btn-fg: var(--btn-color, currentColor);
+        --btn-fg: var(--btn-rest-fg, var(--btn-color, currentColor));
         --btn-border: #0000;
         --btn-noise: none;
       }
@@ -205,7 +214,7 @@
     --btn-noise: none;
     --btn-shadow: "";
 
-    &:not(.btn-disabled, .btn:disabled, .btn[disabled]) {
+    &:not(.btn-disabled, .btn:disabled, .btn[disabled], [aria-disabled="true"]) {
       --btn-fg: var(--btn-color, var(--color-primary));
     }
 
@@ -227,11 +236,12 @@
       :checked:not(.filter [type="radio"].btn),
       :disabled,
       [disabled],
-      .btn-disabled
+      .btn-disabled,
+      [aria-disabled="true"]
     ) {
       --btn-shadow: "";
       --btn-bg: #0000;
-      --btn-fg: var(--btn-color);
+      --btn-fg: var(--btn-rest-fg, var(--btn-color));
       --btn-border: var(--btn-color);
       --btn-noise: none;
     }
@@ -240,7 +250,7 @@
       &:not(.btn-active, :active, :focus-visible, :checked:not(.filter [type="radio"].btn)):hover {
         --btn-shadow: "";
         --btn-bg: #0000;
-        --btn-fg: var(--btn-color);
+        --btn-fg: var(--btn-rest-fg, var(--btn-color));
         --btn-border: var(--btn-color);
         --btn-noise: none;
       }
@@ -262,19 +272,20 @@
       :checked:not(.filter [type="radio"].btn),
       :disabled,
       [disabled],
-      .btn-disabled
+      .btn-disabled,
+      [aria-disabled="true"]
     ) {
       --btn-shadow: "";
-      --btn-fg: var(--btn-color, var(--color-base-content));
+      --btn-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
       --btn-bg: color-mix(
         in oklab,
         var(--btn-color, var(--color-base-content)) 8%,
-        var(--color-base-100)
+        var(--btn-soft-bg, var(--color-base-100))
       );
       --btn-border: color-mix(
         in oklab,
         var(--btn-color, var(--color-base-content)) 10%,
-        var(--color-base-100)
+        var(--btn-soft-bg, var(--color-base-100))
       );
       --btn-noise: none;
     }
@@ -282,16 +293,16 @@
     @media (hover: none) {
       &:not(.btn-active, :active, :focus-visible, :checked:not(.filter [type="radio"].btn)):hover {
         --btn-shadow: "";
-        --btn-fg: var(--btn-color, var(--color-base-content));
+        --btn-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
         --btn-bg: color-mix(
           in oklab,
           var(--btn-color, var(--color-base-content)) 8%,
-          var(--color-base-100)
+          var(--btn-soft-bg, var(--color-base-100))
         );
         --btn-border: color-mix(
           in oklab,
           var(--btn-color, var(--color-base-content)) 10%,
-          var(--color-base-100)
+          var(--btn-soft-bg, var(--color-base-100))
         );
         --btn-noise: none;
       }

--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -44,7 +44,7 @@
     background-color: var(--btn-bg);
     color: var(--btn-fg);
     border-color: var(--btn-border);
-    border-style: solid;
+    border-style: var(--btn-border-style, solid);
     outline-color: var(--btn-color, var(--color-base-content));
     --tw-prose-links: var(--btn-fg);
 
@@ -77,6 +77,7 @@
         --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
         color: var(--btn-fg);
         --btn-border: color-mix(in oklab, var(--btn-bg), #000 calc(var(--depth) * 5%));
+        --btn-border-style: solid;
         --btn-inset: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
         --btn-shadow:
           0 3px 2px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000),
@@ -89,7 +90,6 @@
       --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
       color: var(--btn-fg, var(--color-base-content));
       --btn-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-      --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
       --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
     }
 
@@ -131,7 +131,7 @@
 
 .btn-dash {
   @layer daisyui.l1.l2.l3 {
-    border-style: dashed;
+    --btn-border-style: dashed;
   }
 }
 

--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -8,308 +8,221 @@
   @apply no-underline;
 }
 
+/* 1. BASE STRUCTURE */
 .btn {
   @layer daisyui.l1.l2.l3 {
+    /* User-facing defaults */
+    /* --btn-color */
+    /* --btn-rest-fg */
+    --size: calc(var(--size-field, 0.25rem) * 10);
+    --btn-p: 1rem;
+    --btn-fg: var(--color-base-content);
+    --btn-noise: var(--fx-noise);
+
+    /* Non-changing styles */
     @apply inline-flex shrink-0 cursor-pointer flex-nowrap items-center justify-center gap-1.5 text-center align-middle outline-offset-2 select-none;
-    padding-inline: var(--btn-p);
-    color: var(--btn-fg);
-    --tw-prose-links: var(--btn-fg);
-    height: var(--size);
-    font-size: var(--fontsize, 0.875rem);
     font-weight: 600;
-    outline-color: var(--btn-color, var(--color-base-content));
-    transition-property: color, background-color, border-color, box-shadow;
-    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-    transition-duration: 0.2s;
     border-start-start-radius: var(--join-ss, var(--radius-field));
     border-start-end-radius: var(--join-se, var(--radius-field));
     border-end-start-radius: var(--join-es, var(--radius-field));
     border-end-end-radius: var(--join-ee, var(--radius-field));
-    background-color: var(--btn-bg);
-    background-size: auto, calc(var(--noise) * 100%);
-    background-image: none, var(--btn-noise);
     border-width: var(--border);
-    border-style: solid;
-    border-color: var(--btn-border);
-    text-shadow: 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 0.15));
     touch-action: manipulation;
+    transition-property: color, background-color, border-color, box-shadow, transform;
+    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    transition-duration: 0.2s;
+
+    /* Internal logic */
+    --int-bg: var(--btn-color, var(--color-base-200));
+    --int-fg: var(--btn-fg);
+    --int-border: color-mix(
+      in oklab,
+      var(--btn-color, var(--color-base-200)),
+      #000 calc(var(--depth) * 5%)
+    );
+    --int-border-style: solid;
+    --int-soft-bg: initial;
+    --int-noise: var(--btn-noise);
+    --int-no-shadow: 0 0 0 0 oklch(0% 0 0/0);
+    --int-shadow-def:
+      0 3px 2px -2px color-mix(in oklab, var(--int-bg) calc(var(--depth) * 30%), #0000),
+      0 4px 3px -2px color-mix(in oklab, var(--int-bg) calc(var(--depth) * 30%), #0000);
+    --int-shadow: var(--int-shadow-def);
+    --int-inset-def: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
+    --int-inset: var(--int-inset-def);
+
+    /* Apply internals */
+    height: var(--size);
+    padding-inline: var(--btn-p);
+    font-size: var(--fontsize, 0.875rem);
+    background-color: var(--int-bg);
+    color: var(--int-fg);
+    border-color: var(--int-border);
+    border-style: var(--int-border-style);
+    outline-color: var(--btn-color, var(--color-base-content));
+    --tw-prose-links: var(--int-fg);
+
+    /* Effects */
+    background-image: none, var(--int-noise);
+    background-size: auto, calc(var(--noise, 0) * 100%);
+    text-shadow: 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 0.15));
     box-shadow:
-      0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%)) inset,
-      var(--btn-shadow);
-    --size: calc(var(--size-field, 0.25rem) * 10);
-    --btn-bg: var(--btn-color, var(--color-base-200));
-    --btn-fg: var(--color-base-content);
-    --btn-p: 1rem;
-    --btn-border: color-mix(in oklab, var(--btn-bg), #000 calc(var(--depth) * 5%));
-    --btn-shadow:
-      0 3px 2px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000),
-      0 4px 3px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000);
-    --btn-noise: var(--fx-noise);
-    @media (hover: hover) {
-      &:hover {
-        --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-      }
-    }
+      var(--int-inset) inset,
+      var(--int-shadow);
 
-    &:focus-visible,
-    &:has(:focus-visible) {
-      outline-width: 2px;
-      outline-style: solid;
-      isolation: isolate;
-    }
-
-    &:active:not(.btn-active) {
-      translate: 0 0.5px;
-      --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
-      --btn-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-      --btn-shadow: 0 0 0 0 oklch(0% 0 0/0), 0 0 0 0 oklch(0% 0 0/0);
-    }
-
+    /* Checkable label */
     &:is([type="checkbox"], [type="radio"]) {
       @apply appearance-none;
-
-      /* &:not(.btn-square, .btn-circle) {
-        @apply w-auto;
-      } */
 
       &[aria-label]::after {
         --tw-content: attr(aria-label);
         content: var(--tw-content);
       }
     }
-    &:where(:checked:not(.filter [type="radio"].btn)) {
-      --btn-color: var(--color-primary);
-      --btn-fg: var(--color-primary-content);
-      isolation: isolate;
-    }
   }
 }
 
-.btn-disabled,
-.btn:disabled,
-.btn[disabled],
-.btn[aria-disabled="true"] {
+/* 2. MODIFIERS */
+/* 2a. Style modifiers */
+.btn-outline,
+.btn-dash {
   @layer daisyui.l1.l2 {
-    &:not(.btn-link, .btn-ghost) {
-      @apply bg-base-content/10;
-    }
-
-    @apply pointer-events-none shadow-none;
-    --btn-border: #0000;
-    --btn-noise: none;
-    --btn-fg: color-mix(in oklch, var(--color-base-content) 20%, #0000);
+    --int-bg: #0000;
+    --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
+    --int-border: var(--btn-color, var(--color-base-content));
+    --int-border-style: solid;
+    --int-noise: none;
+    --int-inset: var(--int-no-shadow);
+    --int-shadow: var(--int-no-shadow);
   }
 }
 
-.btn-active {
+.btn-dash {
   @layer daisyui.l1.l2 {
-    --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-    --btn-shadow: 0 0 0 0 oklch(0% 0 0/0), 0 0 0 0 oklch(0% 0 0/0);
+    --int-border-style: dashed;
+  }
+}
+
+.btn-ghost {
+  @layer daisyui.l1.l2 {
+    --int-bg: #0000;
+    --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content, currentColor)));
+    --int-border: #0000;
+    --int-noise: none;
+    --int-inset: var(--int-no-shadow);
+    --int-shadow: var(--int-no-shadow);
+  }
+}
+
+.btn-soft {
+  @layer daisyui.l1.l2 {
+    --int-bg: color-mix(
+      in oklab,
+      var(--btn-color, var(--color-base-content)) 8%,
+      var(--int-soft-bg, var(--color-base-100))
+    );
+    --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
+    --int-border: color-mix(
+      in oklab,
+      var(--btn-color, var(--color-base-content)) 10%,
+      var(--int-soft-bg, var(--color-base-100))
+    );
+    --int-border-style: solid;
+    --int-noise: none;
+    --int-inset: var(--int-no-shadow);
+    --int-shadow: var(--int-no-shadow);
+  }
+}
+
+/* Link is a special case, it goes in higher layer */
+.btn-link {
+  @layer daisyui.l1 {
+    @apply underline;
+    --int-bg: #0000;
+    --int-fg: var(--btn-color, var(--color-primary));
+    --int-border: #0000;
+    --int-noise: none;
+    --int-inset: var(--int-no-shadow);
+    --int-shadow: var(--int-no-shadow);
+  }
+}
+
+/* 2b. Checked/active defaults (must be first to be overridden by specific colors) */
+.btn:where(:checked:not(.filter [type="radio"].btn), .btn-active) {
+  @layer daisyui.l1.l2 {
+    --btn-color: var(--color-primary);
+    --btn-fg: var(--color-primary-content);
     isolation: isolate;
   }
 }
 
+/* 2c. Color modifiers */
 .btn-primary {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-primary);
     --btn-fg: var(--color-primary-content);
-    --btn-soft-bg: initial;
+    --int-soft-bg: initial;
   }
 }
 
 .btn-secondary {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-secondary);
     --btn-fg: var(--color-secondary-content);
-    --btn-soft-bg: initial;
+    --int-soft-bg: initial;
   }
 }
 
 .btn-accent {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-accent);
     --btn-fg: var(--color-accent-content);
-    --btn-soft-bg: initial;
+    --int-soft-bg: initial;
   }
 }
 
 .btn-neutral {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-neutral);
     --btn-fg: var(--color-neutral-content);
-    --btn-soft-bg: var(--color-neutral-content) 80%;
+    --int-soft-bg: var(--color-neutral-content) 80%;
     --btn-rest-fg: initial;
   }
 }
 
 .btn-info {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-info);
     --btn-fg: var(--color-info-content);
-    --btn-soft-bg: initial;
+    --int-soft-bg: initial;
   }
 }
 
 .btn-success {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-success);
     --btn-fg: var(--color-success-content);
-    --btn-soft-bg: initial;
+    --int-soft-bg: initial;
   }
 }
 
 .btn-warning {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-warning);
     --btn-fg: var(--color-warning-content);
-    --btn-soft-bg: initial;
+    --int-soft-bg: initial;
   }
 }
 
 .btn-error {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-color: var(--color-error);
     --btn-fg: var(--color-error-content);
-    --btn-soft-bg: initial;
+    --int-soft-bg: initial;
   }
 }
 
-.btn-ghost {
-  @layer daisyui.l1 {
-    &:not(
-      .btn-active,
-      :hover,
-      :active:focus,
-      :focus-visible,
-      :checked:not(.filter [type="radio"].btn)
-    ) {
-      --btn-shadow: "";
-      --btn-bg: #0000;
-      --btn-border: #0000;
-      --btn-noise: none;
-      &:not(:disabled, [disabled], .btn-disabled, [aria-disabled="true"]) {
-        @apply outline-current;
-        --btn-fg: var(--btn-rest-fg, var(--btn-color, currentColor));
-      }
-    }
-
-    @media (hover: none) {
-      &:not(.btn-active, :active, :focus-visible, :checked:not(.filter [type="radio"].btn)):hover {
-        @apply outline-current;
-        --btn-shadow: "";
-        --btn-bg: #0000;
-        --btn-fg: var(--btn-rest-fg, var(--btn-color, currentColor));
-        --btn-border: #0000;
-        --btn-noise: none;
-      }
-    }
-  }
-}
-
-.btn-link {
-  @layer daisyui.l1 {
-    @apply underline outline-current;
-    --btn-border: #0000;
-    --btn-bg: #0000;
-    --btn-noise: none;
-    --btn-shadow: "";
-
-    &:not(.btn-disabled, .btn:disabled, .btn[disabled], [aria-disabled="true"]) {
-      --btn-fg: var(--btn-color, var(--color-primary));
-    }
-
-    &:is(.btn-active, :hover, :active:focus, :focus-visible) {
-      --btn-border: #0000;
-      --btn-bg: #0000;
-    }
-  }
-}
-
-.btn-outline,
-.btn-dash {
-  @layer daisyui.l1 {
-    &:not(
-      .btn-active,
-      :hover,
-      :active:focus,
-      :focus-visible,
-      :checked:not(.filter [type="radio"].btn),
-      :disabled,
-      [disabled],
-      .btn-disabled,
-      [aria-disabled="true"]
-    ) {
-      --btn-shadow: "";
-      --btn-bg: #0000;
-      --btn-fg: var(--btn-rest-fg, var(--btn-color));
-      --btn-border: var(--btn-color);
-      --btn-noise: none;
-    }
-
-    @media (hover: none) {
-      &:not(.btn-active, :active, :focus-visible, :checked:not(.filter [type="radio"].btn)):hover {
-        --btn-shadow: "";
-        --btn-bg: #0000;
-        --btn-fg: var(--btn-rest-fg, var(--btn-color));
-        --btn-border: var(--btn-color);
-        --btn-noise: none;
-      }
-    }
-  }
-}
-
-.btn-dash {
-  border-style: dashed;
-}
-
-.btn-soft {
-  @layer daisyui.l1 {
-    &:not(
-      .btn-active,
-      :hover,
-      :active:focus,
-      :focus-visible,
-      :checked:not(.filter [type="radio"].btn),
-      :disabled,
-      [disabled],
-      .btn-disabled,
-      [aria-disabled="true"]
-    ) {
-      --btn-shadow: "";
-      --btn-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
-      --btn-bg: color-mix(
-        in oklab,
-        var(--btn-color, var(--color-base-content)) 8%,
-        var(--btn-soft-bg, var(--color-base-100))
-      );
-      --btn-border: color-mix(
-        in oklab,
-        var(--btn-color, var(--color-base-content)) 10%,
-        var(--btn-soft-bg, var(--color-base-100))
-      );
-      --btn-noise: none;
-    }
-
-    @media (hover: none) {
-      &:not(.btn-active, :active, :focus-visible, :checked:not(.filter [type="radio"].btn)):hover {
-        --btn-shadow: "";
-        --btn-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
-        --btn-bg: color-mix(
-          in oklab,
-          var(--btn-color, var(--color-base-content)) 8%,
-          var(--btn-soft-bg, var(--color-base-100))
-        );
-        --btn-border: color-mix(
-          in oklab,
-          var(--btn-color, var(--color-base-content)) 10%,
-          var(--btn-soft-bg, var(--color-base-100))
-        );
-        --btn-noise: none;
-      }
-    }
-  }
-}
-
+/* 2d. Sizes */
 .btn-xs {
   @layer daisyui.l1.l2 {
     --fontsize: 0.6875rem;
@@ -350,6 +263,18 @@
   }
 }
 
+.btn-wide {
+  @layer daisyui.l1.l2 {
+    @apply w-full max-w-64;
+  }
+}
+
+.btn-block {
+  @layer daisyui.l1.l2 {
+    @apply w-full;
+  }
+}
+
 .btn-square {
   @layer daisyui.l1.l2 {
     @apply px-0;
@@ -366,14 +291,69 @@
   }
 }
 
-.btn-wide {
+/* 3. INTERACTION & STATE */
+.btn {
   @layer daisyui.l1.l2 {
-    @apply w-full max-w-64;
+    @media (hover: hover) {
+      &:hover {
+        --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
+        --int-fg: var(--btn-fg);
+        --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
+        --int-noise: var(--fx-noise);
+        --int-inset: var(--int-inset-def);
+        --int-shadow: var(--int-shadow-def);
+      }
+    }
+
+    &:active:not(.btn-active) {
+      translate: 0 0.5px;
+      --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
+      --int-fg: var(--btn-fg, var(--color-base-content));
+      --int-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
+      --int-border-style: solid;
+      --int-inset: var(--int-no-shadow);
+      --int-shadow: var(--int-no-shadow);
+    }
+
+    /* Force solid state (checked/active/focus-visible if not checkable) */
+    &:where(
+      :checked:not(.filter [type="radio"].btn),
+      .btn-active,
+      :not([type="radio"], [type="checkbox"]):focus-visible
+    ) {
+      --int-bg: var(--btn-color, var(--color-base-200));
+      --int-fg: var(--btn-fg, var(--color-base-content));
+      --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
+      --int-border-style: solid;
+      --int-noise: var(--fx-noise);
+      --int-inset: var(--int-inset-def);
+      --int-shadow: var(--int-shadow-def);
+      isolation: isolate;
+    }
+
+    &:focus-visible,
+    &:has(:focus-visible) {
+      outline-width: 2px;
+      outline-style: solid;
+      isolation: isolate;
+    }
   }
 }
 
-.btn-block {
-  @layer daisyui.l1.l2 {
-    @apply w-full;
+/* Disabled State */
+.btn-disabled,
+.btn:is(:disabled, [disabled], [aria-disabled="true"]) {
+  @layer daisyui {
+    @apply pointer-events-none;
+    --int-fg: color-mix(in oklch, var(--color-base-content) 20%, #0000);
+    --int-bg: #0000;
+    --int-border: #0000;
+    --int-noise: none;
+    --int-inset: var(--int-no-shadow);
+    --int-shadow: var(--int-no-shadow);
+
+    &:not(.btn-link, .btn-ghost) {
+      @apply bg-base-content/10;
+    }
   }
 }

--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -10,13 +10,9 @@
 
 .btn {
   @layer daisyui.l1.l2.l3 {
-    /* User-facing defaults */
-    /* --btn-color */
-    /* --btn-rest-fg */
     --size: calc(var(--size-field, 0.25rem) * 10);
     --btn-p: 1rem;
     --btn-fg: var(--color-base-content);
-    --btn-noise: var(--fx-noise);
 
     @apply inline-flex shrink-0 cursor-pointer flex-nowrap items-center justify-center gap-1.5 text-center align-middle outline-offset-2 select-none;
     font-weight: 600;
@@ -30,40 +26,34 @@
     transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
     transition-duration: 0.2s;
 
-    --int-bg: var(--btn-color, var(--color-base-200));
-    --int-fg: var(--btn-fg);
-    --int-border: color-mix(
+    --btn-bg: var(--btn-color, var(--color-base-200));
+    --btn-border: color-mix(
       in oklab,
       var(--btn-color, var(--color-base-200)),
       #000 calc(var(--depth) * 5%)
     );
-    --int-border-style: solid;
-    --int-soft-bg: initial;
-    --int-noise: var(--btn-noise);
-    --int-no-shadow: 0 0 0 0 oklch(0% 0 0/0);
-    --int-shadow-def:
-      0 3px 2px -2px color-mix(in oklab, var(--int-bg) calc(var(--depth) * 30%), #0000),
-      0 4px 3px -2px color-mix(in oklab, var(--int-bg) calc(var(--depth) * 30%), #0000);
-    --int-shadow: var(--int-shadow-def);
-    --int-inset-def: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
-    --int-inset: var(--int-inset-def);
+    --btn-soft-bg: initial;
+    --btn-shadow:
+      0 3px 2px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000),
+      0 4px 3px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000);
+    --btn-inset: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
 
     height: var(--size);
     padding-inline: var(--btn-p);
     font-size: var(--fontsize, 0.875rem);
-    background-color: var(--int-bg);
-    color: var(--int-fg);
-    border-color: var(--int-border);
-    border-style: var(--int-border-style);
+    background-color: var(--btn-bg);
+    color: var(--btn-fg);
+    border-color: var(--btn-border);
+    border-style: solid;
     outline-color: var(--btn-color, var(--color-base-content));
-    --tw-prose-links: var(--int-fg);
+    --tw-prose-links: var(--btn-fg);
 
-    background-image: none, var(--int-noise);
+    background-image: none, var(--fx-noise);
     background-size: auto, calc(var(--noise, 0) * 100%);
     text-shadow: 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 0.15));
     box-shadow:
-      var(--int-inset) inset,
-      var(--int-shadow);
+      var(--btn-inset) inset,
+      var(--btn-shadow);
 
     &:is([type="checkbox"], [type="radio"]) {
       @apply appearance-none;
@@ -84,23 +74,23 @@
 
     @media (hover: hover) {
       &:hover {
-        --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-        --int-fg: var(--btn-fg);
-        --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
-        --int-noise: var(--fx-noise);
-        --int-inset: var(--int-inset-def);
-        --int-shadow: var(--int-shadow-def);
+        --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
+        color: var(--btn-fg);
+        --btn-border: color-mix(in oklab, var(--btn-bg), #000 calc(var(--depth) * 5%));
+        --btn-inset: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
+        --btn-shadow:
+          0 3px 2px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000),
+          0 4px 3px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000);
       }
     }
 
     &:active:not(.btn-active) {
       translate: 0 0.5px;
-      --int-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
-      --int-fg: var(--btn-fg, var(--color-base-content));
-      --int-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
-      --int-border-style: solid;
-      --int-inset: var(--int-no-shadow);
-      --int-shadow: var(--int-no-shadow);
+      --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
+      color: var(--btn-fg, var(--color-base-content));
+      --btn-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
+      --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
+      --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
     }
 
     &:where(
@@ -108,13 +98,13 @@
       .btn-active,
       :not([type="radio"], [type="checkbox"]):focus-visible
     ) {
-      --int-bg: var(--btn-color, var(--color-base-200));
-      --int-fg: var(--btn-fg, var(--color-base-content));
-      --int-border: color-mix(in oklab, var(--int-bg), #000 calc(var(--depth) * 5%));
-      --int-border-style: solid;
-      --int-noise: var(--fx-noise);
-      --int-inset: var(--int-inset-def);
-      --int-shadow: var(--int-shadow-def);
+      --btn-bg: var(--btn-color, var(--color-base-200));
+      color: var(--btn-fg, var(--color-base-content));
+      --btn-border: color-mix(in oklab, var(--btn-bg), #000 calc(var(--depth) * 5%));
+      --btn-inset: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
+      --btn-shadow:
+        0 3px 2px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000),
+        0 4px 3px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000);
       isolation: isolate;
     }
 
@@ -130,62 +120,60 @@
 .btn-outline,
 .btn-dash {
   @layer daisyui.l1.l2.l3 {
-    --int-bg: #0000;
-    --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
-    --int-border: var(--btn-color, var(--color-base-content));
-    --int-border-style: solid;
-    --int-noise: none;
-    --int-inset: var(--int-no-shadow);
-    --int-shadow: var(--int-no-shadow);
+    --btn-bg: #0000;
+    color: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
+    --btn-border: var(--btn-color, var(--color-base-content));
+    background-image: none;
+    --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
+    --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
   }
 }
 
 .btn-dash {
   @layer daisyui.l1.l2.l3 {
-    --int-border-style: dashed;
+    border-style: dashed;
   }
 }
 
 .btn-ghost {
   @layer daisyui.l1.l2.l3 {
-    --int-bg: #0000;
-    --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content, currentColor)));
-    --int-border: #0000;
-    --int-noise: none;
-    --int-inset: var(--int-no-shadow);
-    --int-shadow: var(--int-no-shadow);
+    --btn-bg: #0000;
+    color: var(--btn-rest-fg, var(--btn-color, var(--color-base-content, currentColor)));
+    --btn-border: #0000;
+    background-image: none;
+    --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
+    --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
   }
 }
 
 .btn-soft {
   @layer daisyui.l1.l2.l3 {
-    --int-bg: color-mix(
+    --btn-bg: color-mix(
       in oklab,
       var(--btn-color, var(--color-base-content)) 8%,
-      var(--int-soft-bg, var(--color-base-100))
+      var(--btn-soft-bg, var(--color-base-100))
     );
-    --int-fg: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
-    --int-border: color-mix(
+    color: var(--btn-rest-fg, var(--btn-color, var(--color-base-content)));
+    --btn-border: color-mix(
       in oklab,
       var(--btn-color, var(--color-base-content)) 10%,
-      var(--int-soft-bg, var(--color-base-100))
+      var(--btn-soft-bg, var(--color-base-100))
     );
-    --int-border-style: solid;
-    --int-noise: none;
-    --int-inset: var(--int-no-shadow);
-    --int-shadow: var(--int-no-shadow);
+    background-image: none;
+    --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
+    --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
   }
 }
 
 .btn-link {
   @layer daisyui.l1 {
     @apply underline;
-    --int-bg: #0000;
-    --int-fg: var(--btn-color, var(--color-primary));
-    --int-border: #0000;
-    --int-noise: none;
-    --int-inset: var(--int-no-shadow);
-    --int-shadow: var(--int-no-shadow);
+    --btn-bg: #0000;
+    color: var(--btn-color, var(--color-primary));
+    --btn-border: #0000;
+    background-image: none;
+    --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
+    --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
   }
 }
 
@@ -193,7 +181,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-primary);
     --btn-fg: var(--color-primary-content);
-    --int-soft-bg: initial;
+    --btn-soft-bg: initial;
   }
 }
 
@@ -201,7 +189,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-secondary);
     --btn-fg: var(--color-secondary-content);
-    --int-soft-bg: initial;
+    --btn-soft-bg: initial;
   }
 }
 
@@ -209,7 +197,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-accent);
     --btn-fg: var(--color-accent-content);
-    --int-soft-bg: initial;
+    --btn-soft-bg: initial;
   }
 }
 
@@ -217,7 +205,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-neutral);
     --btn-fg: var(--color-neutral-content);
-    --int-soft-bg: var(--color-neutral-content) 80%;
+    --btn-soft-bg: var(--color-neutral-content) 80%;
     --btn-rest-fg: initial;
   }
 }
@@ -226,7 +214,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-info);
     --btn-fg: var(--color-info-content);
-    --int-soft-bg: initial;
+    --btn-soft-bg: initial;
   }
 }
 
@@ -234,7 +222,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-success);
     --btn-fg: var(--color-success-content);
-    --int-soft-bg: initial;
+    --btn-soft-bg: initial;
   }
 }
 
@@ -242,7 +230,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-warning);
     --btn-fg: var(--color-warning-content);
-    --int-soft-bg: initial;
+    --btn-soft-bg: initial;
   }
 }
 
@@ -250,7 +238,7 @@
   @layer daisyui.l1.l2 {
     --btn-color: var(--color-error);
     --btn-fg: var(--color-error-content);
-    --int-soft-bg: initial;
+    --btn-soft-bg: initial;
   }
 }
 
@@ -326,12 +314,12 @@
 .btn:is(:disabled, [disabled], [aria-disabled="true"]) {
   @layer daisyui {
     @apply pointer-events-none;
-    --int-fg: color-mix(in oklch, var(--color-base-content) 20%, #0000);
-    --int-bg: #0000;
-    --int-border: #0000;
-    --int-noise: none;
-    --int-inset: var(--int-no-shadow);
-    --int-shadow: var(--int-no-shadow);
+    color: color-mix(in oklch, var(--color-base-content) 20%, #0000);
+    --btn-bg: #0000;
+    --btn-border: #0000;
+    background-image: none;
+    --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
+    --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
 
     &:not(.btn-link, .btn-ghost) {
       @apply bg-base-content/10;

--- a/packages/docs/src/routes/(routes)/docs/utilities/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/utilities/+page.md
@@ -129,6 +129,7 @@ If you are using a prefix for daisyUI, these CSS variables will be prefixed with
 |                 | `--size`                      | size of the badge                                        |
 | Button          | `--btn-color`                 | background color of the button                           |
 |                 | `--btn-fg`                    | foreground color of the button                           |
+|                 | `--btn-rest-fg`               | foreground color of the button in default/rest state     |
 |                 | `--btn-shadow`                | shadow of the button                                     |
 |                 | `--btn-noise`                 | noise background of the button if enabled                |
 |                 | `--btn-p`                     | padding of the button                                    |


### PR DESCRIPTION
Organize styles so that there is very little need for duplication.
The only styles that do not work with tailwind responsive modifiers are the ones for disabled .btn-link and .btn-ghost.

I have prepared 3 playgrounds that should cover most of the normal usage:
- 5.4.7: https://play.tailwindcss.com/uUitizu33y?layout=preview
- 5.4.8+: https://play.tailwindcss.com/mkA67TyHx8?layout=preview
- full rewrite: https://play.tailwindcss.com/QZaRC8aifn?layout=preview

Problems fixed:
- [x] if buttons (checkbox) are used in `.filter` they do not show active status
  - also in #4427, so it would be better to first merge that one
- [x] `aria-disabled="true"` is not accounted for
- [x] on all dark themes `.btn-neutral .btn-soft` cannot be used
  - addressed by introducing an internal variable to set the soft bg color for neutral (`--int-soft-bg: var(--color-neutral-content) 80%;`)
- [x] `.btn-soft`, `.btn-outline`, `.btn-dash`, `.btn-ghost`, `.btn-link` when there is contrast between fg (`--btn-fg`) and bg (`--btn-color`) button colors, but there is no contrast in rest state between bg (derivative of `--color-base-100` or page bg) and fg (`--btn-color`)
  - new user facing variable `--btn-rest-fg` that sets the fg color for buttons in rest state (only for soft, outline, dash, ghost) - it is ignored for `.btn-neutral` because that color has its own rules
  - `.btn-link` does not need any mitigation because it uses the same color all the time, so it can already be set by the user
  - in the example `--btn-rest-fg` is set for the  whole theme, but it can be used for individual buttons also
- [x] a checkable button cannot be identified as checked/unchecked when focused
- [x] setting `--btn-color` and ``--btn-fg` on buttons does not work as expected


close #4430