### PR TITLE
docs: remove tooltip neutral class from docs

### DIFF
--- a/packages/docs/src/routes/(routes)/components/tooltip/+page.md
+++ b/packages/docs/src/routes/(routes)/components/tooltip/+page.md
@@ -24,8 +24,6 @@ classnames:
   - class: tooltip-open
     desc: Force open tooltip
   color:
-  - class: tooltip-neutral
-    desc: neutral color
   - class: tooltip-primary
     desc: primary color
   - class: tooltip-secondary
@@ -148,21 +146,6 @@ classnames:
   <button class="$$btn">Right</button>
 </div>
 ```
-
-
-### ~Neutral color
-<div class="my-6">
-  <div data-tip="neutral" class="tooltip tooltip-open tooltip-neutral">
-    <button class="btn btn-neutral">neutral</button>
-  </div>
-</div>
-
-```html
-<div class="$$tooltip $$tooltip-open $$tooltip-neutral" data-tip="neutral">
-  <button class="$$btn $$btn-neutral">neutral</button>
-</div>
-```
-
 
 ### ~Primary color
 <div class="my-6">


### PR DESCRIPTION
## Summary

- remove `tooltip-neutral` from the tooltip component class list
- remove the neutral tooltip example that referenced the non-generated class

## Why

The tooltip component uses the neutral color by default, but `tooltip-neutral` is not generated. Listing it in the docs makes it look like a supported class even though it has no generated selector.

Related to #4492.

## Validation

- Confirmed the committed diff only touches the tooltip docs page
- Searched `packages/docs` and `skills` for `tooltip-neutral`; no matches remain
