### PR TITLE
fix(collapse): open/close transition for details and too lax styling of summary

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -39,6 +39,7 @@
       > .collapse-content,
     &:not(.collapse-close)
       > :where(input:is([type="checkbox"], [type="radio"]):checked ~ .collapse-content) {
+      --overflow-delay: 0.2s;
       overflow: revert-layer;
       content-visibility: visible;
       min-height: fit-content;
@@ -91,6 +92,46 @@
 
       &:has(~ label) {
         z-index: revert-layer;
+      }
+    }
+
+    &:is(details) {
+      width: 100%;
+
+      &::details-content {
+        --overflow-delay: 0s;
+        overflow: clip;
+        height: 0;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        &::details-content {
+          transition:
+            overflow 0.2s allow-discrete var(--overflow-delay),
+            content-visibility 0.2s allow-discrete,
+            visibility 0.2s allow-discrete,
+            min-height 0.2s ease-out allow-discrete,
+            padding 0.1s ease-out 20ms,
+            background-color 0.2s ease-out,
+            height 0.2s;
+          interpolate-size: allow-keywords;
+        }
+
+        &:where([open])::details-content {
+          --overflow-delay: 0.2s;
+          height: auto;
+          overflow: revert-layer;
+        }
+      }
+
+      > summary {
+        position: relative;
+        display: block;
+        outline: none;
+
+        &::-webkit-details-marker {
+          display: none;
+        }
       }
     }
   }
@@ -163,8 +204,7 @@
   }
 }
 
-.collapse-title,
-.collapse-content {
+.collapse-title {
   @layer daisyui.l1.l2.l3 {
     grid-column-start: 1;
     grid-row-start: 1;
@@ -173,6 +213,7 @@
 
 .collapse-content {
   @layer daisyui.l1.l2.l3 {
+    --overflow-delay: 0s;
     content-visibility: hidden;
     overflow: clip;
     grid-column-start: 1;
@@ -186,57 +227,17 @@
     }
     @media (prefers-reduced-motion: no-preference) {
       transition:
-        overflow 0.2s allow-discrete,
+        overflow 0.2s allow-discrete var(--overflow-delay),
         content-visibility 0.2s allow-discrete,
         visibility 0.2s allow-discrete,
         min-height 0.2s ease-out allow-discrete,
         padding 0.1s ease-out 20ms,
         background-color 0.2s ease-out;
     }
-  }
-}
 
-.collapse:is(details) {
-  @layer daisyui.l1.l2.l3 {
-    width: 100%;
-    @media (prefers-reduced-motion: no-preference) {
-      &::details-content {
-        overflow: clip;
-        transition:
-          overflow 0.2s allow-discrete,
-          content-visibility 0.2s allow-discrete,
-          visibility 0.2s allow-discrete,
-          min-height 0.2s ease-out allow-discrete,
-          padding 0.1s ease-out 20ms,
-          background-color 0.2s ease-out,
-          height 0.2s;
-        height: 0;
-        interpolate-size: allow-keywords;
-      }
-
-      &:where([open])::details-content {
-        height: auto;
-        overflow: revert-layer;
-      }
-    }
-    & summary {
-      position: relative;
-      display: block;
-
-      &::-webkit-details-marker {
-        display: none;
-      }
-    }
-
-    & > .collapse-content {
+    details > & {
       content-visibility: visible;
     }
-  }
-}
-
-.collapse:is(details) summary {
-  @layer daisyui.l1.l2.l3 {
-    outline: none;
   }
 }
 
@@ -300,6 +301,7 @@
   @layer daisyui.l1.l2 {
     grid-template-rows: max-content 1fr;
     > .collapse-content {
+      --overflow-delay: 0.2s;
       overflow: revert-layer;
       content-visibility: visible;
       min-height: fit-content;


### PR DESCRIPTION
- remove some redundant styling of `.collapse-content`
- move styling of `details` and `summary` under `collapse` utility

close #4515
example: https://play.tailwindcss.com/6l7BVNX97Q