### PR TITLE
fix: remove text-wrap: balance from menu items

### DIFF
--- a/packages/daisyui/src/components/menu.css
+++ b/packages/daisyui/src/components/menu.css
@@ -26,7 +26,6 @@
       transition-duration: 0.2s;
       transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
       grid-auto-columns: minmax(auto, max-content) auto max-content;
-      text-wrap: balance;
       user-select: none;
     }
 


### PR DESCRIPTION
## Summary

Removes `text-wrap: balance` from `.menu` item labels in `menu.css`, letting them fall back to the CSS default `text-wrap: wrap`. Closes #4329.

## Playground

▶️ https://play.tailwindcss.com/sfbIj8EbWv

Same `menu w-40` and the same labels on both sides — only the menu items' `text-wrap` differs.

## Why

`text-wrap: balance` makes the browser even out line lengths. For short menu labels — especially when a menu is narrow (e.g. inside a dropdown) and items wrap — this produces balanced line breaks instead of natural wrapping. The reporter (#4329) asked for it to be removed; the default `wrap` is more predictable for menu labels, and MDN flags `balance` as ["computationally expensive"](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#balance), so dropping it where it isn't needed is also a small win.

## Effect / scope (verified in Chrome 148 and Firefox 150)

- When a menu sizes freely (fits on one line) there is **no visible difference** — `balance` only engages once text wraps. (This is why the change can look like a no-op at first glance.)
- When menu items are narrow enough to **wrap**, the line breaks differ. Example — `Export the file as PDF` in a `w-40` menu:
  - before (`balance`): `Export the` / `file as PDF`
  - after (`wrap`): `Export the file as` / `PDF`

Same result in both engines.

## Changes

- `packages/daisyui/src/components/menu.css` — remove the single `text-wrap: balance;` line from the menu-item rule (`:where(li:not(.menu-title) > *:not(ul, details, .menu-title, .btn))`).

## Note

`balance` was added intentionally, so this is a small design judgment — happy to adjust if you'd prefer to keep it or gate it behind a modifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
