### PR TITLE
docs(input): add fieldset + label example without a legend

### DIFF
--- a/packages/docs/src/routes/(routes)/components/input/+page.md
+++ b/packages/docs/src/routes/(routes)/components/input/+page.md
@@ -140,6 +140,20 @@ classnames:
 </fieldset>
 ```
 
+### ~With fieldset and label
+
+<fieldset class="fieldset w-xs">
+  <label class="label" for="name">Name</label>
+  <input type="text" id="name" class="input" placeholder="Name" />
+</fieldset>
+
+```html
+<fieldset class="$$fieldset">
+  <label class="$$label" for="name">Name</label>
+  <input type="text" id="name" class="$$input" placeholder="Name" />
+</fieldset>
+```
+
 ### ~Input colors
 
 <div class="grid gap-4 w-xs">


### PR DESCRIPTION
## What

Closes #3573

Adds a simple `fieldset` + `label` grouping example (without a `fieldset-legend`) to the Text Input docs page, right after the existing "With fieldset and fieldset-legend" example.

```html
<fieldset class="fieldset">
  <label class="label" for="name">Name</label>
  <input type="text" id="name" class="input" placeholder="Name" />
</fieldset>
```

## Why

In #3573 the reporter pointed out that the input docs only demonstrate grouping with a `fieldset-legend`, and there was no simple `fieldset` + `label` example matching the [form-control replacement in the upgrade guide](https://daisyui.com/docs/upgrade/#other-removals). This adds exactly that, using `for`/`id` to associate the label with the input.

The issue's other concern — the overlap between `fieldset-label` and `label` — has since been resolved: `fieldset-label` is now marked *deprecated in favor of `label`* in `fieldset.css` (kept only to avoid a breaking change) and no longer appears in any docs example. So this PR only addresses the remaining, still-missing example.

## Notes

- Docs-only change, one file.
- Follows the existing example convention (live preview + `$$`-prefixed code block).
- Verified locally: the docs dev server renders the new "With fieldset and label" section and its live preview correctly.