### PR TITLE
fix(join): use z-index instead of isolation so tooltips aren't trapped

### DIFF
--- a/packages/daisyui/src/utilities/join.css
+++ b/packages/daisyui/src/utilities/join.css
@@ -9,12 +9,12 @@
 
   @scope (&) {
     > :where(:focus, :has(:focus)) {
-      @apply z-1;
+      @apply z-2;
     }
 
     @media (hover: hover) {
       > :where(.btn:hover, :has(.btn:hover)) {
-        @apply isolate;
+        @apply z-1;
       }
     }
 


### PR DESCRIPTION
## Problem

Closes #4618

A tooltip on a join item is painted **under the next join item**.

`join.css` puts the hovered item in a stacking context with `isolation: isolate`. That creates a stacking context but leaves `z-index: auto`, so it only lifts the item to the **`z-index: 0`** layer — and any *later* sibling in that same layer wins on DOM order. In a join that happens constantly, because the later item is typically positioned too:

- `.tooltip` → `position: relative` (`tooltip.css:3`)
- `.input` / `.select` / `.dropdown` → `position: relative`
- `.btn-active` / `:checked` / `:focus-visible` → `isolation: isolate` (`button.css:109,116,129`)

Measured with `elementsFromPoint` against the built CSS:

| hovered item | next sibling | topmost |
|---|---|---|
| *(nothing)* | plain `.btn` | next ← this was #4320 |
| `isolation: isolate` | plain `.btn` | hovered ← the #4320 fix, works |
| `isolation: isolate` | **positioned** (tooltip/input/select/dropdown) | next ← **#4618** |
| `z-index: 1` | positioned | hovered ✅ |

**This also means `isolation` was never a complete fix for #4320**: today, hovering a `.btn.join-item` followed by an `.input`/`.select`/`.tooltip` still fails to highlight the shared border. This PR widens that fix rather than narrowing it.

## Fix

```diff
     > :where(:focus, :has(:focus)) {
-      @apply z-1;
+      @apply z-2;
     }
 
     @media (hover: hover) {
       > :where(.btn:hover, :has(.btn:hover)) {
-        @apply isolate;
+        @apply z-1;
       }
     }
```

Flex items honor `z-index` even while `position: static` (Flexbox spec §4) — which is exactly why the `:focus` rule three lines above already works without `.btn` having a `position`. `z-index: 1` puts the hovered item in the positive-z layer, above positioned siblings.

**Focus goes to `z-2`, and that part isn't cosmetic**: with both rules at `z-1`, an item hovered *after* another item was focused wins on DOM order and clips the focused item's 2px outline. Verified in both orderings.

**`isolation` isn't kept alongside `z-index`**: `z-index: 1` on a flex item creates a stacking context by itself, so it would be dead weight.

**`position: relative` isn't added either**: it isn't needed (paint order is identical without it), and because the rule is conditional it would create a containing block *only while hovered* — making absolutely-positioned descendants jump on hover.

## Before / After (Tailwind Play)

**https://play.tailwindcss.com/TUbFzhmShE**

Play loads the released daisyUI, so the "After" join carries a small shim reproducing this patch. Both rows pin the hovered state so the difference is visible without a pointer: Before the tooltip is completely hidden behind the next button, After it paints on top.

## Verification

Chromium, `document.elementsFromPoint()` at the overlap point, against the real built CSS (`--blink-settings=...HoverType=2` so `@media (hover: hover)` matches in headless):

| case | before | after |
|---|---|---|
| **#4618** — hovered tooltip item vs next item | next item ❌ | **tooltip** ✅ |
| **#4320** — plain buttons, shared border | hovered | hovered (unchanged) ✅ |
| earlier focus, later hover | focus wins | focus wins (unchanged) ✅ |
| earlier hover, later focus | focus wins | focus wins (unchanged) ✅ |
| **#4320 widened** — hovered `.btn` followed by `.input` | `.input` ❌ | **hovered `.btn`** ✅ |

Computed style on the hovered item flips from `isolation: isolate; z-index: auto` to `isolation: auto; z-index: 1`. Screenshots confirm it visually. Build + test suite pass (one pre-existing, unrelated docs-translation timeout fails with and without this change).

## Note — related, deliberately out of scope

`button.css:109/116/129` (`:checked`, `:focus-visible`, `.btn-active`) set `isolation: isolate` and cause the **same** trapping *outside* of `.join` — two adjacent `.btn-active`s, the first with a `.tooltip-right`, hides the tooltip under the second. It's a different component with no shared code path, those rules exist to keep the focus outline from being clipped, and `.btn` has no flex container guaranteeing `z-index` would work, so it needs its own `position` decision. Happy to file it separately.

The residual case after this PR: a join item that is `.btn-active`/`:checked` but neither hovered nor focused still traps its own `tooltip-open`, for that same reason.