### PR TITLE
fix(calendar): clear background on react-day-picker range middle cells

### DIFF
--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -298,6 +298,10 @@
       border: unset;
       border-radius: unset;
       color: inherit;
+      background-color: transparent;
+      &:hover {
+        background-color: transparent;
+      }
     }
     .rdp-range_end {
       color: var(--color-base-content);


### PR DESCRIPTION
## Fixes #4455

### Problem
In react-day-picker **range mode**, every in-range cell — including the *middle* ones — receives the `.rdp-selected` class. daisyUI's `.rdp-selected .rdp-day_button` rule paints a dark `--color-base-content` background. The `.rdp-range_middle .rdp-day_button` override only reset `border`, `border-radius` and `color` — **not** `background-color` — so the dark fill stayed on the middle cells and the middle of a selected range rendered as a black bar with unreadable dates.

### Fix
Reset the middle cells' `.rdp-day_button` background to `transparent` (also on hover) so the light `.rdp-range_middle` (`--color-base-200`) background shows through. The range start/end keep their highlighted (dark) endpoints.

```css
.rdp-range_middle .rdp-day_button {
  border: unset;
  border-radius: unset;
  color: inherit;
  background-color: transparent; /* added */
  &:hover {                      /* added */
    background-color: transparent;
  }
}
```

### Playground
Tailwind Play can't run React, so these use react-day-picker's static range-mode markup (`.rdp-range_middle.rdp-selected` etc.) with the same `.rdp-*` classes the library outputs:

- 🐛 Reproduction (current daisyUI) — middle cells render as a black bar: https://play.tailwindcss.com/7pSf2SKfdC
- ✅ With this fix applied as an override — middle cells use the light range background: https://play.tailwindcss.com/tcpBH38yUw

(The fix link applies the one-line change on top of the released daisyUI because the fix isn't published yet; in this PR it lives in `calendar.css`.)

### Notes
- Single-component change in `packages/daisyui/src/components/calendar.css`.
- `bun run build` succeeds and `bun test` passes (86/86).
