### PR TITLE
fix(modal): add overlay transition to prevent abrupt exit on stacked dialogs

### DIFF
--- a/packages/daisyui/src/components/modal.css
+++ b/packages/daisyui/src/components/modal.css
@@ -2,6 +2,7 @@
   @layer daisyui.l1.l2.l3 {
     @apply pointer-events-none invisible fixed inset-0 m-0 grid h-full max-h-none w-full max-w-none items-center justify-items-center bg-transparent p-0 text-[inherit];
     transition:
+      overlay 0.3s allow-discrete,
       visibility 0.3s allow-discrete,
       background-color 0.3s ease-out,
       opacity 0.1s ease-out;

--- a/packages/docs/src/components/SkillProduct.svelte
+++ b/packages/docs/src/components/SkillProduct.svelte
@@ -4,7 +4,7 @@
   let { product, productKey, convertCurrency, productDiscount = true } = $props()
 </script>
 
-<div class={`relative ${productDiscount ? "outline-error outline-4 outline-offset-4" : ""}`}>
+<div class={`relative ${productDiscount ? "outline-error z-1 outline-4 outline-offset-4" : ""}`}>
   <a
     href={`/skills/${productKey}/`}
     id={productKey}

--- a/packages/docs/src/translation/fa.json
+++ b/packages/docs/src/translation/fa.json
@@ -579,7 +579,7 @@
   "For large sized components like card, modal, alert, etc.": "برای کامپوننت‌های بزرگ مانند کارت، مودال، هشدار و غیره.",
   "rounded-field": "rounded-field",
   "var(--radius-field)": "var(--radius-field)",
-  "For medium sized components like button, input, select, tab, etc.": "برای کامپوننت‌های متوسط ​​مانند دکمه، ورودی، انتخاب، تب و غیره.",
+  "For medium sized components like button, input, select, tab, etc.": "برای کامپوننت‌های متوسط مانند دکمه، اینپوت، سلکت، تب و غیره.",
   "rounded-selector": "rounded-selector",
   "var(--radius-selector)": "var(--radius-selector)",
   "For small sized components like checkbox, toggle, badge, etc.": "برای کامپوننت‌های کوچک مانند checkbox، toggle، بج و غیره.",


### PR DESCRIPTION
Adding a transition to the overlay property allows the dialog to be animated out when another modal is open.

This PR addresses the issue mentioned in: https://github.com/saadeghi/daisyui/issues/4575
