### PR TITLE
fix(footer): make footer-center a standalone class so max-lg:footer-center works

### DIFF
--- a/packages/daisyui/src/components/footer.css
+++ b/packages/daisyui/src/components/footer.css
@@ -7,13 +7,14 @@
     & > *:not(script, style, template) {
       @apply grid place-items-start gap-2;
     }
+  }
+}
+.footer-center {
+  @layer daisyui.l1.l2 {
+    @apply grid-flow-col-dense place-items-center text-center;
 
-    &.footer-center {
-      @apply grid-flow-col-dense place-items-center text-center;
-
-      & > *:not(script, style, template) {
-        @apply place-items-center;
-      }
+    & > *:not(script, style, template) {
+      @apply place-items-center;
     }
   }
 }


### PR DESCRIPTION
## Problem

Closes #4493

`max-lg:footer-center` generates no class (while `max-lg:timeline-compact` works).

`footer-center` is defined **only** as the compound `.footer.footer-center`, so it isn't a standalone utility. The build's component object (`components/footer/object.js`) has no top-level `.footer-center` key — only `.footer`, `.footer-title`, `.footer-horizontal`, `.footer-vertical` — so Tailwind has nothing to attach responsive/variant prefixes to. `timeline-compact` works precisely because it's a standalone `.timeline-compact` rule.

## Fix

Promote `footer-center` to a standalone rule, matching `timeline-compact`:

```css
.footer-center {
  @layer daisyui.l1.l2 {
    @apply grid-flow-col-dense place-items-center text-center;
    & > *:not(script, style, template) {
      @apply place-items-center;
    }
  }
}
```

Using the modifier layer `daisyui.l1.l2` preserves the existing cascade:
- it still overrides the base `.footer` (`l1.l2.l3`);
- it is still overridden by the higher-specificity `.footer-horizontal.footer-center` / `.footer-vertical.footer-center` direction rules.

## Before / After (Tailwind Play)

**https://play.tailwindcss.com/0RPboybGwQ** — resize the preview **below `lg` (1024px)**. *Before* (`max-lg:footer-center`) stays default; *After* (a `@utility footer-centerfix` emulating this PR) centers. On a wide preview both look the same.

## Verification

Compiled with Tailwind against `class="footer max-lg:footer-center max-lg:timeline-compact"`:

| | `max-lg:footer-center` | `max-lg:timeline-compact` (control) |
|---|---|---|
| before (current) | **0 — not generated** | 1 |
| after (this PR) | **generated** (real `@media (width < 64rem)` rule) | 1 |

Base and direction behavior unchanged (computed styles): `footer footer-center` → `column dense` / center; `footer footer-horizontal footer-center` → `row dense` (override still wins); plain `footer` → `row` / start.

## Note

Making `footer-(horizontal|vertical)` **and** `footer-center` responsive at the same time would need combined utilities (per @pdanpdan) and is intentionally out of scope — this fixes the reported base `footer-center` case.