### PR TITLE
fix(btn): move btn-active in layer l2, interactive styles in l1, and link overrides in daisyui layer

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -65,7 +65,7 @@
     }
   }
 
-  @layer daisyui.l1.l2 {
+  @layer daisyui.l1 {
     &:where(:checked:not(.filter [type="radio"].btn)) {
       --btn-color: var(--color-primary);
       --btn-fg: var(--color-primary-content);
@@ -119,7 +119,7 @@
 }
 
 .btn-active {
-  @layer daisyui.l1.l2.l3 {
+  @layer daisyui.l1.l2 {
     --btn-bg: var(--btn-color, var(--color-base-200));
     color: var(--btn-fg, var(--color-base-content));
     --btn-border: color-mix(in oklab, var(--btn-bg), #000 calc(var(--depth) * 5%));
@@ -183,7 +183,7 @@
 }
 
 .btn-link {
-  @layer daisyui.l1 {
+  @layer daisyui {
     @apply underline;
     --btn-bg: #0000;
     color: var(--btn-color, var(--color-primary));


### PR DESCRIPTION
reorder specificity so that:
- base btn is in l3
- btn-active is in l2
- interactivity is in l1
- link overrides in daisyui layer
- disabled overrides in daisyui layer

I'm not sure about the last 2 (link and disabled) - the should be safe but another person checking would help

example: https://play.tailwindcss.com/aRHZQWxcH7

ref #4591