### PR TITLE
fix(themes): emit each theme once so custom themes aren't overridden

### DIFF
--- a/packages/daisyui/functions/pluginOptionsHandler.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.js
@@ -19,9 +19,25 @@ export const pluginOptionsHandler = (() => {
       firstRun = false
     }
 
+    // Themes that already have a rule in this run. Must be per-invocation, not module scope,
+    // otherwise later builds (dev server rebuilds, multiple CSS entries) emit no themes at all.
+    //
+    // A theme must never be emitted twice. Two rules with identical declarations where one
+    // selector list is a subset of the other survive lightningcss' dead-compound elimination,
+    // and when `targets` includes a browser without `:has()` support (Vite derives `targets`
+    // from `build.target`; its default `baseline-widely-available` includes Firefox 104) the
+    // list is rewritten to `:is(...)`. `:is()` takes the highest specificity of its arguments,
+    // so `[data-theme=x]` jumps from (0,1,0) to (0,4,1) and the built-in theme starts winning
+    // over a user theme defined with `@plugin "daisyui/theme"`. See #4488.
+    //
+    // The `--default` variant is always applied first, so keeping the first emission keeps the
+    // `:where(:root)` prefix.
+    const appliedThemes = new Set()
+
     const applyTheme = (themeName, flags) => {
       const theme = themesObject[themeName]
-      if (theme) {
+      if (theme && !appliedThemes.has(themeName)) {
+        appliedThemes.add(themeName)
         // Use prefix for theme-controller class name
         const themeControllerClass = `${prefix}theme-controller`
         let selector = `${root}:has(input.${themeControllerClass}[value=${themeName}]:checked),[data-theme=${themeName}]`

--- a/packages/daisyui/functions/pluginOptionsHandler.test.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.test.js
@@ -29,12 +29,15 @@ test("pluginOptionsHandler should apply default themes", () => {
       color: "black",
     },
   })
-  expect(mockAddBase).toHaveBeenCalledWith({
+  // the default theme must not be emitted a second time without the `:where(:root)` prefix.
+  // duplicate rules get folded into `:is(...)` by lightningcss, which raises their specificity
+  // and makes the built-in theme win over a user theme. see #4488
+  expect(mockAddBase).not.toHaveBeenCalledWith({
     ":root:has(input.theme-controller[value=light]:checked),[data-theme=light]": {
       color: "white",
     },
   })
-  expect(mockAddBase).toHaveBeenCalledTimes(4)
+  expect(mockAddBase).toHaveBeenCalledTimes(3)
 })
 
 test("pluginOptionsHandler should apply all themes when 'all' is specified", () => {
@@ -57,7 +60,13 @@ test("pluginOptionsHandler should apply all themes when 'all' is specified", () 
       color: "black",
     },
   })
-  expect(mockAddBase).toHaveBeenCalledTimes(4)
+  // `light` is emitted by the `--default` branch, so `themeOrder` must not re-emit it. see #4488
+  expect(mockAddBase).not.toHaveBeenCalledWith({
+    ":root:has(input.theme-controller[value=light]:checked),[data-theme=light]": {
+      color: "white",
+    },
+  })
+  expect(mockAddBase).toHaveBeenCalledTimes(3)
 })
 
 test("pluginOptionsHandler should handle custom themes", () => {
@@ -130,4 +139,43 @@ test("pluginOptionsHandler should prefix theme-controller class when prefix is s
         color: "white",
       },
   })
+})
+
+test("pluginOptionsHandler should not emit a theme twice when it is listed twice", () => {
+  mockAddBase.mockReset()
+
+  const options = { themes: ["light --default", "light"] }
+
+  pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
+
+  expect(mockAddBase).toHaveBeenCalledTimes(1)
+  expect(mockAddBase).toHaveBeenCalledWith({
+    ":where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light]": {
+      color: "white",
+    },
+  })
+})
+
+test("pluginOptionsHandler should still emit the regular rule for a --prefersdark theme", () => {
+  mockAddBase.mockReset()
+
+  const options = { themes: ["light --default", "dark --prefersdark"] }
+
+  pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
+
+  const selectors = mockAddBase.mock.calls.map(([rule]) => Object.keys(rule)[0])
+  expect(selectors).toEqual([
+    ":where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light]",
+    "@media (prefers-color-scheme: dark)",
+    ":root:has(input.theme-controller[value=dark]:checked),[data-theme=dark]",
+  ])
+})
+
+test("pluginOptionsHandler should emit every selector only once", () => {
+  mockAddBase.mockReset()
+
+  pluginOptionsHandler({ themes: "all" }, mockAddBase, mockThemesObject, "1.0.0")
+
+  const selectors = mockAddBase.mock.calls.map(([rule]) => Object.keys(rule)[0])
+  expect(new Set(selectors).size).toBe(selectors.length)
 })


### PR DESCRIPTION
## Problem

Closes #4488

Customizing a built-in theme with `@plugin "daisyui/theme"` works on first paint, then loses to the built-in colors once `data-theme` is set — **but only in a Vite 8 production build**.

**1. daisyUI emits the same theme twice.** In `pluginOptionsHandler.js`, a theme listed with `--default` is emitted by the default loop as `:where(:root),:root:has(...),[data-theme=light]`, and then *again* by the "other themes" loop as the plain `:root:has(...),[data-theme=light]` — identical declarations, subset selector list. The `themes: "all"` branch has the same overlap because `themeOrder` contains `light`/`dark`.

**2. `targets` forces an `:is()` rewrite.** Vite derives lightningcss `targets` from `build.target`, and the default `baseline-widely-available` set includes **Firefox 104**, which has no `:has()` support. lightningcss therefore wraps such selector lists in the forgiving `:is(...)`:

```
no targets           :root:has(input.theme-controller[value=light]:checked),[data-theme=light]{…}
chrome107…firefox104 :is(:root:has(input.theme-controller[value=light]:checked),[data-theme=light]){…}
```

`:is()` takes the **highest** specificity of its arguments, so `[data-theme=light]` jumps from **(0,1,0) to (0,4,1)**.

**3. Only the duplicate survives.** lightningcss drops compounds that a later equal-specificity rule fully overrides. The *default* rule's `[data-theme=light]` is correctly dropped in favour of the user's rule — which is why no-attribute rendering is fine. The **duplicate** is nobody's subset, survives, gets `:is()`-promoted, and outranks the user's (0,1,0) rule:

```diff
  BEFORE                                                                     AFTER
  :root:has(…[value=light]:checked){--color-primary:blue}                    (same)
  @media (prefers-color-scheme:dark){…}                                      (same)
- :is(:root:has(…[value=light]:checked),[data-theme=light]){…:blue}   ← (0,4,1), wins
  :is(:root:has(…[value=dark]:checked),[data-theme=dark]){…:black}           (same)
  :where(:root),[data-theme=light]{--color-primary:red}   ← (0,1,0), user     (same, now wins)
```

Without `targets` (Vite ≤7, plain Tailwind CLI) the rewrite never happens — which is why this originally looked unreproducible. It also only bites when the user's theme is declared `default: true`, since that is what makes lightningcss split the user rule down to (0,1,0) for the `[data-theme]` branch.

## Fix

Track applied themes in a **per-invocation** `Set` inside `applyTheme`, so each theme is emitted once and the first (`--default`) emission — the one carrying `:where(:root)` — is the one kept. One hunk covers both the array path and the `themes: "all"` path.

The `--prefersdark` `@media` rules are emitted by raw `addBase`, not through `applyTheme`, so a `dark --prefersdark` theme still gets its regular `[data-theme=dark]` rule from the "other themes" loop. There's a test pinning that.

> The `Set` is deliberately inside the returned function rather than next to `firstRun` in the IIFE closure — module-level state would make every build after the first emit no theme rules at all.

## Before / After (Tailwind Play)

**https://play.tailwindcss.com/tUMYJ3OnTw**

Play doesn't run lightningcss with `targets`, so the demo writes the **post-lightningcss output verbatim** to show the mechanism: the `:is(…)`-wrapped duplicate beats the custom rule (Before, blue) and removing it lets the custom rule win (After, red).

## Verification

Compiled the reproduction through Tailwind, then through lightningcss with Vite's default targets (`chrome107, edge107, firefox104, safari16`, `minify: true`), and read the computed value in Chromium:

| | `data-theme` unset | `data-theme="light"` | `data-theme="dark"` |
|---|---|---|---|
| **before** | `red` | **built-in color** ❌ | built-in dark |
| **after** | `red` | **`red`** ✅ | built-in dark (unchanged) |

`:is(:root:has(…[value=light]…)` occurrences in the built output: **1 → 0**. Uncompressed CSS shrinks ~1.3 KB (one duplicated theme block).

Tests: `pluginOptionsHandler.test.js` goes 7 → 10 passing. Two existing assertions encoded the duplicate emission as expected behavior and are now inverted with a comment; three regression tests are added, including one that pins the emitted selector **order** so an over-eager dedupe can't silently swallow the `--prefersdark` theme's regular rule. Full suite passes (one pre-existing, unrelated docs-translation timeout fails with and without this change).

`packages/bundle/*` holds a compiled copy of this function and is regenerated by `bun run bundle` at release, so the CDN build picks the fix up at the next version bump.