### PR TITLE
docs: fix mockup-browser background color HTML snippet

### DIFF
--- a/packages/docs/src/routes/(routes)/components/mockup-browser/+page.md
+++ b/packages/docs/src/routes/(routes)/components/mockup-browser/+page.md
@@ -26,7 +26,7 @@ classnames:
 </div>
 
 ```html
-<div class="$$mockup-browser border-base-300 border w-full">
+<div class="$$mockup-browser border border-base-300 w-full">
   <div class="$$mockup-browser-toolbar">
     <div class="$$input">https://daisyui.com</div>
   </div>
@@ -44,7 +44,7 @@ classnames:
 </div>
 
 ```html
-<div class="$$mockup-browser border border-base-300 w-full">
+<div class="$$mockup-browser bg-base-100 w-full border border-base-300">
   <div class="$$mockup-browser-toolbar">
     <div class="$$input">https://daisyui.com</div>
   </div>


### PR DESCRIPTION
## Description
In the “browser mockup with background color” section, there was a discrepancy between the preview and the HTML snippet.  

## Changes
- Added the class `bg-base-100` to ensure the example accurately reflects the “background color” intent
- Adjusted the order of the classes to maintain consistency between the preview and the code snippet
