### PR TITLE
fix(otp): keep OTP left-to-right so it renders correctly in RTL

### DIFF
--- a/packages/daisyui/src/components/otp.css
+++ b/packages/daisyui/src/components/otp.css
@@ -1,6 +1,9 @@
 .otp {
   @layer daisyui.l1.l2.l3 {
     @apply relative inline-flex font-mono;
+    /* OTP codes read left-to-right (digits are bidi-LTR), so keep the boxes and
+       the input aligned by pinning the component to LTR even inside dir="rtl". */
+    direction: ltr;
     clip-path: inset(-3.5px 3.5px -3.5px -3.5px);
     border-radius: var(--radius-field);
     font-size: 1.75rem;


### PR DESCRIPTION
## Problem

Closes #4609

Inside `dir="rtl"`, the OTP digits no longer line up with their boxes.

The box positions use **physical** properties (`.otp > span { left: … }`) while the input padding (`padding-inline-start`) and the trailing `:after` slot use **logical** properties. In RTL the logical sides flip but the boxes stay put, so the digits and boxes drift apart. OTP codes are read left-to-right anyway (digits are bidi-LTR), so mirroring the boxes wouldn't help — the digit string never reverses.

## Fix

Pin the component to LTR:

```css
.otp {
  @layer daisyui.l1.l2.l3 {
    @apply relative inline-flex font-mono;
    direction: ltr;   /* new */
    …
```

In an LTR page this is a no-op. In RTL, the OTP now renders identically to LTR — digits centered in their boxes — which is the correct behavior for a numeric code. One line, no markup change.

## Before / After (Tailwind Play, `dir="rtl"`)

**https://play.tailwindcss.com/bXjtFKoU3q**

Two OTP fields inside a `dir="rtl"` page: **Before** (`.otp`) shows the digits drifting off their boxes; **After** (`.otp` + a demo-scoped `.otp-ltr` shim = this PR) shows them aligned.

## Verification

Built daisyUI and screenshotted a filled 6-digit OTP in Chromium:

| | render |
|---|---|
| LTR (unchanged) | `1 2 3 4 5 6` centered |
| RTL **before** | digits misaligned / clipped against boxes |
| RTL **after** | `1 2 3 4 5 6` centered — identical to LTR |

`direction: ltr` is a no-op under LTR, so there is no LTR change. Safari/Firefox are unaffected (property is not engine-specific).