### PR TITLE
fix(theme plugin): use prefix to generate custom theme blocks

### DIFF
--- a/packages/daisyui/functions/generateThemeFiles.js
+++ b/packages/daisyui/functions/generateThemeFiles.js
@@ -4,12 +4,12 @@ import { getFileNames } from "./getFileNames.js"
 
 export const wrapContent = (themeName, content) => {
   if (themeName === "light") {
-    return `:root,:root:has(input.theme-controller[value=${themeName}]:checked),[data-theme="${themeName}"] {
+    return `:root,:root:has(input.theme-controller[value="${themeName}"]:checked),[data-theme="${themeName}"] {
 ${content}}
 `
   }
 
-  return `:root:has(input.theme-controller[value=${themeName}]:checked),[data-theme="${themeName}"] {
+  return `:root:has(input.theme-controller[value="${themeName}"]:checked),[data-theme="${themeName}"] {
 ${content}}
 `
 }

--- a/packages/daisyui/functions/pluginOptionsHandler.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.js
@@ -24,7 +24,7 @@ export const pluginOptionsHandler = (() => {
       if (theme) {
         // Use prefix for theme-controller class name
         const themeControllerClass = `${prefix}theme-controller`
-        let selector = `${root}:has(input.${themeControllerClass}[value=${themeName}]:checked),[data-theme=${themeName}]`
+        let selector = `${root}:has(input.${themeControllerClass}[value="${themeName}"]:checked),[data-theme="${themeName}"]`
         if (flags.includes("--default")) {
           selector = `:where(${root}),${selector}`
         }
@@ -32,9 +32,7 @@ export const pluginOptionsHandler = (() => {
 
         if (flags.includes("--prefersdark")) {
           // Use :root:not([data-theme]) for dark mode specificity
-          const darkSelector =
-            root === ":root" ? ":root:not([data-theme])" : `${root}:not([data-theme])`
-          addBase({ "@media (prefers-color-scheme: dark)": { [darkSelector]: theme } })
+          addBase({ "@media (prefers-color-scheme: dark)": { [`${root}:not([data-theme])`]: theme } })
         }
       }
     }
@@ -45,9 +43,7 @@ export const pluginOptionsHandler = (() => {
       }
 
       if (themesObject["dark"]) {
-        const darkSelector =
-          root === ":root" ? ":root:not([data-theme])" : `${root}:not([data-theme])`
-        addBase({ "@media (prefers-color-scheme: dark)": { [darkSelector]: themesObject["dark"] } })
+        addBase({ "@media (prefers-color-scheme: dark)": { [`${root}:not([data-theme])`]: themesObject["dark"] } })
       }
 
       themeOrder.forEach((themeName) => {
@@ -77,10 +73,8 @@ export const pluginOptionsHandler = (() => {
       themeArray.forEach((themeOption) => {
         const [themeName, ...flags] = themeOption.split(" ")
         if (flags.includes("--prefersdark")) {
-          const darkSelector =
-            root === ":root" ? ":root:not([data-theme])" : `${root}:not([data-theme])`
           addBase({
-            "@media (prefers-color-scheme: dark)": { [darkSelector]: themesObject[themeName] },
+            "@media (prefers-color-scheme: dark)": { [`${root}:not([data-theme])`]: themesObject[themeName] },
           })
         }
       })

--- a/packages/daisyui/functions/pluginOptionsHandler.test.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.test.js
@@ -17,7 +17,7 @@ test("pluginOptionsHandler should apply default themes", () => {
   pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
 
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light]": {
+    ":where(:root),:root:has(input.theme-controller[value=\"light\"]:checked),[data-theme=\"light\"]": {
       color: "white",
     },
   })
@@ -25,12 +25,12 @@ test("pluginOptionsHandler should apply default themes", () => {
     "@media (prefers-color-scheme: dark)": { ":root:not([data-theme])": { color: "black" } },
   })
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":root:has(input.theme-controller[value=dark]:checked),[data-theme=dark]": {
+    ":root:has(input.theme-controller[value=\"dark\"]:checked),[data-theme=\"dark\"]": {
       color: "black",
     },
   })
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":root:has(input.theme-controller[value=light]:checked),[data-theme=light]": {
+    ":root:has(input.theme-controller[value=\"light\"]:checked),[data-theme=\"light\"]": {
       color: "white",
     },
   })
@@ -45,7 +45,7 @@ test("pluginOptionsHandler should apply all themes when 'all' is specified", () 
   pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
 
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light]": {
+    ":where(:root),:root:has(input.theme-controller[value=\"light\"]:checked),[data-theme=\"light\"]": {
       color: "white",
     },
   })
@@ -53,7 +53,7 @@ test("pluginOptionsHandler should apply all themes when 'all' is specified", () 
     "@media (prefers-color-scheme: dark)": { ":root:not([data-theme])": { color: "black" } },
   })
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":root:has(input.theme-controller[value=dark]:checked),[data-theme=dark]": {
+    ":root:has(input.theme-controller[value=\"dark\"]:checked),[data-theme=\"dark\"]": {
       color: "black",
     },
   })
@@ -68,7 +68,7 @@ test("pluginOptionsHandler should handle custom themes", () => {
   pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
 
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":root:has(input.theme-controller[value=custom]:checked),[data-theme=custom]": {
+    ":root:has(input.theme-controller[value=\"custom\"]:checked),[data-theme=\"custom\"]": {
       color: "blue",
     },
   })
@@ -95,7 +95,7 @@ test("pluginOptionsHandler should not create duplicate styles for single light t
   // Should be called exactly once
   expect(mockAddBase).toHaveBeenCalledTimes(1)
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light]": {
+    ":where(:root),:root:has(input.theme-controller[value=\"light\"]:checked),[data-theme=\"light\"]": {
       color: "white",
     },
   })
@@ -111,7 +111,7 @@ test("pluginOptionsHandler should not create duplicate styles for single dark th
   // Should be called exactly once
   expect(mockAddBase).toHaveBeenCalledTimes(1)
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":where(:root),:root:has(input.theme-controller[value=dark]:checked),[data-theme=dark]": {
+    ":where(:root),:root:has(input.theme-controller[value=\"dark\"]:checked),[data-theme=\"dark\"]": {
       color: "black",
     },
   })
@@ -125,7 +125,7 @@ test("pluginOptionsHandler should prefix theme-controller class when prefix is s
   pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
 
   expect(mockAddBase).toHaveBeenCalledWith({
-    ":where(:root),:root:has(input.myprefix-theme-controller[value=light]:checked),[data-theme=light]":
+    ":where(:root),:root:has(input.myprefix-theme-controller[value=\"light\"]:checked),[data-theme=\"light\"]":
       {
         color: "white",
       },

--- a/packages/daisyui/functions/themePlugin.js
+++ b/packages/daisyui/functions/themePlugin.js
@@ -15,11 +15,12 @@ export default plugin.withOptions((options = {}) => {
       prefersdark = false,
       "color-scheme": colorScheme,
       root = ":root",
+      prefix = "",
       ...customThemeTokens
     } = options
 
     const escapedName = escapeCssString(name)
-    let selector = `${root}:has(input.theme-controller[value="${escapedName}"]:checked),[data-theme="${escapedName}"]`
+    let selector = `${root}:has(input.${prefix}theme-controller[value="${escapedName}"]:checked),[data-theme="${escapedName}"]`
     if (isDefault) {
       selector = `:where(${root}),${selector}`
     }
@@ -44,11 +45,9 @@ export default plugin.withOptions((options = {}) => {
 
     if (prefersdark) {
       // Use :root:not([data-theme]) for dark mode specificity
-      const darkSelector =
-        root === ":root" ? ":root:not([data-theme])" : `${root}:not([data-theme])`
       addBase({
         "@media (prefers-color-scheme: dark)": {
-          [darkSelector]: baseStyles[selector],
+          [`${root}:not([data-theme])`]: baseStyles[selector],
         },
       })
     }

--- a/packages/docs/src/routes/(routes)/docs/themes/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/themes/+page.md
@@ -109,6 +109,8 @@ To add a new theme, use `@plugin "daisyui/theme" {}` in your CSS file, with the 
   default: true; /* set as default */
   prefersdark: false; /* set as default dark mode (prefers-color-scheme:dark) */
   color-scheme: light; /* color of browser-provided UI */
+  root: '.my-custom-root'; /* OPTIONAL - use same value used in @plugin "daisyui" if you used a custom root */
+  prefix: 'my-custom-prefix-'; /* OPTIONAL - use same value used in @plugin "daisyui" if you used a custom daisyui prefix */
 
   --color-base-100: oklch(98% 0.02 240);
   --color-base-200: oklch(95% 0.03 240);


### PR DESCRIPTION
`daisyui/theme` plugin now:
- tries to read and use the `root` option (but it is not the option passed to the `daisyui` plugin, it must be passed to the `daisyui/theme` plugin)
- does not use the `prefix` option

I cannot find a way to use the same options in both plugins, so what this fixes is:
- to also use the `prefix` option (both `root` and `prefix` options must be passed to the `daisyui/theme` plugin)

There are also some small tweaks:
- consistency in quoting theme names
- remove redundant checking if root is ':root' to build the dark-mode selector

ref #4513
example of bad behavior:
~https://play.tailwindcss.com/dwkjhIRnuv~
https://play.tailwindcss.com/4afH5PJoWe

The code generated by the example (only relevant parts):

```css
/* original themes */
@layer base {
  :root:has(input.d-theme-controller[value=light]:checked),[data-theme=light] {
    color-scheme: light;
    --color-primary: oklch(45% 0.24 277.023);
  }
}
@layer base {
  :root:has(input.d-theme-controller[value=dark]:checked),[data-theme=dark] {
    color-scheme: dark;
    --color-primary: oklch(58% 0.233 277.117);
  }
}
/* first set of overwritten themes - notice absence of prefix */
@layer base {
  :where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme="light"] {
    color-scheme: light;
    --color-primary: oklch(63% 0.237 25.331);
  }
}
@layer base {
  @media (prefers-color-scheme: dark) {
    :root:not([data-theme]) {
      color-scheme: dark;
      --color-primary: oklch(72% 0.219 149.579);
    }
  }
}
@layer base {
  :root:has(input.theme-controller[value=dark]:checked),[data-theme="dark"] {
    color-scheme: dark;
    --color-primary: oklch(72% 0.219 149.579);
  }
}
/* second set of overwritten themes - notice absence of prefix */
@layer base {
  :where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme="light"] {
    color-scheme: light;
    --color-primary: oklch(55% 0.027 264.364);
  }
}
@layer base {
  @media (prefers-color-scheme: dark) {
    :root:not([data-theme]) {
      color-scheme: dark;
      --color-primary: oklch(79% 0.184 86.047);
    }
  }
}
@layer base {
  :root:has(input.theme-controller[value=dark]:checked),[data-theme="dark"] {
    color-scheme: dark;
    --color-primary: oklch(79% 0.184 86.047);
  }
}
```