### PR TITLE
fix(select): use same label color and box shadow for select disabled as for input

### DIFF
--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -81,7 +81,12 @@
     &:has(> select[disabled]),
     &:is(:disabled, [disabled]),
     fieldset:disabled & {
-      @apply border-base-200 bg-base-200 text-base-content/40 cursor-not-allowed;
+      @apply border-base-200 bg-base-200 cursor-not-allowed;
+      &:is(select),
+      :is(select) {
+        @apply text-base-content/40;
+      }
+      box-shadow: none;
 
       &::placeholder,
       ::placeholder {


### PR DESCRIPTION
- in https://github.com/saadeghi/daisyui/commit/b88dbb5aee08c2a09ae0c6ad7072fe9c401b1dcd only input was adjusted
- box-shadow was not applied also for select (only for input)

example: https://play.tailwindcss.com/85fYlexxg6?file=css

close #4604