### PR TITLE
fix(calendar): replace invalid ::part(day):hover:not(selected, today) selector

### DIFF
--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -33,22 +33,23 @@
     ::part(day):hover {
       background: var(--color-base-200);
     }
+    /* `:not()` can't follow `::part()` and part names can't be negated, so
+       today/selected re-assert their background on hover (with a subtle mix
+       toward the day-hover color for feedback) instead */
     ::part(button day today) {
       background: var(--color-primary);
       color: var(--color-primary-content);
-    }
-    /* `:not()` can't follow `::part()` and part names can't be negated,
-       so today/selected re-assert their background on hover instead */
-    ::part(button day today):hover {
-      background: var(--color-primary);
+      &:hover {
+        background: color-mix(in oklch, var(--color-primary) 90%, var(--color-base-200));
+      }
     }
     ::part(selected) {
       color: var(--color-base-100);
       background: var(--color-base-content);
       border-radius: var(--radius-field);
-    }
-    ::part(selected):hover {
-      background: var(--color-base-content);
+      &:hover {
+        background: color-mix(in oklch, var(--color-base-content) 90%, var(--color-base-200));
+      }
     }
     ::part(range-inner) {
       border-radius: 0;

--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -31,18 +31,24 @@
       font-size: 0.7rem;
     }
     ::part(day):hover {
-      &:not(selected, today) {
-        background: var(--color-base-200);
-      }
+      background: var(--color-base-200);
     }
     ::part(button day today) {
       background: var(--color-primary);
       color: var(--color-primary-content);
     }
+    /* `:not()` can't follow `::part()` and part names can't be negated,
+       so today/selected re-assert their background on hover instead */
+    ::part(button day today):hover {
+      background: var(--color-primary);
+    }
     ::part(selected) {
       color: var(--color-base-100);
       background: var(--color-base-content);
       border-radius: var(--radius-field);
+    }
+    ::part(selected):hover {
+      background: var(--color-base-content);
     }
     ::part(range-inner) {
       border-radius: 0;

--- a/packages/daisyui/src/components/calendar.css
+++ b/packages/daisyui/src/components/calendar.css
@@ -34,22 +34,24 @@
       background: var(--color-base-200);
     }
     /* `:not()` can't follow `::part()` and part names can't be negated, so
-       today/selected re-assert their background on hover (with a subtle mix
-       toward the day-hover color for feedback) instead */
+       today/selected re-assert their background on hover instead.
+       These can't be nested as `&:hover` either: `&` is equivalent to
+       `:is(...)`, which can't contain a pseudo-element, so the nested form
+       never matches. */
     ::part(button day today) {
       background: var(--color-primary);
       color: var(--color-primary-content);
-      &:hover {
-        background: color-mix(in oklch, var(--color-primary) 90%, var(--color-base-200));
-      }
+    }
+    ::part(button day today):hover {
+      background: var(--color-primary);
     }
     ::part(selected) {
       color: var(--color-base-100);
       background: var(--color-base-content);
       border-radius: var(--radius-field);
-      &:hover {
-        background: color-mix(in oklch, var(--color-base-content) 90%, var(--color-base-200));
-      }
+    }
+    ::part(selected):hover {
+      background: var(--color-base-content);
     }
     ::part(range-inner) {
       border-radius: 0;


### PR DESCRIPTION
## Problem

Closes #4630

`calendar.css` nests `&:not(selected, today)` under `::part(day):hover`, which flattens to:

```css
.cally ::part(day):hover:not(selected, today)
```

Per the CSS spec, only user-action pseudo-classes (`:hover`, …) and `:state()` may follow `::part()` — `:not()` is not allowed there, and `selected` / `today` are bare type selectors, not part names (part names can't be negated in CSS at all). This is a **two-layer bug**:

1. **Build failure (Lightning CSS pipelines)** — with an older browserslist (the reporter's `> 1%`), Lightning CSS *desugars* the nested source into the flat selector above, then fails to re-parse its own output with `Invalid state`. That's the Next.js 16 / Turbopack crash. Reproduced locally:
   - nested source + old targets → desugar output contains `.cally ::part(day):hover:not(selected,today)` → re-parse: **`Invalid state`**
   - webpack/PostCSS pipelines pass the selector through, which is why this only surfaces on Lightning CSS-based toolchains.
2. **Dead style in every browser** — browsers silently drop the invalid rule (`CSSStyleSheet.replaceSync` keeps 0 rules; `querySelector` throws SyntaxError), so **the day hover background has never applied anywhere**, regardless of bundler.

## Fix

Restore the plain day hover, and keep the #4085 behavior (`today` / `selected` must not change color on hover) with later same-specificity re-assertions instead of an impossible `:not()`:

```css
::part(day):hover {
  background: var(--color-base-200);
}
::part(button day today) {
  background: var(--color-primary);
  color: var(--color-primary-content);
}
::part(button day today):hover {
  background: var(--color-primary);
}
::part(selected) {
  color: var(--color-base-100);
  background: var(--color-base-content);
  border-radius: var(--radius-field);
}
::part(selected):hover {
  background: var(--color-base-content);
}
```

**Cascade reasoning**: `.cally ::part(day):hover` is (0,2,1) and would beat `.cally ::part(selected)` (0,1,1) — so just deleting the `:not()` (the reporter's minimal patch) would regress #4085. The `:hover` re-assertions are also (0,2,1) and come later in source, so they win; a selected+today day resolves to the selected style, matching the non-hover precedence.

**Why these are flat and not nested as `&:hover`**: `&` is equivalent to `:is(...)`, and `:is()` cannot contain a pseudo-element — so `&:hover` nested under a `::part(...)` rule parses but **never matches**. Measured in Chromium with real shadow-DOM parts: with the nested form, hovering `today` fell through to `::part(day):hover` and turned base-200; with the flat rules it keeps `primary`. (Same class of invalid-selector trap as the bug this PR fixes, so it's called out in a comment in the source.)

## Before / After (Tailwind Play)

**https://play.tailwindcss.com/FdppubfhJq**

Play can't run JS (no shadow-DOM parts), so the demo shows the exact failure mechanism with the **literal selectors**: each box's hover rule is a selector list that includes the real daisyUI selector. The "Before" list contains the invalid selector, so the browser drops the whole rule — hover does nothing (exactly why day-hover has been dead). The "After" list uses this PR's valid selector — hover works.

## Verification

- **Lightning CSS** (old targets, desugar → re-parse of the full compiled `daisyui.css`): before **`Invalid state`** → after **passes**.
- **Chromium, real shadow-DOM parts** (custom element exposing `part="button day"`, `"button day today"`, `"button day selected"`; hover via Playwright):

  | part | before hover | after hover |
  |---|---|---|
  | plain day | no change (rule dropped) | **base-200** (restored) |
  | today | unchanged | **unchanged** (primary) — #4085 kept |
  | selected | unchanged | **unchanged** (base-content) — #4085 kept |

- Test suite: passes (one pre-existing, unrelated docs-translation timeout also fails without this change).