### PR TITLE
fix(mockup-code): span highlighted line background across full scroll width

### DIFF
--- a/packages/daisyui/src/components/mockup.css
+++ b/packages/daisyui/src/components/mockup.css
@@ -15,6 +15,8 @@
 
     pre {
       @apply pr-5;
+      width: max-content;
+      min-width: 100%;
 
       &:before {
         content: "";


### PR DESCRIPTION
## Fixes #4542

### Problem
A highlighted line in `mockup-code` — the documented pattern `<pre data-prefix="…" class="bg-… text-…"><code>…</code></pre>` — only painted its background across the **visible** width. When the line overflows horizontally and the code block scrolls, the highlight clips at the viewport edge instead of covering the whole line.

`.mockup-code` is `overflow-x-auto` and its child `<pre>` is `display:block` with no width, so the pre box equals the visible container width and a background on it stops at the scroll edge. (The line-number prefix is rendered via `pre::before`, so a full-line highlight belongs on the `<pre>`, not the inner `<code>`.)

### Fix
`packages/daisyui/src/components/mockup.css` — give `.mockup-code pre`:
```css
width: max-content; /* box covers the full line incl. overflow → background spans it */
min-width: 100%;    /* short highlighted lines still fill the width */
```
No change for short or non-highlighted lines; the scroll range is still the longest line.

### Playground (scroll the code block to the right to see the highlighted line)
- 🐛 Reproduction (current daisyUI) — highlight clips at the scroll edge: https://play.tailwindcss.com/Wf4l7ZAMKF
- ✅ With this fix — highlight spans the full line: https://play.tailwindcss.com/BNdrpvV182

### Notes
- Single-component change in `packages/daisyui/src/components/mockup.css`.
- `bun run build` succeeds; `bun test` passes (86/86).
- The existing docs "Highlighted line" example now renders correctly with no docs change.
