### PR TITLE
fix: allow hyphens and spaces in theme generator theme name

### DIFF
--- a/packages/docs/src/lib/themeGeneratorCssParser.js
+++ b/packages/docs/src/lib/themeGeneratorCssParser.js
@@ -61,7 +61,7 @@ export function parseThemeCSS(text, currentThemeData) {
 
       // Handle base theme properties
       if (key === "name") {
-        const cleanName = value.replace(/['"]/g, "")
+        const cleanName = value.replace(/['"]/g, "").trim()
         if (!validateThemeName(cleanName)) {
           console.error(`Invalid theme name: ${cleanName} (must be 3-20 lowercase letters)`)
           hasErrors = true

--- a/packages/docs/src/lib/themeGeneratorValidation.js
+++ b/packages/docs/src/lib/themeGeneratorValidation.js
@@ -1,5 +1,5 @@
 // Validation patterns
-const themeNamePattern = /^[a-z]{3,20}$/
+const themeNamePattern = /^[a-z][a-z0-9- ]{1,18}[a-z0-9]$|^[a-z]{3,20}$/
 const borderRadiusPattern = /^(0|0rem|0\.125rem|0\.25rem|0\.5rem|0\.75rem|1rem|2rem)$/
 const sizePattern = /^(0\.1875rem|0\.21875rem|0\.25rem|0\.28125rem|0\.3125rem)$/
 const borderWidthPattern = /^(0\.5px|1px|1\.5px|2px)$/
@@ -37,7 +37,8 @@ export function validateThemeName(name) {
     console.error("Theme name must be a string", name)
     return false
   }
-  if (!themeNamePattern.test(name)) {
+  const trimmedName = name.trim()
+  if (!themeNamePattern.test(trimmedName)) {
     console.error("Theme name does not match the required pattern", name)
     return false
   }

--- a/packages/docs/src/routes/(routes)/theme-generator/+page.svelte
+++ b/packages/docs/src/routes/(routes)/theme-generator/+page.svelte
@@ -362,7 +362,7 @@
 
   const generateCSS = (theme) => {
     const baseProps = [
-      `  name: "${theme.name}";`,
+      `  name: "${theme.name.trim()}";`,
       `  default: ${theme.default ? "true" : "false"};`,
       `  prefersdark: ${theme.prefersdark ? "true" : "false"};`,
       `  color-scheme: "${theme["color-scheme"]}";`,


### PR DESCRIPTION
Fixes #4387.
The theme generator silently discards all changes when the theme name contains a hyphen (e.g. my-theme) or a space (e.g. cringe classic). This is caused by an overly restrictive regex in `themeGeneratorValidation.js `that only accepts `[a-z]` characters.

## changes made
- Updated themeNamePattern in `themeGeneratorValidation.js` to allow lowercase letters, digits, spaces, and hyphens (while continuing to prevent them at the very start or end of the name).
- Added `.trim()` to the validation pipeline so that trailing spaces typed by users don't temporarily break the validator or pollute the generated output.



https://github.com/user-attachments/assets/6de1f64d-a0cb-4aab-a308-e32e084ee907



