### PR TITLE
docs(install/angular): note how to keep color-mix from being downleveled

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/angular/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/angular/+page.md
@@ -51,3 +51,29 @@ ng serve
 ```
 
 Now you can use daisyUI class names!
+
+### Note about modern CSS support
+
+Angular builds CSS for an old list of browsers by default, so modern CSS features like `color-mix()` (used by some daisyUI colors) can render differently than on daisyui.com.
+
+To fix this, tell the build to target modern browsers by adding a `browserslist` to your `package.json`:
+
+```sh:Terminal
+npm pkg set browserslist="> 1%"
+```
+
+This tells Angular's CSS optimizer (Lightning CSS) to keep modern CSS instead of polyfilling it for outdated browsers — the same fix used in the [Next.js guide](/docs/install/nextjs/). daisyUI and Tailwind CSS target modern browsers, so this doesn't drop any supported browser.
+
+Alternatively, you can run Tailwind's own optimization step in `.postcssrc.json`:
+
+```json:.postcssrc.json
+{
+  "plugins": {
+    "@tailwindcss/postcss": {
+      "optimize": true
+    }
+  }
+}
+```
+
+Use `"optimize": { "minify": false }` if you'd rather keep the development CSS unminified.


### PR DESCRIPTION
## Closes #4291

### Problem
Using daisyUI in Angular, `color-mix()`-based colors (e.g. the list bottom border `border-base-content/5`) render differently than on daisyui.com. Angular's build (esbuild + Lightning CSS) targets an **old browserslist** by default and downlevels/polyfills `color-mix()`. It also can't tell the Tailwind PostCSS plugin it's a production build, so Tailwind's own optimization doesn't run (see [angular/angular-cli#28938](https://github.com/angular/angular-cli/issues/28938)).

### Fix (docs note)
Adds a **"Note about modern CSS support"** to the Angular install guide with two options:

1. **`browserslist: "> 1%"`** in `package.json` — tells Lightning CSS to target modern browsers. This is the same approach the [Next.js guide](https://daisyui.com/docs/install/nextjs/) already documents for the equivalent Turbopack/Lightning CSS issue.
2. **`optimize: true`** on `@tailwindcss/postcss` — the fix the reporter confirmed in #4291 (with a note that `{ "minify": false }` keeps the dev CSS unminified).

daisyUI and Tailwind CSS v4 target modern browsers anyway (Safari 16.4+, Chrome 111+, Firefox 128+), so neither option drops a supported browser.

### Notes
- @pdanpdan suggested adding this to the Angular docs in the issue thread.
- Docs-only change; no source CSS or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
