### PR TITLE
fix(footer): don't apply grid display to script/style/template children

### DIFF
--- a/packages/daisyui/src/components/footer.css
+++ b/packages/daisyui/src/components/footer.css
@@ -4,14 +4,14 @@
     font-size: 0.875rem;
     line-height: 1.25rem;
 
-    & > * {
+    & > *:not(script, style, template) {
       @apply grid place-items-start gap-2;
     }
 
     &.footer-center {
       @apply grid-flow-col-dense place-items-center text-center;
 
-      & > * {
+      & > *:not(script, style, template) {
         @apply place-items-center;
       }
     }


### PR DESCRIPTION
## Fixes #4471

### Problem

`.footer` applies `display: grid` to every direct child via `.footer > * { … }`. Non-visual elements (`<script>`, `<style>`, `<template>`) default to `display: none`, but this unscoped rule overrides that to `display: grid`, so their text content becomes visible. This surfaces in real apps when a framework inlines a `<script>` as a direct child of `.footer` — the reporter hit it with an **Astro production build**.

### Fix

Scope the two `.footer` child selectors with `:not(script, style, template)` so non-visual elements keep their default `display: none`, while real content still gets the grid layout. This mirrors the existing `:not(td, tr, colgroup)` pattern already shipped in `collapse.css`.

```css
.footer > *:not(script, style, template) { … }              /* was .footer > * */
.footer.footer-center > *:not(script, style, template) { … }
```

### Playground

▶️ Before / after: https://play.tailwindcss.com/ZX2NXke6UT — an inlined `<script>` inside `.footer` is visible before, hidden after.

(The AFTER pane hides script/style/template via a scoped override on top of the released daisyUI, because the fix isn't published yet; in this PR it lives in `footer.css`.)

### Verification

Headless-Chromium computed `display` of `<script>` / `<style>` / `<template>` placed as direct `.footer` children (both `.footer` and `.footer-center`):

- **Before**: `display: grid` — the script/style text visibly renders.
- **After**: `display: none` — hidden; real content children still `display: grid`.

### Notes

- Single-component change in `packages/daisyui/src/components/footer.css`; no new classes.
- `bun run build` succeeds and `bun test` passes (86/86); the `:not(...)` selector-list compiles cleanly through lightningcss (`validatecss`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
