### PR TITLE
fix: prevent iOS legend stretch causing missing top border in fieldset

### DIFF
--- a/packages/daisyui/src/components/fieldset.css
+++ b/packages/daisyui/src/components/fieldset.css
@@ -10,6 +10,7 @@
   @layer daisyui.l1.l2.l3 {
     @apply text-base-content -mb-1 flex items-center justify-between gap-2 py-2;
     font-weight: 600;
+    margin-inline-end: auto;
   }
 }
 /* deprecated in favor of label - but stays in source code to avoid breaking change */


### PR DESCRIPTION
Fixes #4611

### Problem
When `<fieldset>` has `display: flex` on iOS, the `<legend>` element stretches to full width, consuming the top border. This only happens on iOS — Chrome and Firefox render correctly.

### Fix
Add `margin-inline-end: auto` to `.fieldset-legend` to prevent iOS from stretching the legend across the full fieldset width. This is the fix proposed and confirmed in the issue discussion.