### PR TITLE
Update for tailwind 4 +page.md

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/nuxt/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/nuxt/+page.md
@@ -27,15 +27,15 @@ Add Tailwind CSS to Vite config
 import tailwindcss from "@tailwindcss/vite";
 export default defineNuxtConfig({
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [tailwindcss() as any],
   },
-  css: ["./app/tailwind.css"],
+  css: ['~/assets/css/main.css'],
 });
 ```
 
 Put Tailwind CSS and daisyUI in your CSS file (and remove old styles)
   
-```postcss:app/tailwind.css
+```postcss:app/assets/css/main.css
 @import "tailwindcss";
 @plugin "daisyui";
 ```


### PR DESCRIPTION
- Update for tailwind 4 compatible with nuxt ui https://ui.nuxt.com/docs/getting-started/installation/nuxt#import-tailwind-css-and-nuxt-ui-in-your-css
- Fix the following error: Type 'Plugin<any>[]' is not assignable to type 'PluginOption'.