### PR TITLE
fix(join): prevent --join-(ss|se|es|ee) propagation to children of .join-item

### DIFF
--- a/packages/daisyui/src/utilities/join.css
+++ b/packages/daisyui/src/utilities/join.css
@@ -42,6 +42,15 @@
 }
 
 .join-item {
+  @layer daisyui.l1.l2.l3.l4 {
+    > * {
+      --join-ss: initial;
+      --join-se: initial;
+      --join-es: initial;
+      --join-ee: initial;
+    }
+  }
+
   border-style: solid;
   border-width: var(--border, 1px);
   border-start-start-radius: var(--join-ss);


### PR DESCRIPTION
example: https://play.tailwindcss.com/XR1lLHzRSt?file=css

close #4597