### PR TITLE
docs(alert): use stroke-current text-info so the icon is colored on the CDN

### DIFF
--- a/packages/docs/src/routes/(routes)/components/alert/+page.md
+++ b/packages/docs/src/routes/(routes)/components/alert/+page.md
@@ -37,13 +37,13 @@ classnames:
 
 ### ~Alert
 <div role="alert" class="alert w-full">
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current text-info shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
   <span>12 unread messages. Tap to see.</span>
 </div>
 
 ```html
 <div role="alert" class="$$alert">
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info h-6 w-6 shrink-0">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current text-info h-6 w-6 shrink-0">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
   </svg>
   <span>12 unread messages. Tap to see.</span>
@@ -207,7 +207,7 @@ classnames:
 
 ### ~Alert with buttons + responsive
 <div role="alert" class="alert w-full alert-vertical sm:alert-horizontal">
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current text-info shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
   <span>we use cookies for no reason.</span>
   <div>
     <button class="btn btn-sm">Deny</button>
@@ -217,7 +217,7 @@ classnames:
 
 ```html
 <div role="alert" class="$$alert $$alert-vertical sm:$$alert-horizontal">
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info h-6 w-6 shrink-0">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current text-info h-6 w-6 shrink-0">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
   </svg>
   <span>we use cookies for no reason.</span>
@@ -231,7 +231,7 @@ classnames:
 
 ### ~Alert with title and description
 <div role="alert" class="alert w-full alert-vertical sm:alert-horizontal">
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current text-info shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
   <div>
     <h3 class="font-bold">New message!</h3>
     <div class="text-xs">You have 1 unread message</div>
@@ -241,7 +241,7 @@ classnames:
 
 ```html
 <div role="alert" class="$$alert $$alert-vertical sm:$$alert-horizontal">
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info h-6 w-6 shrink-0">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current text-info h-6 w-6 shrink-0">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
   </svg>
   <div>


### PR DESCRIPTION
## Closes #4502

### Problem
The alert examples color the inline SVG icon with `stroke-info`. daisyUI's CDN/dist build **omits `stroke-*` color utilities** — they're generated into `colors/properties-extended.css`, which `packCss` excludes from `daisyui.css`. So CDN users get an **uncolored icon**.

### Fix
Replace `stroke-info` with `stroke-current text-info` in the 6 alert icon examples (live previews + copyable code blocks). `text-info` ships in the CDN and `stroke-current` is a core Tailwind utility, so the icon is colored via `currentColor` using only classes the CDN includes — the same approach the other alert examples in this file already use.

### Verification
- `packages/daisyui/build.js`: `stroke` color rules → `properties-extended.css`; `packCss` `exclude.colors` drops `properties-extended` from `daisyui.css`.
- Built dist `daisyui.css`: `.stroke-info` → **0** occurrences, `.text-info` → **20**. So `stroke-current text-info` is CDN-safe whereas `stroke-info` was not.
- `bun test`: the only failing test (`missingClassnamePrefix` on `components/aura/+page.md`, an unprefixed `btn`) is pre-existing on `v5.6` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
