### PR TITLE
fix: position of the megamenu when switching from vertical opened to non-vertical megamenu

### DIFF
--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -158,14 +158,16 @@
       margin-top: var(--mm-mt, 4rem);
       [popovertarget],
       > [popover]:not(:nth-of-type(1)) {
-        display: var(--mm-display, none);
+        display: var(--mm-display, block);
       }
       &::backdrop {
         background-color: var(--mm-backdrop, oklch(0% 0 0/ 0.4));
       }
       border-inline-width: 0;
       position-area: block-end;
-      max-block-size: calc(100% - 0.25rem);
+      top: 0;
+      inset-inline: 0;
+      max-block-size: 90svh;
       translate: 0 0;
       scale: 1;
       transition:
@@ -206,6 +208,9 @@
 .megamenu-wide {
   @layer daisyui.l1.l2 {
     anchor-name: --megamenu;
+    &:popover-open {
+      inset-inline: 0;
+    }
     [popover] {
       position-area: block-end;
       position-anchor: --megamenu;
@@ -217,6 +222,9 @@
 .megamenu-full {
   @layer daisyui.l1.l2 {
     anchor-name: --megamenu;
+    &:popover-open {
+      inset-inline: 0;
+    }
     [popover] {
       position-area: block-end;
       position-anchor: --megamenu;

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -167,7 +167,7 @@
       position-area: block-end;
       top: 0;
       inset-inline-start: 0;
-      max-block-size: 90svh;
+      max-block-size: 80svh;
       translate: 0 0;
       scale: 1;
       transition:

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -151,7 +151,7 @@
     }
   }
 
-  @layer daisyui.l1 {
+  @layer daisyui.l1.l2 {
     &:popover-open {
       @apply fixed w-full flex-col items-start overflow-y-scroll rounded-none pt-4 opacity-100;
       background-color: var(--color-base-100);
@@ -166,7 +166,7 @@
       border-inline-width: 0;
       position-area: block-end;
       top: 0;
-      inset-inline-start: 0;
+      inset-inline: 0;
       max-block-size: 80svh;
       translate: 0 0;
       scale: 1;
@@ -208,9 +208,6 @@
 .megamenu-wide {
   @layer daisyui.l1.l2 {
     anchor-name: --megamenu;
-    &:popover-open {
-      inset-inline: 0;
-    }
     [popover] {
       position-area: block-end;
       position-anchor: --megamenu;
@@ -222,9 +219,6 @@
 .megamenu-full {
   @layer daisyui.l1.l2 {
     anchor-name: --megamenu;
-    &:popover-open {
-      inset-inline: 0;
-    }
     [popover] {
       position-area: block-end;
       position-anchor: --megamenu;

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -166,7 +166,7 @@
       border-inline-width: 0;
       position-area: block-end;
       top: 0;
-      inset-inline: 0;
+      inset-inline-start: 0;
       max-block-size: 90svh;
       translate: 0 0;
       scale: 1;


### PR DESCRIPTION
example: https://play.tailwindcss.com/Ms2Kg3l7bH