### PR TITLE
docs: add fixed height example to select

### DIFF
--- a/packages/docs/src/routes/(routes)/components/select/+page.md
+++ b/packages/docs/src/routes/(routes)/components/select/+page.md
@@ -104,7 +104,7 @@ classnames:
 
 <fieldset class="fieldset w-xs">
   <legend class="fieldset-legend">Browsers</legend>
-  <select class="select">
+  <select class="select max-h-60 overflow-y-auto z-[1]">
     <option disabled selected>Pick a Browser</option>
     <option>Chrome</option>
     <option>FireFox</option>


### PR DESCRIPTION
Added a fixed height usage example to the Select component documentation, by using the max-h- and overflow-y-auto utility classes, within the select menu, improving usability and layout stability.

Closes #4440