### PR TITLE
fix(select,input,textarea,rating): restore -xs/-sm size modifiers in the packed CSS

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -10,11 +10,6 @@
     --font-size-min: 0.875rem;
     --spin-my: -3;
 
-    .floating-label:has(&) {
-      --top-mul: 5;
-      --font-size: 0.875rem;
-    }
-
     cursor: text;
     width: clamp(3rem, 20rem, 100%);
     height: var(--size);

--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -4,6 +4,16 @@
 
     --size: calc(var(--size-field, 0.25rem) * var(--in-size-mul));
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
+    /* md defaults live on the base (deeper layer = weaker) so size modifiers
+       win regardless of source order in the packed CSS */
+    --in-size-mul: 10;
+    --font-size-min: 0.875rem;
+    --spin-my: -3;
+
+    .floating-label:has(&) {
+      --top-mul: 5;
+      --font-size: 0.875rem;
+    }
 
     cursor: text;
     width: clamp(3rem, 20rem, 100%);
@@ -242,7 +252,6 @@
   }
 }
 
-.input,
 .input-md {
   @layer daisyui.l1.l2 {
     --in-size-mul: 10;

--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -2,18 +2,13 @@
   @layer daisyui.l1.l2.l3 {
     @apply bg-base-100 relative inline-flex shrink appearance-none items-center gap-2 px-3 align-middle whitespace-nowrap;
 
-    --size: calc(var(--size-field, 0.25rem) * var(--in-size-mul));
+    --size: calc(var(--size-field, 0.25rem) * var(--in-size-mul, 10));
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
-    /* md defaults live on the base (deeper layer = weaker) so size modifiers
-       win regardless of source order in the packed CSS */
-    --in-size-mul: 10;
-    --font-size-min: 0.875rem;
-    --spin-my: -3;
 
     cursor: text;
     width: clamp(3rem, 20rem, 100%);
     height: var(--size);
-    font-size: max(var(--font-size, 0rem), var(--font-size-min));
+    font-size: max(var(--font-size, 0rem), var(--font-size-min, 0.875rem));
     touch-action: manipulation;
     border-start-start-radius: var(--join-ss, var(--radius-field));
     border-start-end-radius: var(--join-se, var(--radius-field));
@@ -69,7 +64,7 @@
       }
 
       &::-webkit-inner-spin-button {
-        margin-block: calc(var(--spacing) * var(--spin-my));
+        margin-block: calc(var(--spacing) * var(--spin-my, -3));
       }
 
       &::-webkit-calendar-picker-indicator {

--- a/packages/daisyui/src/components/rating.css
+++ b/packages/daisyui/src/components/rating.css
@@ -63,7 +63,6 @@
   }
 }
 
-.rating,
 .rating-md {
   @layer daisyui.l1.l2 {
     --size: var(--size-selector, 0.25rem) * 6;

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -4,6 +4,16 @@
 
     --size: calc(var(--size-field, 0.25rem) * var(--sl-size-mul));
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
+    /* md defaults live on the base (deeper layer = weaker) so size modifiers
+       win regardless of source order in the packed CSS */
+    --sl-size-mul: 10;
+    --font-size-min: 0.875rem;
+    --option-px: 3;
+
+    .floating-label:has(&) {
+      --top-mul: 5;
+      --font-size: 0.875rem;
+    }
 
     width: clamp(3rem, 20rem, 100%);
     height: var(--size);
@@ -298,7 +308,6 @@
   }
 }
 
-.select,
 .select-md {
   @layer daisyui.l1.l2 {
     --sl-size-mul: 10;

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -10,11 +10,6 @@
     --font-size-min: 0.875rem;
     --option-px: 3;
 
-    .floating-label:has(&) {
-      --top-mul: 5;
-      --font-size: 0.875rem;
-    }
-
     width: clamp(3rem, 20rem, 100%);
     height: var(--size);
     font-size: max(var(--font-size, 0rem), var(--font-size-min));

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -2,17 +2,12 @@
   @layer daisyui.l1.l2.l3 {
     @apply bg-base-100 relative inline-flex shrink appearance-none items-center gap-1.5 ps-3 pe-7 align-middle;
 
-    --size: calc(var(--size-field, 0.25rem) * var(--sl-size-mul));
+    --size: calc(var(--size-field, 0.25rem) * var(--sl-size-mul, 10));
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
-    /* md defaults live on the base (deeper layer = weaker) so size modifiers
-       win regardless of source order in the packed CSS */
-    --sl-size-mul: 10;
-    --font-size-min: 0.875rem;
-    --option-px: 3;
 
     width: clamp(3rem, 20rem, 100%);
     height: var(--size);
-    font-size: max(var(--font-size, 0rem), var(--font-size-min));
+    font-size: max(var(--font-size, 0rem), var(--font-size-min, 0.875rem));
     touch-action: manipulation;
     border-start-start-radius: var(--join-ss, var(--radius-field));
     border-start-end-radius: var(--join-se, var(--radius-field));
@@ -143,7 +138,7 @@
       }
       option {
         @apply rounded-field py-1.5;
-        padding-inline: calc(var(--spacing) * var(--option-px));
+        padding-inline: calc(var(--spacing) * var(--option-px, 3));
         transition-property: color, background-color;
         transition-duration: 0.2s;
         transition-timing-function: cubic-bezier(0, 0, 0.2, 1);

--- a/packages/daisyui/src/components/textarea.css
+++ b/packages/daisyui/src/components/textarea.css
@@ -3,6 +3,14 @@
     @apply bg-base-100 rounded-field min-h-20 shrink appearance-none px-3 py-2 align-middle;
 
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
+    /* md defaults live on the base (deeper layer = weaker) so size modifiers
+       win regardless of source order in the packed CSS */
+    --font-size-min: 0.875rem;
+
+    .floating-label:has(&) {
+      --top-mul: 5;
+      --font-size: 0.875rem;
+    }
 
     width: clamp(3rem, 20rem, 100%);
     font-size: max(var(--font-size, 0rem), var(--font-size-min));
@@ -181,7 +189,6 @@
   }
 }
 
-.textarea,
 .textarea-md {
   @layer daisyui.l1.l2 {
     --font-size-min: 0.875rem;

--- a/packages/daisyui/src/components/textarea.css
+++ b/packages/daisyui/src/components/textarea.css
@@ -7,11 +7,6 @@
        win regardless of source order in the packed CSS */
     --font-size-min: 0.875rem;
 
-    .floating-label:has(&) {
-      --top-mul: 5;
-      --font-size: 0.875rem;
-    }
-
     width: clamp(3rem, 20rem, 100%);
     font-size: max(var(--font-size, 0rem), var(--font-size-min));
     touch-action: manipulation;

--- a/packages/daisyui/src/components/textarea.css
+++ b/packages/daisyui/src/components/textarea.css
@@ -3,12 +3,9 @@
     @apply bg-base-100 rounded-field min-h-20 shrink appearance-none px-3 py-2 align-middle;
 
     --input-color: color-mix(in oklab, var(--color-base-content) 20%, #0000);
-    /* md defaults live on the base (deeper layer = weaker) so size modifiers
-       win regardless of source order in the packed CSS */
-    --font-size-min: 0.875rem;
 
     width: clamp(3rem, 20rem, 100%);
-    font-size: max(var(--font-size, 0rem), var(--font-size-min));
+    font-size: max(var(--font-size, 0rem), var(--font-size-min, 0.875rem));
     touch-action: manipulation;
     border: var(--border) solid var(--input-color, #0000);
     box-shadow:


### PR DESCRIPTION
## Problem

Closes #4631 — Ref discussions/4620

Since v5.6, `select-xs` / `select-sm` (and the same sizes on `input`, `textarea`, `rating`) render identical to `-md` **when daisyUI is consumed as the packed CSS file** (the CDN / `daisyui.css`).

v5.6 moved sizing to multipliers (`--size: calc(var(--size-field) * var(--sl-size-mul))`) and put the md defaults into grouped selectors like:

```css
.select-xs { --sl-size-mul: 6; … }
.select-sm { --sl-size-mul: 8; … }
.select, .select-md { --sl-size-mul: 10; … }   /* ← after -xs/-sm in the source */
```

In the packed file these all land in the same layer (`daisyui.l1.l2`) with the same `(0,1,0)` specificity, so for `<select class="select select-xs">` the later defaults rule wins by **source order** and `-xs`/`-sm` collapse to md. `-lg`/`-xl` sit after the defaults, which is why only the two smaller sizes broke — exactly what @pdanpdan diagnosed in #4620: *"the order how they are generated — now the select and select-md are generated after select-xs and select-sm"*.

### Why it "worked" on daisyui.com but not on the CDN

Both observations in #4620 were correct: the **Tailwind plugin path is unaffected** because Tailwind splits the grouped selector and emits the base `.select` (with the defaults) early and each size modifier later — so the docs site looks fine. The **packed file keeps source order**, so CDN users hit the bug (reporter's live repro: https://cristhiancustodio.github.io/daisy-example/).

## Fix

Restore the pre-5.6 arrangement: the md defaults live on the **base component block** (`@layer daisyui.l1.l2.l3` — deeper layer = weaker in daisyUI's layer design), so any size modifier (`daisyui.l1.l2`) wins **regardless of source order**, and `.component, .component-md` is ungrouped into a standalone `.component-md`.

- `select.css`, `input.css`, `textarea.css`: defaults (incl. the `.floating-label:has(&)` vars) moved to the base block + ungrouped.
- `rating.css`: the base already had the default `--size`; it only needed ungrouping (the `.rating,` prefix was re-asserting md after `-xs`/`-sm`).

## Before / After (Tailwind Play)

**https://play.tailwindcss.com/CaPMTXIZR7**

Play compiles through the plugin path where the bug can't reproduce, so the demo replays the packed-CSS cascade literally on real daisyUI selects: "Before" orders the same-specificity rules like the packed file (`-xs` first, defaults after → renders md-size); "After" puts the defaults in a weaker layer like this PR (→ renders xs-size).

## Verification (packed CSS in Chromium)

| metric | before (xs / sm / md / lg / xl) | after |
|---|---|---|
| select height | 40 / 40 / 40 / 48 / 56 px | **24 / 32 / 40 / 48 / 56** |
| input height | 40 / 40 / 40 / 48 / 56 px | **24 / 32 / 40 / 48 / 56** |
| textarea font-size | 14 / 14 / 14 / 18 / 22 px | **11 / 12 / 14 / 18 / 22** |
| rating item size | 24 / 24 / 24 / 28 / 32 px | **16 / 20 / 24 / 28 / 32** |

The Tailwind plugin path still yields 5 distinct sizes for all four components (unchanged — no regression). Test suite: 177 pass / 0 fail.