### PR TITLE
fix(progress): animate value changes to match radial-progress

### DIFF
--- a/packages/daisyui/src/components/progress.css
+++ b/packages/daisyui/src/components/progress.css
@@ -37,6 +37,9 @@
     @supports (-moz-appearance: none) {
       &::-moz-progress-bar {
         @apply rounded-box bg-current;
+        @media (prefers-reduced-motion: no-preference) {
+          transition: inline-size 0.3s ease;
+        }
       }
     }
 
@@ -48,6 +51,9 @@
       &::-webkit-progress-value {
         @apply rounded-box;
         background-color: currentColor;
+        @media (prefers-reduced-motion: no-preference) {
+          transition: inline-size 0.3s ease;
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

Closes #4622

`radial-progress` smoothly interpolates when `--value` changes, but the standard `<progress class="progress">` snaps instantly, because its value fill has no `transition`.

- `radialprogress.css` transitions the registered `--radialprogress` `@property` (`transition: --radialprogress 0.3s`), so the conic gradient animates.
- `progress.css` set no transition on `::-webkit-progress-value` / `::-moz-progress-bar`, so `value` changes jump. (The existing `animation: progress` is `:indeterminate`-only and unrelated.)

## Fix

Add a `prefers-reduced-motion`-guarded transition to the value fill in `progress.css`:

```css
&::-webkit-progress-value {
  /* … */
  @media (prefers-reduced-motion: no-preference) {
    transition: inline-size 0.3s ease;
  }
}
/* same for &::-moz-progress-bar */
```

- Indeterminate progress only animates `background-position-x` (not `inline-size`), so it's unaffected.
- Guarded by `prefers-reduced-motion` for accessibility.
- Firefox parity (`::-moz-progress-bar`) is by analogy — symmetric rule.

## Before / After (Tailwind Play)

**https://play.tailwindcss.com/N83TEOsv50**

Two `.progress` bars sweep the same values. **Before** jumps between them (today's snapping); **After** eases between them (this PR). *Note: Tailwind Play can't run JS to change `value` live, so the demo drives the fill with a CSS keyframe purely to illustrate the difference — the PR itself only adds the transition, not the keyframe.*

## Verification

Built daisyUI and checked in Chromium by changing `value` 10 → 90:

| bar | 60ms after change vs settled |
|---|---|
| with this PR | **differs** → fill is mid-transition (animating) |
| without (transition:none) | identical → snaps instantly |

The settled rendering (value fully applied) is **byte-identical** with and without the change, so there is no visual regression — only the transition between values differs.