### PR TITLE
fix(collapse): open/close transition for details and too lax styling of summary

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -39,6 +39,7 @@
       > .collapse-content,
     &:not(.collapse-close)
       > :where(input:is([type="checkbox"], [type="radio"]):checked ~ .collapse-content) {
+      --overflow-delay: 0.2s;
       overflow: revert-layer;
       content-visibility: visible;
       min-height: fit-content;
@@ -91,6 +92,46 @@
 
       &:has(~ label) {
         z-index: revert-layer;
+      }
+    }
+
+    &:is(details) {
+      width: 100%;
+
+      &::details-content {
+        --overflow-delay: 0s;
+        overflow: clip;
+        height: 0;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        &::details-content {
+          transition:
+            overflow 0.2s allow-discrete var(--overflow-delay),
+            content-visibility 0.2s allow-discrete,
+            visibility 0.2s allow-discrete,
+            min-height 0.2s ease-out allow-discrete,
+            padding 0.1s ease-out 20ms,
+            background-color 0.2s ease-out,
+            height 0.2s;
+          interpolate-size: allow-keywords;
+        }
+
+        &:where([open])::details-content {
+          --overflow-delay: 0.2s;
+          height: auto;
+          overflow: revert-layer;
+        }
+      }
+
+      > summary {
+        position: relative;
+        display: block;
+        outline: none;
+
+        &::-webkit-details-marker {
+          display: none;
+        }
       }
     }
   }
@@ -163,8 +204,7 @@
   }
 }
 
-.collapse-title,
-.collapse-content {
+.collapse-title {
   @layer daisyui.l1.l2.l3 {
     grid-column-start: 1;
     grid-row-start: 1;
@@ -173,6 +213,7 @@
 
 .collapse-content {
   @layer daisyui.l1.l2.l3 {
+    --overflow-delay: 0s;
     content-visibility: hidden;
     overflow: clip;
     grid-column-start: 1;
@@ -186,57 +227,17 @@
     }
     @media (prefers-reduced-motion: no-preference) {
       transition:
-        overflow 0.2s allow-discrete,
+        overflow 0.2s allow-discrete var(--overflow-delay),
         content-visibility 0.2s allow-discrete,
         visibility 0.2s allow-discrete,
         min-height 0.2s ease-out allow-discrete,
         padding 0.1s ease-out 20ms,
         background-color 0.2s ease-out;
     }
-  }
-}
 
-.collapse:is(details) {
-  @layer daisyui.l1.l2.l3 {
-    width: 100%;
-    @media (prefers-reduced-motion: no-preference) {
-      &::details-content {
-        overflow: clip;
-        transition:
-          overflow 0.2s allow-discrete,
-          content-visibility 0.2s allow-discrete,
-          visibility 0.2s allow-discrete,
-          min-height 0.2s ease-out allow-discrete,
-          padding 0.1s ease-out 20ms,
-          background-color 0.2s ease-out,
-          height 0.2s;
-        height: 0;
-        interpolate-size: allow-keywords;
-      }
-
-      &:where([open])::details-content {
-        height: auto;
-        overflow: revert-layer;
-      }
-    }
-    & summary {
-      position: relative;
-      display: block;
-
-      &::-webkit-details-marker {
-        display: none;
-      }
-    }
-
-    & > .collapse-content {
+    details > & {
       content-visibility: visible;
     }
-  }
-}
-
-.collapse:is(details) summary {
-  @layer daisyui.l1.l2.l3 {
-    outline: none;
   }
 }
 
@@ -300,6 +301,7 @@
   @layer daisyui.l1.l2 {
     grid-template-rows: max-content 1fr;
     > .collapse-content {
+      --overflow-delay: 0.2s;
       overflow: revert-layer;
       content-visibility: visible;
       min-height: fit-content;

--- a/packages/docs/src/components/Footer.svelte
+++ b/packages/docs/src/components/Footer.svelte
@@ -382,15 +382,6 @@
         <a
           target="_blank"
           rel="noopener, noreferrer"
-          href="https://github.com/aalaap/laravel-livewire-daisyui-starter-kit"
-          class="link link-hover group"
-        >
-          Laravel Starter Kit
-          {@html newtabicon}
-        </a>
-        <a
-          target="_blank"
-          rel="noopener, noreferrer"
           href="https://tailscan.com/?ref=daisyui"
           class="link link-hover group"
         >

--- a/packages/docs/src/components/StoreFooter.svelte
+++ b/packages/docs/src/components/StoreFooter.svelte
@@ -1,0 +1,65 @@
+<script>
+  import { t } from "$lib/i18n.svelte.js"
+</script>
+
+<div class="h-20"></div>
+
+<div data-sveltekit-preload-data>
+  <div class="bg-base-200 text-base-content">
+    <footer
+      class="footer md:footer-horizontal mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-6 px-4 py-20 text-xs sm:flex-row"
+    >
+      <div>
+        <span class="footer-title opacity-70">{$t("daisyUI Store")}</span>
+        <a class="link link-hover" href="https://www.creem.io/my-orders/login">
+          {$t("My Orders")}
+        </a>
+        <a class="link link-hover" href="https://app.lemonsqueezy.com/my-orders">
+          {$t("My Orders (old panel)")}
+        </a>
+        <a class="link link-hover" href="/store/pages/terms/">{$t("Terms and Conditions")}</a>
+        <a class="link link-hover" href="/store/pages/privacy/">{$t("Privacy Policy")}</a>
+        <a class="link link-hover" href="/store/pages/support/">{$t("Customer Support")}</a>
+        <span></span>
+        <a class="link link-hover -ms-3.5" href="/">{$t("← Go back to daisyui.com")}</a>
+      </div>
+      <div>
+        <form
+          action="https://app.kit.com/forms/7041226/subscriptions"
+          method="post"
+          target="_blank"
+          class="flex flex-col"
+        >
+          <p class="text-base-content/70 mb-4 text-xs font-bold">
+            Get the daisyUI updates and news
+          </p>
+          <div class="join mb-2">
+            <input
+              type="email"
+              class="join-item input"
+              name="email_address"
+              placeholder="email@site.com"
+              required
+            />
+            <button class="join-item btn btn-neutral">Subscribe</button>
+          </div>
+          <p class="text-base-content/60 text-[0.625rem] tracking-wide">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              class="text-success inline-block size-3"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M8.5 1.709a.75.75 0 0 0-1 0 8.963 8.963 0 0 1-4.84 2.217.75.75 0 0 0-.654.72 10.499 10.499 0 0 0 5.647 9.672.75.75 0 0 0 .694-.001 10.499 10.499 0 0 0 5.647-9.672.75.75 0 0 0-.654-.719A8.963 8.963 0 0 1 8.5 1.71Zm2.34 5.504a.75.75 0 0 0-1.18-.926L7.394 9.17l-1.156-.99a.75.75 0 1 0-.976 1.138l1.75 1.5a.75.75 0 0 0 1.078-.106l2.75-3.5Z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            We don't share your email address with anyone
+          </p>
+        </form>
+      </div>
+    </footer>
+  </div>
+</div>

--- a/packages/docs/src/components/TopBanner.svelte
+++ b/packages/docs/src/components/TopBanner.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <!-- Without timer -->
-{#if true && !$page.url.pathname.startsWith("/blueprint/")}
+{#if false && !$page.url.pathname.startsWith("/blueprint/")}
   <div class="bg-base-100 flex justify-center rounded-sm">
     <a
       href="/blueprint/"
@@ -65,45 +65,35 @@
   </div>
 {/if}
 <!-- With timer -->
-<!-- {#if true && !$page.url.pathname.startsWith("/store/")} -->
-{#if false}
+{#if true}
   <div class="bg-base-100 flex justify-center rounded-sm">
     <a
       data-sveltekit-preload-data
-      href="/store/nexus/"
+      href="/store/daisyui-charts/"
       class="alert border-base-300 hover:bg-base-200 bg-base-100 flex w-full justify-center rounded-none border-x-0 border-t-0 p-2 text-center text-xs shadow-none transition-colors"
     >
       <p class="leading-relaxed [text-wrap:balance]">
         <span class="text-base-content/70">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 14 16"
-            class="mx-1 inline-block size-4 -rotate-12 align-middle"
-          >
-            <g fill="currentColor">
-              <path
-                d="M13 4h-1.38c.19-.33.33-.67.36-.91.06-.67-.11-1.22-.52-1.61C11.1 1.1 10.65 1 10.1 1h-.11c-.53.02-1.11.25-1.53.58-.42.33-.73.72-.97 1.2-.23-.48-.55-.88-.97-1.2-.42-.32-1-.58-1.53-.58h-.03c-.56 0-1.06.09-1.44.48-.41.39-.58.94-.52 1.61.03.23.17.58.36.91H1.98c-.55 0-1 .45-1 1v3h1v5c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V8h1V5c0-.55-.45-1-1-1H13zm-4.78-.88c.17-.36.42-.67.75-.92.3-.23.72-.39 1.05-.41h.09c.45 0 .66.11.8.25s.33.39.3.95c-.05.19-.25.61-.5 1h-2.9l.41-.88v.01zM4.09 2.04c.13-.13.31-.25.91-.25.31 0 .72.17 1.03.41.33.25.58.55.75.92L7.2 4H4.3c-.25-.39-.45-.81-.5-1-.03-.56.16-.81.3-.95l-.01-.01zM7 12.99H3V8h4v5-.01zm0-6H2V5h5v2-.01zm5 6H8V8h4v5-.01zm1-6H8V5h5v2-.01z"
-              >
-              </path>
-            </g>
-          </svg>
-          Happy New Year! Use code
+          <span class="bg-warning text-warning-content rounded-selector px-2 font-semibold">
+            NEW
+          </span>
+          <span class="font-bold">daisyUI Charts</span> – Use code
           <code
             class="decoration-success font-mono tracking-wide underline decoration-wavy underline-offset-4"
           >
-            NEXUS26
+            CHART30
           </code>
-          and get 26% discount on Nexus Dashboard Template!
+          to get 30% discount
           <span class="inline-block w-2"></span>
           <Countdown
-            from={new Date("2026-01-06T00:00:00.000000Z").toLocaleString("en-GB", dateFormat)}
+            from={new Date("2026-04-13T00:00:00.000000Z").toLocaleString("en-GB", dateFormat)}
             dateFormat="DD/MM/YYYY, HH:mm:ss"
           >
             {#snippet children({ remaining })}
               {#if remaining.done === false}
                 <span class="border-base-content/20 rounded-full border border-dashed px-2 py-1">
                   <date
-                    datetime={new Date("2025-04-19T01:01:00.000000Z").toLocaleString(
+                    datetime={new Date("2026-04-13T00:00:00.000000Z").toLocaleString(
                       "en-GB",
                       dateFormat,
                     )}

--- a/packages/docs/src/components/TopBanner.svelte
+++ b/packages/docs/src/components/TopBanner.svelte
@@ -65,7 +65,7 @@
   </div>
 {/if}
 <!-- With timer -->
-{#if true}
+{#if false}
   <div class="bg-base-100 flex justify-center rounded-sm">
     <a
       data-sveltekit-preload-data

--- a/packages/docs/src/components/TopBanner.svelte
+++ b/packages/docs/src/components/TopBanner.svelte
@@ -65,7 +65,7 @@
   </div>
 {/if}
 <!-- With timer -->
-{#if true && new Date() < new Date("2026-04-21T00:00:00.000000Z")}
+{#if false && new Date() < new Date("2026-04-21T00:00:00.000000Z")}
   <div class="bg-base-100 flex justify-center rounded-sm">
     <a
       data-sveltekit-preload-data

--- a/packages/docs/src/components/TopBanner.svelte
+++ b/packages/docs/src/components/TopBanner.svelte
@@ -65,28 +65,25 @@
   </div>
 {/if}
 <!-- With timer -->
-{#if false}
+{#if true && new Date() < new Date("2026-04-21T00:00:00.000000Z")}
   <div class="bg-base-100 flex justify-center rounded-sm">
     <a
       data-sveltekit-preload-data
-      href="/store/daisyui-charts/"
-      class="alert border-base-300 hover:bg-base-200 bg-base-100 flex w-full justify-center rounded-none border-x-0 border-t-0 p-2 text-center text-xs shadow-none transition-colors"
+      href="/store/nexus/"
+      class="alert border-base-300 hover:bg-base-200 bg-base-100 flex w-full justify-center rounded-none border-x-0 border-t-0 p-2 text-center text-[0.6875rem] shadow-none transition-colors"
     >
       <p class="leading-relaxed [text-wrap:balance]">
         <span class="text-base-content/70">
-          <span class="bg-warning text-warning-content rounded-selector px-2 font-semibold">
-            NEW
-          </span>
-          <span class="font-bold">daisyUI Charts</span> – Use code
+          🎉 Celebrating <span class="font-bold">Nexus Dashboard</span> anniversary – Use code
           <code
             class="decoration-success font-mono tracking-wide underline decoration-wavy underline-offset-4"
           >
-            CHART30
+            NEXUS27
           </code>
-          to get 30% discount
+          to get 27% discount
           <span class="inline-block w-2"></span>
           <Countdown
-            from={new Date("2026-04-13T00:00:00.000000Z").toLocaleString("en-GB", dateFormat)}
+            from={new Date("2026-04-21T00:00:00.000000Z").toLocaleString("en-GB", dateFormat)}
             dateFormat="DD/MM/YYYY, HH:mm:ss"
           >
             {#snippet children({ remaining })}

--- a/packages/docs/src/components/themegenerator/ThemeCSSModal.svelte
+++ b/packages/docs/src/components/themegenerator/ThemeCSSModal.svelte
@@ -111,13 +111,14 @@
       <span class="text-base-content/40">Add it after</span>
       <span class="text-base-content/50 font-bold italic">@plugin "daisyui";</span></span
     >
-    <textarea
-      spellcheck="false"
-      data-theme="dark"
-      class="textarea textarea-border textarea-xs block h-96 min-h-80 w-full max-w-none resize-none font-mono"
-      value={themeCSS}
-      oninput={handleThemeCSSInput}
-    ></textarea>
+    <div data-theme="dark">
+      <textarea
+        spellcheck="false"
+        class="textarea textarea-border textarea-xs block h-96 min-h-80 w-full max-w-none resize-none font-mono"
+        value={themeCSS}
+        oninput={handleThemeCSSInput}
+      ></textarea>
+    </div>
   </div>
   <div class="modal-backdrop" onclick={() => dialog.close()}></div>
 </dialog>

--- a/packages/docs/src/lib/themeGeneratorCssParser.js
+++ b/packages/docs/src/lib/themeGeneratorCssParser.js
@@ -61,7 +61,7 @@ export function parseThemeCSS(text, currentThemeData) {
 
       // Handle base theme properties
       if (key === "name") {
-        const cleanName = value.replace(/['"]/g, "")
+        const cleanName = value.replace(/['"]/g, "").trim()
         if (!validateThemeName(cleanName)) {
           console.error(`Invalid theme name: ${cleanName} (must be 3-20 lowercase letters)`)
           hasErrors = true

--- a/packages/docs/src/lib/themeGeneratorValidation.js
+++ b/packages/docs/src/lib/themeGeneratorValidation.js
@@ -1,5 +1,5 @@
 // Validation patterns
-const themeNamePattern = /^[a-z]{3,20}$/
+const themeNamePattern = /^[a-z][a-z0-9- ]{1,18}[a-z0-9]$|^[a-z]{3,20}$/
 const borderRadiusPattern = /^(0|0rem|0\.125rem|0\.25rem|0\.5rem|0\.75rem|1rem|2rem)$/
 const sizePattern = /^(0\.1875rem|0\.21875rem|0\.25rem|0\.28125rem|0\.3125rem)$/
 const borderWidthPattern = /^(0\.5px|1px|1\.5px|2px)$/
@@ -37,7 +37,8 @@ export function validateThemeName(name) {
     console.error("Theme name must be a string", name)
     return false
   }
-  if (!themeNamePattern.test(name)) {
+  const trimmedName = name.trim()
+  if (!themeNamePattern.test(trimmedName)) {
     console.error("Theme name does not match the required pattern", name)
     return false
   }

--- a/packages/docs/src/routes/(routes)/blueprint/+page.svelte
+++ b/packages/docs/src/routes/(routes)/blueprint/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import SEO from "$components/SEO.svelte"
-  import Footer from "$components/Footer.svelte"
+  import StoreFooter from "$components/StoreFooter.svelte"
+
   let dialogs = $state({})
 
   let videoModal = $state({
@@ -4090,7 +4091,7 @@
             F.A.Q
           </h2>
           <p class="text-base-content/60 text-xs">
-            If you have any questions before purchase <br />send me an email to pouya@daisyui.com
+            If you have any questions before purchase <br />send me an email to help@daisyui.com
             <br />I will do my best to help you.
           </p>
         </div>
@@ -4720,7 +4721,7 @@
   </form>
 </dialog> -->
 
-<Footer />
+<StoreFooter />
 
 <style>
   @keyframes fade-in {

--- a/packages/docs/src/routes/(routes)/blueprint/+page.svelte
+++ b/packages/docs/src/routes/(routes)/blueprint/+page.svelte
@@ -4149,8 +4149,9 @@
             <div
               class="collapse-content text-base-content/70 border-base-content/10 ms-4 border-s-2 px-6 text-xs"
             >
-              Yes you can cancel your subscription at any time. If you cancel, you will still have
-              access to the product until the end of your billing cycle.
+              Yes you can cancel your subscription at any time at
+              https://www.creem.io/my-orders/login. If you cancel, you will still have access to the
+              product until the end of your billing cycle.
             </div>
           </div>
           <div class="collapse-plus collapse">

--- a/packages/docs/src/routes/(routes)/components/collapse/+page.md
+++ b/packages/docs/src/routes/(routes)/components/collapse/+page.md
@@ -65,10 +65,32 @@ classnames:
 </div>
 
 ```html
-<div class="$$collapse bg-base-100 border-base-300 border">
+<div class="$$collapse bg-base-100 border border-base-300">
   <input type="checkbox" />
   <div class="$$collapse-title font-semibold">How do I create an account?</div>
   <div class="$$collapse-content text-sm">
+    Click the "Sign Up" button in the top right corner and follow the registration process.
+  </div>
+</div>
+```
+
+### ~Collapse with checkbox and close on click outside
+
+#### An alternative where you can also click outside to close it.
+
+<div class="collapse bg-base-100 border border-base-300">
+  <input id="collapse-1-toggle" type="checkbox" class="peer" autocomplete="off" />
+  <label for="collapse-1-toggle" class="fixed inset-0 hidden peer-checked:block"></label>
+  <div class="collapse-title font-semibold">How do I create an account?</div>
+  <div class="collapse-content text-sm z-1">Click the "Sign Up" button in the top right corner and follow the registration process.</div>
+</div>
+
+```html
+<div class="$$collapse bg-base-100 border border-base-300">
+  <input id="collapse-1-toggle" type="checkbox" class="peer" />
+  <label for="collapse-1-toggle" class="fixed inset-0 hidden peer-checked:block"></label>
+  <div class="$$collapse-title font-semibold">How do I create an account?</div>
+  <div class="$$collapse-content text-sm z-1">
     Click the "Sign Up" button in the top right corner and follow the registration process.
   </div>
 </div>

--- a/packages/docs/src/routes/(routes)/components/mockup-browser/+page.md
+++ b/packages/docs/src/routes/(routes)/components/mockup-browser/+page.md
@@ -26,7 +26,7 @@ classnames:
 </div>
 
 ```html
-<div class="$$mockup-browser border-base-300 border w-full">
+<div class="$$mockup-browser border border-base-300 w-full">
   <div class="$$mockup-browser-toolbar">
     <div class="$$input">https://daisyui.com</div>
   </div>
@@ -44,7 +44,7 @@ classnames:
 </div>
 
 ```html
-<div class="$$mockup-browser border border-base-300 w-full">
+<div class="$$mockup-browser bg-base-100 w-full border border-base-300">
   <div class="$$mockup-browser-toolbar">
     <div class="$$input">https://daisyui.com</div>
   </div>

--- a/packages/docs/src/routes/(routes)/components/navbar/+page.md
+++ b/packages/docs/src/routes/(routes)/components/navbar/+page.md
@@ -359,7 +359,7 @@ classnames:
 ```
 
 
-### ~responsive (dropdown menu on small screen, center menu on large screen)
+### ~Responsive (dropdown menu on small screen, center menu on large screen)
 #### Resize screen to see changes
 
 <div class="navbar bg-base-100 mb-48 shadow-sm">
@@ -442,6 +442,102 @@ classnames:
   </div>
   <div class="$$navbar-end">
     <a class="$$btn">Button</a>
+  </div>
+</div>
+```
+
+
+### ~Responsive (collapse on small screen, full content on large screen)
+#### Resize screen to see changes
+
+<div class="max-lg:collapse bg-base-200 lg:mb-48 shadow-sm w-full rounded-md">
+  <input id="navbar-1-toggle" class="peer hidden" type="checkbox" />
+  <label for="navbar-1-toggle" class="fixed inset-0 hidden max-lg:peer-checked:block"></label>
+  <div class="collapse-title navbar">
+    <div class="navbar-start">
+      <label for="navbar-1-toggle" class="btn btn-ghost lg:hidden">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" /></svg>
+      </label>
+      <button class="btn btn-ghost text-xl">daisyUI</button>
+    </div>
+    <div class="navbar-center hidden lg:flex">
+      <ul class="menu menu-horizontal px-1">
+        <li><button>Item 1</button></li>
+        <li>
+          <details>
+            <summary>Parent</summary>
+            <ul class="p-2 bg-base-100 w-40 z-1">
+              <li><button>Submenu 1</button></li>
+              <li><button>Submenu 2</button></li>
+            </ul>
+          </details>
+        </li>
+        <li><button>Item 3</button></li>
+      </ul>
+    </div>
+    <div class="navbar-end">
+      <input type="text" placeholder="Search" class="input input-bordered w-64 lg:w-auto" />
+    </div>
+  </div>
+
+  <div class="collapse-content lg:hidden z-1">
+    <ul class="menu">
+      <li><button>Item 1</button></li>
+      <li>
+        <button>Parent</button>
+        <ul>
+          <li><button>Submenu 1</button></li>
+          <li><button>Submenu 2</button></li>
+        </ul>
+      </li>
+      <li><button>Item 3</button></li>
+    </ul>
+  </div>
+</div>
+
+```html
+<div class="max-lg:$$collapse bg-base-200 lg:mb-48 shadow-sm w-full rounded-md">
+  <input id="navbar-1-toggle" class="peer hidden" type="checkbox" />
+  <label for="navbar-1-toggle" class="fixed inset-0 hidden max-lg:peer-checked:block"></label>
+  <div class="$$collapse-title $$navbar">
+    <div class="$$navbar-start">
+      <label for="navbar-1-toggle" class="$$btn $$btn-ghost lg:hidden">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" /></svg>
+      </label>
+      <button class="$$btn $$btn-ghost text-xl">daisyUI</button>
+    </div>
+    <div class="$$navbar-center hidden lg:flex">
+      <ul class="$$menu $$menu-horizontal px-1">
+        <li><button>Item 1</button></li>
+        <li>
+          <details>
+            <summary>Parent</summary>
+            <ul class="p-2 bg-base-100 w-40 z-1">
+              <li><button>Submenu 1</button></li>
+              <li><button>Submenu 2</button></li>
+            </ul>
+          </details>
+        </li>
+        <li><button>Item 3</button></li>
+      </ul>
+    </div>
+    <div class="$$navbar-end">
+      <input type="text" placeholder="Search" class="$$input $$input-bordered w-64 lg:w-auto" />
+    </div>
+  </div>
+
+  <div class="$$collapse-content lg:hidden z-1">
+    <ul class="$$menu">
+      <li><button>Item 1</button></li>
+      <li>
+        <button>Parent</button>
+        <ul>
+          <li><button>Submenu 1</button></li>
+          <li><button>Submenu 2</button></li>
+        </ul>
+      </li>
+      <li><button>Item 3</button></li>
+    </ul>
   </div>
 </div>
 ```

--- a/packages/docs/src/routes/(routes)/docs/install/django/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/django/+page.md
@@ -160,8 +160,8 @@ chmod +x myapp/static/css/tailwindcss
 Run this code to download latest version of daisyUI as a single js file and put it next to Tailwind's executable file.
 
 ```sh:Terminal
-curl -sLO myapp/static/css/daisyui.mjs https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.mjs
-curl -sLO myapp/static/css/daisyui-theme.mjs https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.mjs
+curl -sLo myapp/static/css/daisyui.mjs https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.mjs
+curl -sLo myapp/static/css/daisyui-theme.mjs https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.mjs
 ```
 
 #### Add Tailwind CSS and daisyUI

--- a/packages/docs/src/routes/(routes)/store/+layout.svelte
+++ b/packages/docs/src/routes/(routes)/store/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-  import Footer from "$components/Footer.svelte"
+  import StoreFooter from "$components/StoreFooter.svelte"
   let { data, children } = $props()
 </script>
 
@@ -12,4 +12,5 @@
 <div class="w-full px-4 pt-20 md:px-20" dir="ltr">
   {@render children?.()}
 </div>
-<Footer />
+
+<StoreFooter />

--- a/packages/docs/src/routes/(routes)/store/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/+page.svelte
@@ -496,9 +496,9 @@
     {/each}
   </div>
 
-  <div class="divider text-base-content/30 my-20"></div>
+  <!-- <div class="divider text-base-content/30 my-20"></div> -->
 
-  <div class="card mt-10">
+  <!-- <div class="card mt-10">
     <div class="card-body flex flex-col gap-4 p-0">
       <h2 class="font-title text-xl font-semibold lg:text-4xl">
         Get notified about products and discounts!
@@ -539,5 +539,5 @@
         </p>
       </form>
     </div>
-  </div>
+  </div> -->
 </div>

--- a/packages/docs/src/routes/(routes)/store/[productId]/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/[productId]/+page.svelte
@@ -912,7 +912,7 @@
       </h2>
       <p class="text-base-content/60 text-xs">
         If you have any questions before purchase
-        <br />send me an email to pouya@daisyui.com
+        <br />send me an email to help@daisyui.com
         <br />I will do my best to help you.
       </p>
     </div>

--- a/packages/docs/src/routes/(routes)/store/pages/+layout.svelte
+++ b/packages/docs/src/routes/(routes)/store/pages/+layout.svelte
@@ -1,0 +1,39 @@
+<div class="mx-auto max-w-4xl">
+  <article class="prose prose-sm sm:prose-base text-base-content max-w-none">
+    <div>
+      <a class="btn btn-ghost group mb-6" href="/store/" data-sveltekit-preload-data>
+        <svg
+          class="inline-block size-4 transition-transform group-hover:-translate-x-0.5"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+        >
+          <g fill="currentColor">
+            <line
+              x1="17"
+              y1="10"
+              x2="3"
+              y2="10"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            >
+            </line>
+            <polyline
+              points="8 5 3 10 8 15"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            >
+            </polyline>
+          </g>
+        </svg>
+        <span class="text-sm">Back to store</span>
+      </a>
+    </div>
+    <slot />
+  </article>
+</div>

--- a/packages/docs/src/routes/(routes)/store/pages/privacy/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/pages/privacy/+page.svelte
@@ -7,98 +7,106 @@
   desc="Privacy Policy for purchases made through the daisyUI Store."
 />
 
-  <h1>Privacy Policy for the daisyUI Store</h1>
-  <p>Last update: April 2026</p>
-  <p>
-    This Privacy Policy applies only to <a href="/store/">daisyui.com/store</a> and
-    <a href="/blueprint/">daisyui.com/blueprint</a>. It covers data related to purchases,
-    subscriptions, licenses, and support for those services. It does not apply to the rest of the
-    daisyUI website unless another page says so directly.
-  </p>
+<h1>Privacy Policy for the daisyUI Store</h1>
+<p>Last update: April 2026</p>
+<p>
+  This Privacy Policy applies only to <a href="/store/">daisyui.com/store</a> and
+  <a href="/blueprint/">daisyui.com/blueprint</a>. It covers data related to purchases,
+  subscriptions, licenses, and support for those services. It does not apply to the rest of the
+  daisyUI website unless another page says so directly.
+</p>
 
-  <h2>1. What personal data is collected</h2>
-  <p>
-    If you buy from the daisyUI Store or buy a Blueprint subscription or lifetime license, the only
-    personal data kept directly is your email address. Payment card details, bank details, and full
-    billing information are not stored directly.
-  </p>
+<h2>1. What personal data is collected</h2>
+<p>
+  If you buy from the daisyUI Store or buy a Blueprint subscription or lifetime license, the only
+  personal data kept directly is your email address. Payment card details, bank details, and full
+  billing information are not stored directly.
+</p>
 
-  <h2>2. Why your email address is used</h2>
-  <p>Your email address is used only for purchase-related purposes, including:</p>
-  <ul>
-    <li>sending or confirming digital delivery,</li>
-    <li>identifying your order,</li>
-    <li>managing subscription or license access,</li>
-    <li>handling customer support requests, and</li>
-    <li>sending important updates related to your purchase when needed.</li>
-  </ul>
+<h2>2. Why your email address is used</h2>
+<p>Your email address is used only for purchase-related purposes, including:</p>
+<ul>
+  <li>sending or confirming digital delivery,</li>
+  <li>identifying your order,</li>
+  <li>managing subscription or license access,</li>
+  <li>handling customer support requests, and</li>
+  <li>sending important updates related to your purchase when needed.</li>
+</ul>
 
-  <h2>3. Payment processing by Creem</h2>
-  <p>
-    Payments are processed by Creem. Creem acts as the payment provider for the daisyUI Store and
-    Blueprint and may collect and process personal data needed to complete transactions, manage
-    subscriptions and renewals, prevent fraud, comply with legal obligations, and manage billing
-    records.
-  </p>
-  <p>Creem's handling of your personal data is governed by Creem's own policies:</p>
-  <ul>
-    <li><a href="https://www.creem.io/terms">Creem Terms</a></li>
-    <li><a href="https://www.creem.io/privacy">Creem Privacy Policy</a></li>
-  </ul>
+<h2>3. Payment processing by Creem</h2>
+<p>
+  Payments are processed by Creem. Creem acts as the payment provider for the daisyUI Store and
+  Blueprint and may collect and process personal data needed to complete transactions, manage
+  subscriptions and renewals, prevent fraud, comply with legal obligations, and manage billing
+  records.
+</p>
+<p>Creem's handling of your personal data is governed by Creem's own policies:</p>
+<ul>
+  <li>
+    <a href="https://www.creem.io/terms" target="_blank" rel="nofollow noopener noreferrer"
+      >Creem Terms</a
+    >
+  </li>
+  <li>
+    <a href="https://www.creem.io/privacy" target="_blank" rel="nofollow noopener noreferrer"
+      >Creem Privacy Policy</a
+    >
+  </li>
+</ul>
 
-  <h2>4. How long the store keeps data</h2>
-  <p>
-    Your email address is kept for as long as it is reasonably needed to manage your purchase,
-    provide access or support, respond to order questions, manage subscriptions or licenses, or keep
-    basic order history.
-  </p>
+<h2>4. How long the store keeps data</h2>
+<p>
+  Your email address is kept for as long as it is reasonably needed to manage your purchase, provide
+  access or support, respond to order questions, manage subscriptions or licenses, or keep basic
+  order history.
+</p>
 
-  <h2>5. How data is shared</h2>
-  <p>
-    Personal data is not sold. Your email address may be shared only when needed to operate the store
-    or Blueprint service, complete your order, respond to support requests, comply with the law, or
-    protect the service against fraud or abuse.
-  </p>
+<h2>5. How data is shared</h2>
+<p>
+  Personal data is not sold. Your email address may be shared only when needed to operate the store
+  or Blueprint service, complete your order, respond to support requests, comply with the law, or
+  protect the service against fraud or abuse.
+</p>
 
-  <h2>6. Cookies and tracking</h2>
-  <p>
-    This page covers purchase, subscription, and license data only. Checkout, payment, and order
-    portals provided by Creem may use their own cookies, analytics, or security technologies under
-    their own privacy policy.
-  </p>
+<h2>6. Cookies and tracking</h2>
+<p>
+  This page covers purchase, subscription, and license data only. Checkout, payment, and order
+  portals provided by Creem may use their own cookies, analytics, or security technologies under
+  their own privacy policy.
+</p>
 
-  <h2>7. Your rights</h2>
-  <p>
-    Depending on where you live, you may have rights to request access, correction, deletion, or
-    restriction of personal data related to your purchase, subscription, or license. If you want help
-    with directly held data, use the <a href="/store/pages/support/">customer support page</a>.
-  </p>
-  <p>
-    If your request concerns payment, billing, fraud checks, or transaction records handled by Creem,
-    you may also need to contact Creem directly.
-  </p>
+<h2>7. Your rights</h2>
+<p>
+  Depending on where you live, you may have rights to request access, correction, deletion, or
+  restriction of personal data related to your purchase, subscription, or license. If you want help
+  with directly held data, use the <a href="/store/pages/support/">customer support page</a>.
+</p>
+<p>
+  If your request concerns payment, billing, fraud checks, or transaction records handled by Creem,
+  you may also need to contact Creem directly.
+</p>
 
-  <h2>8. Data security</h2>
-  <p>
-    Reasonable steps are taken to protect the limited personal data the store keeps. No method of
-    storage or transmission is completely secure, so absolute security cannot be guaranteed.
-  </p>
+<h2>8. Data security</h2>
+<p>
+  Reasonable steps are taken to protect the limited personal data the store keeps. No method of
+  storage or transmission is completely secure, so absolute security cannot be guaranteed.
+</p>
 
-  <h2>9. International processing</h2>
-  <p>
-    Store, Blueprint, and payment providers may process data in different countries. By purchasing
-    through these services, you understand that your information may be processed outside your country
-    of residence where allowed by law.
-  </p>
+<h2>9. International processing</h2>
+<p>
+  Store, Blueprint, and payment providers may process data in different countries. By purchasing
+  through these services, you understand that your information may be processed outside your country
+  of residence where allowed by law.
+</p>
 
-  <h2>10. Changes to this policy</h2>
-  <p>
-    This Privacy Policy may be updated from time to time. The version published on this page applies
-    from its effective date.
-  </p>
+<h2>10. Changes to this policy</h2>
+<p>
+  This Privacy Policy may be updated from time to time. The version published on this page applies
+  from its effective date.
+</p>
 
-  <h2>11. Contact</h2>
-  <p>
-    For privacy questions about these purchases or licenses, use the
-    <a href="/store/pages/support/">customer support page</a>.
-  </p>
+<h2>11. Contact</h2>
+<p>
+  For privacy questions about these purchases or licenses, use the
+  <a href="/store/pages/support/">customer support page</a>.
+</p>

--- a/packages/docs/src/routes/(routes)/store/pages/privacy/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/pages/privacy/+page.svelte
@@ -1,0 +1,104 @@
+<script>
+  import SEO from "$components/SEO.svelte"
+</script>
+
+<SEO
+  title="daisyUI Store Privacy Policy"
+  desc="Privacy Policy for purchases made through the daisyUI Store."
+/>
+
+  <h1>Privacy Policy for the daisyUI Store</h1>
+  <p>Last update: April 2026</p>
+  <p>
+    This Privacy Policy applies only to <a href="/store/">daisyui.com/store</a> and
+    <a href="/blueprint/">daisyui.com/blueprint</a>. It covers data related to purchases,
+    subscriptions, licenses, and support for those services. It does not apply to the rest of the
+    daisyUI website unless another page says so directly.
+  </p>
+
+  <h2>1. What personal data is collected</h2>
+  <p>
+    If you buy from the daisyUI Store or buy a Blueprint subscription or lifetime license, the only
+    personal data kept directly is your email address. Payment card details, bank details, and full
+    billing information are not stored directly.
+  </p>
+
+  <h2>2. Why your email address is used</h2>
+  <p>Your email address is used only for purchase-related purposes, including:</p>
+  <ul>
+    <li>sending or confirming digital delivery,</li>
+    <li>identifying your order,</li>
+    <li>managing subscription or license access,</li>
+    <li>handling customer support requests, and</li>
+    <li>sending important updates related to your purchase when needed.</li>
+  </ul>
+
+  <h2>3. Payment processing by Creem</h2>
+  <p>
+    Payments are processed by Creem. Creem acts as the payment provider for the daisyUI Store and
+    Blueprint and may collect and process personal data needed to complete transactions, manage
+    subscriptions and renewals, prevent fraud, comply with legal obligations, and manage billing
+    records.
+  </p>
+  <p>Creem's handling of your personal data is governed by Creem's own policies:</p>
+  <ul>
+    <li><a href="https://www.creem.io/terms">Creem Terms</a></li>
+    <li><a href="https://www.creem.io/privacy">Creem Privacy Policy</a></li>
+  </ul>
+
+  <h2>4. How long the store keeps data</h2>
+  <p>
+    Your email address is kept for as long as it is reasonably needed to manage your purchase,
+    provide access or support, respond to order questions, manage subscriptions or licenses, or keep
+    basic order history.
+  </p>
+
+  <h2>5. How data is shared</h2>
+  <p>
+    Personal data is not sold. Your email address may be shared only when needed to operate the store
+    or Blueprint service, complete your order, respond to support requests, comply with the law, or
+    protect the service against fraud or abuse.
+  </p>
+
+  <h2>6. Cookies and tracking</h2>
+  <p>
+    This page covers purchase, subscription, and license data only. Checkout, payment, and order
+    portals provided by Creem may use their own cookies, analytics, or security technologies under
+    their own privacy policy.
+  </p>
+
+  <h2>7. Your rights</h2>
+  <p>
+    Depending on where you live, you may have rights to request access, correction, deletion, or
+    restriction of personal data related to your purchase, subscription, or license. If you want help
+    with directly held data, use the <a href="/store/pages/support/">customer support page</a>.
+  </p>
+  <p>
+    If your request concerns payment, billing, fraud checks, or transaction records handled by Creem,
+    you may also need to contact Creem directly.
+  </p>
+
+  <h2>8. Data security</h2>
+  <p>
+    Reasonable steps are taken to protect the limited personal data the store keeps. No method of
+    storage or transmission is completely secure, so absolute security cannot be guaranteed.
+  </p>
+
+  <h2>9. International processing</h2>
+  <p>
+    Store, Blueprint, and payment providers may process data in different countries. By purchasing
+    through these services, you understand that your information may be processed outside your country
+    of residence where allowed by law.
+  </p>
+
+  <h2>10. Changes to this policy</h2>
+  <p>
+    This Privacy Policy may be updated from time to time. The version published on this page applies
+    from its effective date.
+  </p>
+
+  <h2>11. Contact</h2>
+  <p>
+    For privacy questions about these purchases or licenses, use the
+    <a href="/store/pages/support/">customer support page</a>.
+  </p>

--- a/packages/docs/src/routes/(routes)/store/pages/support/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/pages/support/+page.svelte
@@ -16,7 +16,9 @@
 <h2>Discord community</h2>
 <p>
   You can also get help in the daisyUI Discord server at
-  <a href="https://daisyui.com/discord">daisyui.com/discord</a>.
+  <a href="https://daisyui.com/discord" target="_blank" rel="nofollow noopener noreferrer"
+    >daisyui.com/discord</a
+  >.
 </p>
 
 <h2>Email support</h2>

--- a/packages/docs/src/routes/(routes)/store/pages/support/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/pages/support/+page.svelte
@@ -1,0 +1,32 @@
+<script>
+  import SEO from "$components/SEO.svelte"
+</script>
+
+<SEO
+  title="daisyUI Store and Blueprint Support"
+  desc="Support for daisyUI Store purchases and Blueprint subscriptions or licenses."
+/>
+
+<h1>daisyUI Store Customer Support</h1>
+<p>
+  This support page covers questions about products from <a href="/store/">daisyui.com/store</a> and
+  <a href="/blueprint/">daisyui.com/blueprint</a>.
+</p>
+
+<h2>Discord community</h2>
+<p>
+  You can also get help in the daisyUI Discord server at
+  <a href="https://daisyui.com/discord">daisyui.com/discord</a>.
+</p>
+
+<h2>Email support</h2>
+<p>
+  For any help or questions about purchases, downloads, licenses, subscriptions, or access, email
+  <a href="mailto:help@daisyui.com">help@daisyui.com</a>.
+</p>
+
+<h2>What to include</h2>
+<p>
+  To get faster help, include the email address used for the purchase and a short description of the
+  issue.
+</p>

--- a/packages/docs/src/routes/(routes)/store/pages/terms/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/pages/terms/+page.svelte
@@ -1,0 +1,132 @@
+<script>
+  import SEO from "$components/SEO.svelte"
+</script>
+
+<SEO
+  title="daisyUI Store Terms and Conditions"
+  desc="Terms and Conditions for purchases made through the daisyUI Store."
+/>
+
+<h1>Terms and Conditions for the daisyUI Store</h1>
+<p>Last update: April 2026</p>
+<p>
+  These Terms and Conditions apply only to purchases made through
+  <a href="/store/">daisyui.com/store</a> and <a href="/blueprint/">daisyui.com/blueprint</a>. They
+  do not apply to the rest of the daisyUI website, open source package, docs, or any other service
+  unless a page says so directly.
+</p>
+
+<h2>1. What is covered</h2>
+<p>
+  The daisyUI Store sells digital products, including templates, UI kits, and related files.
+  Blueprint is the official daisyUI MCP server and may be offered as a subscription or as a lifetime
+  license. When you buy a product or license, you receive the usage rights described on the product
+  page or in the license terms provided with that purchase.
+</p>
+
+<h2>2. Order processing and payment provider</h2>
+<p>
+  Payments for the daisyUI Store and Blueprint are processed by Creem. Creem handles checkout,
+  payment processing, billing details, fraud checks, subscriptions, renewals, cancellations, and
+  transaction records on its own systems. Creem may also collect and process personal data needed to
+  complete your order.
+</p>
+<p>By placing an order, you also agree to Creem's terms and privacy policy:</p>
+<ul>
+  <li><a href="https://www.creem.io/terms">Creem Terms</a></li>
+  <li><a href="https://www.creem.io/privacy">Creem Privacy Policy</a></li>
+</ul>
+
+<h2>3. What information is received</h2>
+<p>
+  daisyUI does not store your payment card details or other billing information for these purchases.
+  If you buy from the store or buy a Blueprint subscription or lifetime license, the only personal
+  data kept directly is your email address so your order, license, access, delivery, support, or
+  renewal status can be identified and managed when needed.
+</p>
+
+<h2>4. Digital delivery</h2>
+<p>
+  Products and licenses are delivered digitally. Access, download links, license files, subscription
+  access, and order management may be provided through Creem or a connected order portal. You are
+  responsible for giving a valid email address at checkout.
+</p>
+
+<h2>5. License and permitted use</h2>
+<p>
+  Buying a product or Blueprint license gives you the right to use it under the license included
+  with the purchase. You may not resell, redistribute, sublicense, publish, share, or expose the
+  purchased files, credentials, or licensed access except where the license clearly allows it.
+</p>
+<p>
+  Some products may include third-party assets, fonts, icons, images, or dependencies with their own
+  licenses. You are responsible for following those license terms where they apply.
+</p>
+
+<h2>6. Prices, taxes, and changes</h2>
+<p>
+  Prices may change at any time without notice. Taxes, VAT, sales tax, or similar charges may be
+  added by Creem where required by law or by the payment provider's checkout rules.
+</p>
+
+<h2>7. Refunds and payment disputes</h2>
+<p>
+  Because these products and licenses are digital, refund requests are reviewed case by case unless
+  a specific refund policy is shown on the product page or required by law. If you have a problem
+  with an order, subscription, or license, use the support page first.
+</p>
+<p>
+  Payment disputes, chargebacks, or provider-level claims may also be handled through Creem or your
+  payment method provider under their rules.
+</p>
+
+<h2>8. Product updates and availability</h2>
+<p>
+  Products, subscriptions, and licenses may be updated, improved, replaced, paused, or removed from
+  sale at any time. Buying a product or license does not guarantee lifetime updates, ongoing
+  support, or future compatibility unless a product page says that clearly.
+</p>
+
+<h2>9. Support</h2>
+<p>
+  Support is limited to purchase-related questions about access, downloads, licensing,
+  subscriptions, Blueprint access, and product-specific issues where support is offered. Support
+  does not include custom development, consulting, or guaranteed response times unless stated on the
+  product page.
+</p>
+
+<h2>10. Acceptable use</h2>
+<p>
+  You may not use the store, Blueprint, download links, license access, subscription access, or
+  purchased files in a way that breaks the law, infringes intellectual property rights, bypasses
+  access controls, or harms the service, its infrastructure, or other customers.
+</p>
+
+<h2>11. No warranty</h2>
+<p>
+  Store products and Blueprint access are provided on an "as is" and "as available" basis to the
+  maximum extent allowed by law. No promise is made that every product, subscription, or license
+  will fit your exact project, workflow, or technical environment.
+</p>
+
+<h2>12. Limitation of liability</h2>
+<p>
+  To the maximum extent allowed by law, daisyUI Store will not be liable for indirect, incidental,
+  special, consequential, or punitive damages, or for loss of revenue, profits, data, business, or
+  goodwill arising from your use of the store, Blueprint, or purchased products and licenses.
+</p>
+<p>
+  If liability applies despite the limitation above, the total liability will not exceed the amount
+  you paid for the product that gave rise to the claim.
+</p>
+
+<h2>13. Changes to these terms</h2>
+<p>
+  These terms may be updated from time to time. The version published on this page applies to new
+  purchases from its effective date.
+</p>
+
+<h2>14. Contact</h2>
+<p>
+  For purchase-related questions, use the <a href="/store/pages/support/">customer support page</a>.
+</p>

--- a/packages/docs/src/routes/(routes)/store/pages/terms/+page.svelte
+++ b/packages/docs/src/routes/(routes)/store/pages/terms/+page.svelte
@@ -33,8 +33,16 @@
 </p>
 <p>By placing an order, you also agree to Creem's terms and privacy policy:</p>
 <ul>
-  <li><a href="https://www.creem.io/terms">Creem Terms</a></li>
-  <li><a href="https://www.creem.io/privacy">Creem Privacy Policy</a></li>
+  <li>
+    <a href="https://www.creem.io/terms" target="_blank" rel="nofollow noopener noreferrer"
+      >Creem Terms</a
+    >
+  </li>
+  <li>
+    <a href="https://www.creem.io/privacy" target="_blank" rel="nofollow noopener noreferrer"
+      >Creem Privacy Policy</a
+    >
+  </li>
 </ul>
 
 <h2>3. What information is received</h2>

--- a/packages/docs/src/routes/(routes)/theme-generator/+page.svelte
+++ b/packages/docs/src/routes/(routes)/theme-generator/+page.svelte
@@ -362,7 +362,7 @@
 
   const generateCSS = (theme) => {
     const baseProps = [
-      `  name: "${theme.name}";`,
+      `  name: "${theme.name.trim()}";`,
       `  default: ${theme.default ? "true" : "false"};`,
       `  prefersdark: ${theme.prefersdark ? "true" : "false"};`,
       `  color-scheme: "${theme["color-scheme"]}";`,

--- a/packages/docs/static/llms.txt
+++ b/packages/docs/static/llms.txt
@@ -1832,6 +1832,28 @@ Toggle is a checkbox that is styled to look like a switch button
 #### Rules
 - {MODIFIER} is optional and can have one of each color/size class names
 
+### tooltip
+Tooltip can be used to show a message when hovering over an element
+
+[tooltip docs](https://daisyui.com/components/tooltip/)
+
+#### Class names
+- component: `tooltip`
+- part: `tooltip-content`
+- modifier: `tooltip-open`
+- placement: `tooltip-top`, `tooltip-bottom`, `tooltip-left`, `tooltip-right`
+- color: `tooltip-primary`, `tooltip-secondary`, `tooltip-accent`, `tooltip-info`, `tooltip-success`, `tooltip-warning`, `tooltip-error`
+
+#### Syntax
+```html
+<div class="tooltip {MODIFIER}" data-tip="Tooltip text">
+  <button class="btn">Hover me</button>
+</div>
+```
+
+#### Rules
+- {MODIFIER} is optional and can have one of each modifier/placement/color class names
+
 ### validator
 Validator class changes the color of form elements to error or success based on input's validation rules
 


### PR DESCRIPTION
- remove some redundant styling of `.collapse-content`
- move styling of `details` and `summary` under `collapse` utility

close #4515
example: https://play.tailwindcss.com/6l7BVNX97Q