### PR TITLE
fix(fab): prevent text selection on the FAB trigger/labels (Safari)

### DIFF
--- a/packages/daisyui/src/components/fab.css
+++ b/packages/daisyui/src/components/fab.css
@@ -1,6 +1,8 @@
 .fab {
   @layer daisyui.l1.l2.l3 {
-    @apply pointer-events-none fixed end-4 bottom-4 z-999 flex flex-col-reverse items-end gap-2 text-sm whitespace-nowrap;
+    /* select-none: stop Safari from selecting the trigger/labels on the click
+       that toggles :focus-within (also emits the -webkit- prefix Safari needs). */
+    @apply pointer-events-none fixed end-4 bottom-4 z-999 flex flex-col-reverse items-end gap-2 text-sm whitespace-nowrap select-none;
     > * {
       @apply pointer-events-auto flex items-center gap-2;
       &:hover,


### PR DESCRIPTION
## Fixes #4539

### Problem
Clicking the FAB trigger to toggle `:focus-within` can start a text selection in Safari, selecting the trigger and its action labels. `fab.css` is the only interactive/toggle component missing a `user-select: none` guard — `menu` and `calendar` already have it.

### Fix
Add `select-none` to the `.fab` root rule. Using the Tailwind utility (rather than a raw `user-select: none`) also emits the `-webkit-user-select` prefix Safari/WebKit needs, so the built `.fab` carries **both** `user-select: none` and `-webkit-user-select: none`.

```css
.fab {
  @layer daisyui.l1.l2.l3 {
    @apply ... select-none;   /* added */
```

### Playground
https://play.tailwindcss.com/67UUaIyQJQ — in Safari, try to drag-select / double-click the FAB action labels; with the fix the text is not selectable.

### Verification
- Built; the dist `.fab` rule now has both `user-select: none` and `-webkit-user-select: none`.
- Drove WebKit (Safari engine, via Playwright) and double-clicked a FAB action label:
  - **before** (default): the label text gets selected.
  - **after** (this fix): computed `-webkit-user-select` is `none` and the selection is empty.
- `bun test`: 85 pass. The single failure (`missingClassnamePrefix` on `components/aura/+page.md` — an unprefixed `btn` in a docs code block) is pre-existing on `v5.6` and unrelated to this change.

Closes #4539

🤖 Generated with [Claude Code](https://claude.com/claude-code)
