### PR TITLE
docs(drawer): add drawer-button to navbar example for keyboard focus

### DIFF
--- a/packages/docs/src/routes/(routes)/components/drawer/+page.md
+++ b/packages/docs/src/routes/(routes)/components/drawer/+page.md
@@ -106,7 +106,7 @@ You can check/uncheck the checkbox using JavaScript or by clicking the `label` t
   <div class="flex flex-col drawer-content">
     <div class="w-full navbar bg-base-300">
       <div class="flex-none lg:hidden">
-        <label for="my-drawer-2" aria-label="open sidebar" class="btn btn-square btn-ghost">
+        <label for="my-drawer-2" aria-label="open sidebar" class="btn btn-square btn-ghost drawer-button">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-6 h-6 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
         </label>
       </div>
@@ -136,7 +136,7 @@ You can check/uncheck the checkbox using JavaScript or by clicking the `label` t
     <!-- Navbar -->
     <div class="$$navbar bg-base-300 w-full">
       <div class="flex-none lg:hidden">
-        <label for="my-drawer-2" aria-label="open sidebar" class="$$btn $$btn-square $$btn-ghost">
+        <label for="my-drawer-2" aria-label="open sidebar" class="$$btn $$btn-square $$btn-ghost $$drawer-button">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"


### PR DESCRIPTION
## What

Addresses one item of #4424 (`ref #4424`, not `closes` — the checklist has other open items).

The **"Navbar menu for desktop + sidebar drawer for mobile"** example is the only drawer example whose toggle button (the mobile hamburger) doesn't use the `drawer-button` class. This adds it (live preview + code block):

```diff
- <label for="my-drawer-2" aria-label="open sidebar" class="btn btn-square btn-ghost">
+ <label for="my-drawer-2" aria-label="open sidebar" class="btn btn-square btn-ghost drawer-button">
```

## Why

Per the checklist in #4424: *"example needs `drawer-button`"*.

The `.drawer-toggle` checkbox is visually hidden (`h-0 w-0 opacity-0`) but still keyboard-focusable. `drawer.css` surfaces a visible focus indicator via:

```css
.drawer-toggle:focus-visible ~ .drawer-content label.drawer-button {
  outline: 2px solid;
  outline-offset: 2px;
}
```

Without `drawer-button` on the hamburger, a keyboard user tabbing to the toggle gets **no** focus indicator. The other three drawer examples already use `btn drawer-button`; this makes the navbar example consistent. No CSS change — it just enables the existing rule.

## Verification

Built daisyUI and checked computed styles in Chromium after focusing the toggle with the keyboard (`Tab`, so `:focus-visible` applies):

| hamburger | `outline` |
|---|---|
| before (no `drawer-button`) | `none` |
| after (`drawer-button`) | `2px solid` |

## Notes

- Docs-only, one file, navbar example only.
- The sibling checklist item *"the checkbox should be hidden when drawer is `drawer-open`"* is already satisfied by `drawer.css` (`.drawer-open > .drawer-toggle { @apply hidden; }`).
- The icon-only drawer items in #4424 are left out — the reporter noted they *"need a deeper analysis"*.