### PR TITLE
fix: add missing tooltip-neutral color variant

### DIFF
--- a/packages/daisyui/src/components/tooltip.css
+++ b/packages/daisyui/src/components/tooltip.css
@@ -191,6 +191,17 @@
   }
 }
 
+.tooltip-neutral {
+  @layer daisyui.l1.l2 {
+    --tt-bg: var(--color-neutral);
+
+    > .tooltip-content,
+    &[data-tip]:before {
+      @apply text-neutral-content;
+    }
+  }
+}
+
 .tooltip-error {
   @layer daisyui.l1.l2 {
     --tt-bg: var(--color-error);


### PR DESCRIPTION
## Problem

`tooltip-neutral` was never defined in `tooltip.css`, making it a silent no-op. Every other semantic color variant exists (`tooltip-primary`, `tooltip-secondary`, `tooltip-accent`, `tooltip-info`, `tooltip-success`, `tooltip-warning`, `tooltip-error`) but `neutral` was skipped.

This means:
- `tooltip-neutral` has no effect on styling
- It does not appear in autocomplete (Tailwind Play, IDE plugins)
- Users expecting consistent API across all color variants are left with a broken class

## Fix

Added `.tooltip-neutral` following the exact same pattern as the other color variants — sets `--tt-bg` to `var(--color-neutral)` and applies `text-neutral-content` to the tooltip content.

The placement in the file follows alphabetical ordering relative to the other variants.

Closes #4492