### PR TITLE
fix(calendar): use defined theme colors for Pikaday has-event/in-range

### DIFF
--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -486,14 +486,14 @@
 
       .has-event {
         .pika-button {
-          background: var(--color-base-primary);
+          background: var(--color-primary);
         }
       }
 
       .is-disabled,
       .is-inrange {
         .pika-button {
-          background: var(--color-base-primary);
+          background: var(--color-base-200);
         }
       }
 


### PR DESCRIPTION
## Fixes #4496

### Problem

The Pikaday styles in `calendar.css` reference `var(--color-base-primary)` — a variable that **doesn't exist** in any daisyUI theme (a typo concatenating `--color-base-*` and `--color-primary`). It appears at exactly two sites and nowhere else in the repo. Because the variable is undefined, each `background: var(--color-base-primary)` is invalid-at-computed-value-time and resets the background to `transparent`:

- `.has-event .pika-button` → the event day keeps its `color: var(--color-base-100)` (white) text but loses its background, so **the day number renders invisible (white on white)**.
- `.is-disabled, .is-inrange .pika-button` → in-range (range-middle) cells get **no highlight**.

### Fix

Replace the undefined variable with the intended, defined theme colors (the fix the reporter suggested), matching the file's own patterns — `.is-today` uses `--color-primary`; react-day-picker's `.rdp-range_middle` uses `--color-base-200`:

```css
.has-event .pika-button                 { background: var(--color-primary); }     /* was --color-base-primary */
.is-disabled, .is-inrange .pika-button  { background: var(--color-base-200); }    /* was --color-base-primary */
```

### Playground

▶️ Before / after: https://play.tailwindcss.com/aK7Jt5ScRL — the `has-event` day goes from invisible to a primary highlight; `in-range` gets a base-200 highlight.

(The AFTER pane applies the corrected colors via a scoped override on top of the released daisyUI, because the fix isn't published yet; in this PR it lives in `calendar.css`.)

### Verification

Headless-Chromium computed `background-color` of each Pikaday state cell:

- **has-event**: `transparent` (invisible day number) → `--color-primary`.
- **is-inrange**: `transparent` → `--color-base-200`.
- Other states unchanged (`is-today` = primary, `is-selected` = base-content).

### Notes

- Single-component change in `packages/daisyui/src/components/calendar.css`; two one-word edits, no new declarations.
- `bun run build` succeeds, `bun test` passes (86/86), and `--color-base-primary` no longer appears anywhere in the built CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
