### PR TITLE
fix: #4602 indicator center and middle misalign when item is a child …

### DIFF
--- a/packages/daisyui/src/components/indicator.css
+++ b/packages/daisyui/src/components/indicator.css
@@ -30,7 +30,7 @@
 .indicator-center {
   @layer daisyui.l1.l2 {
     --indicator-s: 50%;
-    --indicator-e: 50%;
+    --indicator-e: auto;
     --indicator-x: -50%;
     [dir="rtl"] & {
       --indicator-x: 50%;
@@ -62,7 +62,7 @@
 .indicator-middle {
   @layer daisyui.l1.l2 {
     --indicator-t: 50%;
-    --indicator-b: 50%;
+    --indicator-b: auto;
     --indicator-y: -50%;
   }
 }

--- a/packages/daisyui/src/components/indicator.css
+++ b/packages/daisyui/src/components/indicator.css
@@ -33,6 +33,7 @@
     --indicator-e: auto;
     --indicator-x: -50%;
     [dir="rtl"] & {
+      --indicator-e: 50%;
       --indicator-x: 50%;
     }
   }


### PR DESCRIPTION
…html tag.

closes: #4602 