### PR TITLE
fix(kbd): set text-base-content so .kbd is legible inside colored buttons

### DIFF
--- a/packages/daisyui/src/components/kbd.css
+++ b/packages/daisyui/src/components/kbd.css
@@ -1,7 +1,7 @@
 .kbd {
   box-shadow: none;
   @layer daisyui.l1.l2.l3 {
-    @apply bg-base-200 rounded-field inline-flex items-center justify-center align-middle;
+    @apply bg-base-200 text-base-content rounded-field inline-flex items-center justify-center align-middle;
     padding-inline: 0.5em;
     border: var(--border) solid color-mix(in srgb, var(--color-base-content) 20%, #0000);
     border-bottom: calc(var(--border) + 1px) solid


### PR DESCRIPTION
## Fixes #4353

### Problem

`.kbd` sets `bg-base-200` but never sets its own text color. When a `.kbd` is placed inside a colored button (`.btn-primary`, `.btn-secondary`, …) it inherits the button's `--btn-fg` — a `*-content` color meant for the button's *colored* background. On the keycap's light `base-200` background that foreground has very low contrast, so the key label is barely readable. @pdanpdan confirmed in the issue that `.kbd` should also set its color.

### Fix

Add `text-base-content` to `.kbd`'s `@apply`, mirroring the existing `bg-base-200 text-base-content` pairing in `badge.css`, so the keycap foreground is pinned to `base-content` regardless of any inherited color:

```css
@apply bg-base-200 text-base-content rounded-field inline-flex items-center justify-center align-middle;
```

### Playground

▶️ Before / after in one view (the same colored buttons with `.kbd` inside): https://play.tailwindcss.com/9HBEZyK4Ey

(The AFTER pane applies the one-line change as an override on top of the released daisyUI, because the fix isn't published yet; in this PR it lives in `kbd.css`.)

WCAG contrast of the `.kbd` label inside `.btn-primary` (light theme): **1.16 (fail) → 16.74 (AAA)**.

### Notes

- Single-component change in `packages/daisyui/src/components/kbd.css`; no new classes.
- Standalone `.kbd` (outside a colored button) is unchanged — it was already `base-content` on `base-200`.
- `bun run build` succeeds and `bun test` passes (86/86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
