### PR TITLE
fix(fab): fan out the first fab-flower action when no main-action is set

### DIFF
--- a/packages/daisyui/src/components/fab.css
+++ b/packages/daisyui/src/components/fab.css
@@ -76,7 +76,11 @@
   @layer daisyui.l1.l2.l3 {
     @apply grid;
     --position: 0rem;
-    > *:nth-child(-n + 2) {
+    /* Center the trigger and an explicit main-action/close by identity (not by
+       position), so the first real action fans out when neither is present. */
+    > *:nth-child(1),
+    > .fab-main-action,
+    > .fab-close {
       --position: 0rem;
     }
     > * {
@@ -93,46 +97,115 @@
     > :nth-child(n + 7) {
       @apply hidden;
     }
-    &:has(:nth-child(3)) {
-      --position: 140%;
-      > :nth-child(3) {
-        --degree: 135deg;
+    /* Mode A: an explicit main-action/close occupies the center; the arc starts
+       at the 3rd child. (Unchanged from before.) */
+    &:has(.fab-main-action),
+    &:has(.fab-close) {
+      &:has(:nth-child(3)) {
+        --position: 140%;
+        > :nth-child(3) {
+          --degree: 135deg;
+        }
+      }
+      &:has(:nth-child(4)) {
+        --position: 140%;
+        > :nth-child(3) {
+          --degree: 165deg;
+        }
+        > :nth-child(4) {
+          --degree: 105deg;
+        }
+      }
+      &:has(:nth-child(5)) {
+        --position: 180%;
+        > :nth-child(3) {
+          --degree: 180deg;
+        }
+        > :nth-child(4) {
+          --degree: 135deg;
+        }
+        > :nth-child(5) {
+          --degree: 90deg;
+        }
+      }
+      &:has(:nth-child(6)) {
+        --position: 220%;
+        > :nth-child(3) {
+          --degree: 180deg;
+        }
+        > :nth-child(4) {
+          --degree: 150deg;
+        }
+        > :nth-child(5) {
+          --degree: 120deg;
+        }
+        > :nth-child(6) {
+          --degree: 90deg;
+        }
       }
     }
-    &:has(:nth-child(4)) {
-      --position: 140%;
-      > :nth-child(3) {
-        --degree: 165deg;
+    /* Mode B: no main-action/close — the first action (2nd child) fans out too;
+       the arc starts at the 2nd child. */
+    &:not(:has(.fab-main-action)):not(:has(.fab-close)) {
+      &:has(:nth-child(2)) {
+        --position: 140%;
+        > :nth-child(2) {
+          --degree: 135deg;
+        }
       }
-      > :nth-child(4) {
-        --degree: 105deg;
+      &:has(:nth-child(3)) {
+        --position: 140%;
+        > :nth-child(2) {
+          --degree: 165deg;
+        }
+        > :nth-child(3) {
+          --degree: 105deg;
+        }
       }
-    }
-    &:has(:nth-child(5)) {
-      --position: 180%;
-      > :nth-child(3) {
-        --degree: 180deg;
+      &:has(:nth-child(4)) {
+        --position: 180%;
+        > :nth-child(2) {
+          --degree: 180deg;
+        }
+        > :nth-child(3) {
+          --degree: 135deg;
+        }
+        > :nth-child(4) {
+          --degree: 90deg;
+        }
       }
-      > :nth-child(4) {
-        --degree: 135deg;
+      &:has(:nth-child(5)) {
+        --position: 220%;
+        > :nth-child(2) {
+          --degree: 180deg;
+        }
+        > :nth-child(3) {
+          --degree: 150deg;
+        }
+        > :nth-child(4) {
+          --degree: 120deg;
+        }
+        > :nth-child(5) {
+          --degree: 90deg;
+        }
       }
-      > :nth-child(5) {
-        --degree: 90deg;
-      }
-    }
-    &:has(:nth-child(6)) {
-      --position: 220%;
-      > :nth-child(3) {
-        --degree: 180deg;
-      }
-      > :nth-child(4) {
-        --degree: 150deg;
-      }
-      > :nth-child(5) {
-        --degree: 120deg;
-      }
-      > :nth-child(6) {
-        --degree: 90deg;
+      &:has(:nth-child(6)) {
+        --position: 260%;
+        > :nth-child(2) {
+          --degree: 180deg;
+        }
+        > :nth-child(3) {
+          --degree: 157.5deg;
+        }
+        > :nth-child(4) {
+          --degree: 135deg;
+        }
+        > :nth-child(5) {
+          --degree: 112.5deg;
+        }
+        > :nth-child(6) {
+          --degree: 90deg;
+        }
       }
     }
   }

--- a/packages/daisyui/src/components/fab.css
+++ b/packages/daisyui/src/components/fab.css
@@ -97,56 +97,54 @@
     > :nth-child(n + 7) {
       @apply hidden;
     }
-    /* Mode A: an explicit main-action/close occupies the center; the arc starts
-       at the 3rd child. (Unchanged from before.) */
-    &:has(.fab-main-action),
-    &:has(.fab-close) {
-      &:has(:nth-child(3)) {
-        --position: 140%;
-        > :nth-child(3) {
-          --degree: 135deg;
-        }
-      }
-      &:has(:nth-child(4)) {
-        --position: 140%;
-        > :nth-child(3) {
-          --degree: 165deg;
-        }
-        > :nth-child(4) {
-          --degree: 105deg;
-        }
-      }
-      &:has(:nth-child(5)) {
-        --position: 180%;
-        > :nth-child(3) {
-          --degree: 180deg;
-        }
-        > :nth-child(4) {
-          --degree: 135deg;
-        }
-        > :nth-child(5) {
-          --degree: 90deg;
-        }
-      }
-      &:has(:nth-child(6)) {
-        --position: 220%;
-        > :nth-child(3) {
-          --degree: 180deg;
-        }
-        > :nth-child(4) {
-          --degree: 150deg;
-        }
-        > :nth-child(5) {
-          --degree: 120deg;
-        }
-        > :nth-child(6) {
-          --degree: 90deg;
-        }
+    &:has(:nth-child(3)) {
+      --position: 140%;
+      > :nth-child(3) {
+        --degree: 135deg;
       }
     }
-    /* Mode B: no main-action/close — the first action (2nd child) fans out too;
-       the arc starts at the 2nd child. */
-    &:not(:has(.fab-main-action)):not(:has(.fab-close)) {
+    &:has(:nth-child(4)) {
+      --position: 140%;
+      > :nth-child(3) {
+        --degree: 165deg;
+      }
+      > :nth-child(4) {
+        --degree: 105deg;
+      }
+    }
+    &:has(:nth-child(5)) {
+      --position: 180%;
+      > :nth-child(3) {
+        --degree: 180deg;
+      }
+      > :nth-child(4) {
+        --degree: 135deg;
+      }
+      > :nth-child(5) {
+        --degree: 90deg;
+      }
+    }
+    &:has(:nth-child(6)) {
+      --position: 220%;
+      > :nth-child(3) {
+        --degree: 180deg;
+      }
+      > :nth-child(4) {
+        --degree: 150deg;
+      }
+      > :nth-child(5) {
+        --degree: 120deg;
+      }
+      > :nth-child(6) {
+        --degree: 90deg;
+      }
+    }
+    /* No main-action/close: the first action (2nd child) fans out too, so the arc
+       starts at the 2nd child — same degrees as above, shifted by one child. */
+    &:not(:has(.fab-main-action, .fab-close)) {
+      > :nth-child(n + 6) {
+        @apply hidden;
+      }
       &:has(:nth-child(2)) {
         --position: 140%;
         > :nth-child(2) {
@@ -186,24 +184,6 @@
           --degree: 120deg;
         }
         > :nth-child(5) {
-          --degree: 90deg;
-        }
-      }
-      &:has(:nth-child(6)) {
-        --position: 260%;
-        > :nth-child(2) {
-          --degree: 180deg;
-        }
-        > :nth-child(3) {
-          --degree: 157.5deg;
-        }
-        > :nth-child(4) {
-          --degree: 135deg;
-        }
-        > :nth-child(5) {
-          --degree: 112.5deg;
-        }
-        > :nth-child(6) {
           --degree: 90deg;
         }
       }

--- a/packages/docs/src/routes/(routes)/components/fab/+page.md
+++ b/packages/docs/src/routes/(routes)/components/fab/+page.md
@@ -290,7 +290,7 @@ classnames:
 
 ### ~FAB Flower and Speed Dial
 
-#### fab-flower modifier class will open the button in a quarter circle instead of a vertical. fab-flower can fit 1 to 4 buttons, not including the original button, the fab-close button or the fab-main-action button.
+#### fab-flower modifier class will open the button in a quarter circle instead of a vertical. The fab-main-action / fab-close button is optional in fab-flower; without it, the first action button also fans out into the arc. fab-flower fits 1 to 4 action buttons when a fab-main-action or fab-close button is used, or up to 5 action buttons without one, not including the original button.
 
 <div class="h-54">
   <div class="fab fab-flower absolute z-1">
@@ -310,6 +310,33 @@ classnames:
 
   <!-- Main Action button replaces the original button when FAB is open -->
   <button class="$$fab-main-action $$btn $$btn-circle $$btn-lg">M</button>
+
+  <!-- buttons that show up when FAB is open -->
+  <button class="$$btn $$btn-lg $$btn-circle">A</button>
+  <button class="$$btn $$btn-lg $$btn-circle">B</button>
+  <button class="$$btn $$btn-lg $$btn-circle">C</button>
+  <button class="$$btn $$btn-lg $$btn-circle">D</button>
+</div>
+```
+
+### ~FAB Flower without a main action button
+
+#### The fab-main-action button is optional. Without it, the first action button also fans out into the arc instead of replacing the trigger.
+
+<div class="h-54">
+  <div class="fab fab-flower absolute z-1">
+    <div tabindex="0" role="button" class="btn btn-lg btn-circle btn-primary">F</div>
+    <button class="btn btn-lg btn-circle">A</button>
+    <button class="btn btn-lg btn-circle">B</button>
+    <button class="btn btn-lg btn-circle">C</button>
+    <button class="btn btn-lg btn-circle">D</button>
+  </div>
+</div>
+
+```html
+<div class="$$fab $$fab-flower">
+  <!-- a focusable div with tabindex is necessary to work on all browsers. role="button" is necessary for accessibility -->
+  <div tabindex="0" role="button" class="$$btn $$btn-lg $$btn-circle $$btn-primary">F</div>
 
   <!-- buttons that show up when FAB is open -->
   <button class="$$btn $$btn-lg $$btn-circle">A</button>

--- a/packages/docs/src/routes/(routes)/components/fab/+page.md
+++ b/packages/docs/src/routes/(routes)/components/fab/+page.md
@@ -290,7 +290,7 @@ classnames:
 
 ### ~FAB Flower and Speed Dial
 
-#### fab-flower modifier class will open the button in a quarter circle instead of a vertical. The fab-main-action / fab-close button is optional in fab-flower; without it, the first action button also fans out into the arc. fab-flower fits 1 to 4 action buttons when a fab-main-action or fab-close button is used, or up to 5 action buttons without one, not including the original button.
+#### fab-flower modifier class will open the button in a quarter circle instead of a vertical. The fab-main-action / fab-close button is optional in fab-flower; without it, the first action button also fans out into the arc. fab-flower fits up to 4 action buttons (not including the original button), with or without a fab-main-action / fab-close button.
 
 <div class="h-54">
   <div class="fab fab-flower absolute z-1">


### PR DESCRIPTION
## Fixes #4531

### Problem

In `.fab-flower` the center pin was `> *:nth-child(-n + 2) { --position: 0rem; }`, which pinned **both** the trigger (1st child) **and** the first action (2nd child) to the center. So when no `.fab-main-action` / `.fab-close` is present, the first action button overlaps and "replaces" the trigger instead of fanning out into the quarter-circle arc.

As reported by @topherfangio, this should only happen when a button is explicitly marked `.fab-main-action`. (@saadeghi: *"You're right. Will be fixed in v5.6 soon."*)

### Fix (minimal / additive)

Following review (@pdanpdan, @saadeghi) the change is kept as small and additive as possible:

1. **Center by identity, not position** — pin the trigger plus `.fab-main-action` / `.fab-close` (`> *:nth-child(1), > .fab-main-action, > .fab-close`).
2. **The existing arc blocks (`:has(:nth-child(3..6))`) are left untouched** — Mode A (with a main-action/close) is byte-identical to `v5.6`, so there is no regression risk.
3. A single block is **appended** for the no-main-action case: `&:not(:has(.fab-main-action, .fab-close))`, mirroring the existing degrees shifted by one child (the arc starts at the 2nd child) and hiding `:nth-child(n + 6)` so it caps at the same 4 actions as Mode A.

Net diff vs `v5.6` is just the identity-pin line + the appended `:not(:has())` block. (An earlier revision wrapped the existing rules in `:has(.fab-main-action)/:has(.fab-close)`; that wrapping has been reverted.)

### Playground

▶️ **Before / after, side by side:** https://play.tailwindcss.com/LifJWa8hZG

Rows are action counts, left column is the released (buggy) daisyUI, right column is this PR. Heads-up: Play loads the **released** daisyUI, so the right column re-creates the fix's result with a **clearly-labelled preview shim** on top of it — that shim is more verbose than this PR (it has to override the released `@layer` rules). The real CSS is the small diff above.

### Verification

`bun run build` succeeds (lightningcss accepts the `:not(:has())` selectors) and `bun test` passes (86/86).

Headless-Chromium measurement of each action's center offset from the trigger (button = 48px), opening each FAB via `:focus-within`:

| case | trigger | center button | arc actions (dist @ angle) |
|------|---------|---------------|----------------------------|
| no main / 1 | 0px | — | A 67px @135° |
| no main / 2 | 0px | — | A, B 67px @165° / 105° |
| no main / 3 | 0px | — | A, B, C 86px @180° / 135° / 90° |
| no main / 4 | 0px | — | A, B, C, D 106px @180° / 150° / 120° / 90° |
| `fab-main-action` / 3 | 0px | **0px (centered)** | A, B, C 86px @180° / 135° / 90° |
| `fab-close` / 3 | 0px | **0px (centered)** | A, B, C 86px @180° / 135° / 90° |

- **Without a main-action** the first action goes from overlapping the trigger (`dist 0`) to fanning out (`dist > 0`) at the correct angles.
- **With `fab-main-action` / `fab-close`** the center button stays on the trigger and the arc matches the unchanged `v5.6` geometry.

### Notes

- Single-component change in `packages/daisyui/src/components/fab.css`, plus a docs example (fab-flower without a main action) and a capacity note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
