### PR TITLE
docs(rating): add read-only rating pattern to the skill (so it reaches llms.txt)

### DIFF
--- a/skills/daisyui/components/rating.md
+++ b/skills/daisyui/components/rating.md
@@ -15,7 +15,17 @@ Rating is a set of radio buttons that allow the user to rate something
 </div>
 ```
 
+For a read-only (non-interactive) rating, use `<div>` elements instead of radio inputs and mark the selected one with `aria-current="true"`:
+```html
+<div class="rating">
+  <div class="mask mask-star" aria-label="1 star"></div>
+  <div class="mask mask-star" aria-label="2 star" aria-current="true"></div>
+  <div class="mask mask-star" aria-label="3 star"></div>
+</div>
+```
+
 #### Rules
 - {MODIFIER} is optional and can have one of the modifier/size class names
 - Each set of rating inputs should have unique `name` attributes to avoid conflicts with other ratings on the same page
 - Add `rating-hidden` for the first radio to make it hidden so user can clear the rating
+- For a read-only/non-interactive rating, use `<div>` elements instead of the radio inputs and mark the selected one with `aria-current="true"`


### PR DESCRIPTION
## Closes #4500

### Problem
`/llms.txt` is generated from the condensed `skills/daisyui/components/*.md` files (via `packages/docs/src/routes/llms.txt/+server.js`). The **read-only rating** pattern is documented on the rating docs page (`### ~Read-only Rating`) but was never added to `skills/daisyui/components/rating.md`, so it never reached `/llms.txt` — which is the missing content reported in #4500.

### Fix
Add the read-only rating pattern (use `<div>` elements + `aria-current="true"` instead of radio inputs) to the skill's **Syntax** and **Rules** sections, mirroring the docs page, so it propagates to `/llms.txt`.

```html
<div class="rating">
  <div class="mask mask-star" aria-label="1 star"></div>
  <div class="mask mask-star" aria-label="2 star" aria-current="true"></div>
  <div class="mask mask-star" aria-label="3 star"></div>
</div>
```

### Verification
`llms.txt/+server.js` globs `skills/daisyui/components/*.md` and concatenates each file (frontmatter stripped). `rating.md` has no frontmatter, so the new content is included verbatim in the generated `/llms.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
