### PR TITLE
Fixes for megamenu - see review

### DIFF
--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -26,7 +26,7 @@
         pointer-events: none;
         inset-inline-end: 1.4rem;
         box-shadow: inset 2px 2px;
-        transition: opacity 200ms ease-out;
+        transition: opacity 200ms ease-out, rotate 200ms ease-out;
         width: 0.375rem;
         height: 0.375rem;
         display: block;
@@ -116,6 +116,7 @@
 
     [popovertarget]:has(+ [popover]:popover-open):after {
       opacity: 1;
+      rotate: 45deg;
     }
 
     [popover] {

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -1,6 +1,6 @@
 .megamenu {
   @layer daisyui.l1.l2.l3 {
-    @apply relative flex items-center overflow-x-hidden;
+    @apply relative flex items-center overflow-visible;
     width: unset;
     background-color: transparent;
     border-radius: calc(var(--radius-field) + var(--border));
@@ -21,7 +21,8 @@
         outline-offset: 2px;
       }
       &:after {
-        content: "";
+        --tw-content: "";
+        content: var(--tw-content);
         pointer-events: none;
         inset-inline-end: 1.4rem;
         box-shadow: inset 2px 2px;
@@ -113,22 +114,12 @@
       --mm-anchor: --mm10;
     }
 
-    &:has([popover]:nth-of-type(1):popover-open) [popovertarget]:nth-of-type(1):after,
-    &:has([popover]:nth-of-type(2):popover-open) [popovertarget]:nth-of-type(2):after,
-    &:has([popover]:nth-of-type(3):popover-open) [popovertarget]:nth-of-type(3):after,
-    &:has([popover]:nth-of-type(4):popover-open) [popovertarget]:nth-of-type(4):after,
-    &:has([popover]:nth-of-type(5):popover-open) [popovertarget]:nth-of-type(5):after,
-    &:has([popover]:nth-of-type(6):popover-open) [popovertarget]:nth-of-type(6):after,
-    &:has([popover]:nth-of-type(7):popover-open) [popovertarget]:nth-of-type(7):after,
-    &:has([popover]:nth-of-type(8):popover-open) [popovertarget]:nth-of-type(8):after,
-    &:has([popover]:nth-of-type(9):popover-open) [popovertarget]:nth-of-type(9):after,
-    &:has([popover]:nth-of-type(10):popover-open) [popovertarget]:nth-of-type(10):after {
+    [popovertarget]:has(+ [popover]:popover-open):after {
       opacity: 1;
     }
 
     [popover] {
-      @apply border-base-300 mt-1 border opacity-0;
-      max-height: 100vh;
+      @apply mt-1 max-h-dvh border border-base-300 opacity-0;
       border-radius: var(--radius-box);
       background-color: var(--color-base-100);
       position-area: block-end span-inline-end;
@@ -159,7 +150,7 @@
 }
 .megamenu-active {
   @layer daisyui.l1.l2.l3 {
-    @apply bg-base-content/10 pointer-events-none absolute;
+    @apply pointer-events-none absolute bg-base-content/10;
     border-radius: var(--radius-field);
     transition:
       inset 300ms linear(0, 0.5 10%, 0.9 30%, 1.05 50%, 1.1 75%, 1),
@@ -193,10 +184,9 @@
 
 .megamenu-vertical {
   @layer daisyui.l1.l2 {
-    @apply flex-col items-start rounded-none opacity-0;
-    position: relative;
+    @apply relative w-full flex-col items-start rounded-none opacity-0;
+    background-color: var(--color-base-100);
     border-inline-width: 0;
-    width: 100%;
     position-area: block-end;
     max-block-size: calc(100% - 0.25rem);
     translate: 0 -0.5rem;
@@ -208,8 +198,7 @@
       display 200ms ease-out allow-discrete,
       overlay 200ms ease-out allow-discrete;
     &:popover-open {
-      @apply fixed pt-4 opacity-100;
-      background-color: var(--color-base-100);
+      @apply pt-4 opacity-100;
       @starting-style {
         @apply opacity-0;
       }
@@ -230,11 +219,7 @@
       }
     }
     [popover] {
-      opacity: 1;
-      overflow: visible;
-      position: relative;
-      display: block;
-      background-color: transparent;
+      @apply relative block overflow-visible bg-transparent opacity-100;
       border: none;
     }
   }


### PR DESCRIPTION
- use overflow visible to prevent hiding outline and showing overscroll on megamenu-active spring mivement
- use --tw-content to allow customization
- simplify popover-open change of opacity selector
- for megamenu-vertical move apply always bg color so that on close it does not become transparent
- for megamenu-vertical  do not use fixed position
- replace some props with tw apply classes
- tailwind auto class ordering

- feat: rotate dropdown indicator when open