### PR TITLE
docs: add tooltip component to llms.txt

### DIFF
--- a/packages/docs/static/llms.txt
+++ b/packages/docs/static/llms.txt
@@ -1832,6 +1832,28 @@ Toggle is a checkbox that is styled to look like a switch button
 #### Rules
 - {MODIFIER} is optional and can have one of each color/size class names
 
+### tooltip
+Tooltip can be used to show a message when hovering over an element
+
+[tooltip docs](https://daisyui.com/components/tooltip/)
+
+#### Class names
+- component: `tooltip`
+- part: `tooltip-content`
+- modifier: `tooltip-open`
+- placement: `tooltip-top`, `tooltip-bottom`, `tooltip-left`, `tooltip-right`
+- color: `tooltip-primary`, `tooltip-secondary`, `tooltip-accent`, `tooltip-info`, `tooltip-success`, `tooltip-warning`, `tooltip-error`
+
+#### Syntax
+```html
+<div class="tooltip {MODIFIER}" data-tip="Tooltip text">
+  <button class="btn">Hover me</button>
+</div>
+```
+
+#### Rules
+- {MODIFIER} is optional and can have one of each modifier/placement/color class names
+
 ### validator
 Validator class changes the color of form elements to error or success based on input's validation rules
 


### PR DESCRIPTION
This PR adds the missing `tooltip` component to the `packages/docs/static/llms.txt` file. It ensures the documentation accurately reflects the available daisyUI components for LLMs.