### PR TITLE
fix dropdown animation inside a modal

### DIFF
--- a/packages/daisyui/src/components/dropdown.css
+++ b/packages/daisyui/src/components/dropdown.css
@@ -23,7 +23,7 @@
       z-index: 999;
       @media (prefers-reduced-motion: no-preference) {
         animation: dropdown 0.2s;
-        transition-property: opacity, scale, display;
+        transition-property: opacity, scale, display, overlay;
         transition-behavior: allow-discrete;
         transition-duration: 0.2s;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
When a popover-based dropdown closes inside a `<dialog>` modal, the element exits the browser's top layer before the animation completes. This causes it to fall back into the modal's layout context during the closing animation causing issues with the modal height/scroll.

I added `overlay` in the `transition-property`


Before: [https://play.tailwindcss.com/bcmrab9L6n](https://play.tailwindcss.com/bcmrab9L6n)
Fix: [https://play.tailwindcss.com/v4w7D5enGS](https://play.tailwindcss.com/v4w7D5enGS)