### PR TITLE
fix(collapse): don't force display:grid on colgroup/td/tr

### DIFF
--- a/packages/daisyui/src/components/collapse.css
+++ b/packages/daisyui/src/components/collapse.css
@@ -1,8 +1,6 @@
 .collapse:not(td, tr, colgroup) {
   visibility: revert-layer;
-}
 
-.collapse {
   @layer daisyui.l1.l2.l3 {
     display: grid;
     position: relative;


### PR DESCRIPTION
## Problem

Closes #4463

Applying `.collapse` to a `<colgroup>` (or `<td>`/`<tr>`) forces `display: grid` onto it, overriding the required `display: table-column-group` (resp. `table-cell` / `table-row`). This breaks the table layout, as reported in #4463.

The `display: grid` (plus `grid-template-rows` / `grid-template-columns`, `position`, `isolation`, …) is set on `.collapse` inside `@layer daisyui.l1.l2.l3`. The existing guard only reverts `visibility` and already excludes these elements:

```css
.collapse:not(td, tr, colgroup) {
  visibility: revert-layer;
}
```

…but the component's `display: grid` was set on a bare `.collapse`, so it still landed on a `<colgroup class="collapse">`.

## Fix

Scope the component rule so it never applies to table elements in the first place, rather than applying it and reverting it afterwards:

```diff
- .collapse {
+ .collapse:not(td, tr, colgroup) {
    @layer daisyui.l1.l2.l3 {
      display: grid;
      …
```

This mirrors the intent already encoded by the existing `visibility` guard, so the two rules now share the same selector and are merged into one:

```css
.collapse:not(td, tr, colgroup) {
  visibility: revert-layer;

  @layer daisyui.l1.l2.l3 {
    display: grid;
    …
  }
}
```

Table elements (`td` / `tr` / `colgroup`) keep their user-agent `display` because no component styling is applied to them — nothing needs to be reverted.

> Approach updated per @saadeghi's review (https://github.com/saadeghi/daisyui/pull/4605#issuecomment-4911026282): scoping the selector replaces the earlier `.collapse:is(td, tr, colgroup) { all: revert-layer }` companion-rule approach.

## Verification

Built and ran the test suite (**129 pass / 0 fail**). Confirmed in the compiled `daisyui.css` that `display: grid` and the other component properties are emitted only under `.collapse:not(td, tr, colgroup)` (no `all: revert-layer` companion remains). The resulting computed `display` (see the before/after Tailwind Play demos in the review thread):

| element | before | after |
|---|---|---|
| `<colgroup class="collapse">` | `grid` (bug) | `table-column-group` |
| `<tr class="collapse">` | `grid` | `table-row` |
| `<td class="collapse">` | `grid` | `table-cell` |
| `<div class="collapse">` | `grid` | `grid` (unchanged) |
