### PR TITLE
fix(btn): for btn-active apply :active styles not checked styles

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -120,14 +120,12 @@
 
 .btn-active {
   @layer daisyui.l1.l2 {
-    --btn-bg: var(--btn-color, var(--color-base-200));
+    --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
     color: var(--btn-fg, var(--color-base-content));
-    --btn-border: color-mix(in oklab, var(--btn-bg), #000 calc(var(--depth) * 5%));
+    --btn-border: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);
     --btn-border-style: solid;
-    --btn-inset: 0 0.5px 0 0.5px oklch(100% 0 0 / calc(var(--depth) * 6%));
-    --btn-shadow:
-      0 3px 2px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000),
-      0 4px 3px -2px color-mix(in oklab, var(--btn-bg) calc(var(--depth) * 30%), #0000);
+    --btn-inset: 0 0 0 0 oklch(0% 0 0/0);
+    --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
     isolation: isolate;
   }
 }


### PR DESCRIPTION
v5.5: https://play.tailwindcss.com/59JGGtsjoT
v5.6: https://play.tailwindcss.com/Vw9AW4DSsa
v5.6 with styles applied from `:active` not from `checked`: https://play.tailwindcss.com/5PHLLYVVqd?file=css (changes only in btn-active, I left the old ones commented)

Full example: https://play.tailwindcss.com/LikDkJmNwh?file=css

ref #4584
close #4632