### PR TITLE
fix(input): tweaks for safari quirks for datetime inputs

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -51,7 +51,9 @@
         direction: ltr;
       }
 
+      &::-webkit-datetime-edit,
       &::-webkit-date-and-time-value {
+        @apply grid min-h-full items-center;
         text-align: inherit;
       }
 


### PR DESCRIPTION
ref #4370

example: https://play.tailwindcss.com/xEdHm4ThAw

I tested it on ios and looks good
Can you please test on macos?