### PR TITLE
fix(table): pin thead/tfoot as a group so multi-row headers stack

### DIFF
--- a/packages/daisyui/src/components/table.css
+++ b/packages/daisyui/src/components/table.css
@@ -24,12 +24,16 @@
       border-top: var(--border) solid color-mix(in oklch, var(--color-base-content) 5%, #0000);
     }
 
-    :where(.table-pin-rows thead tr) {
-      @apply bg-base-100 sticky top-0 z-1;
+    :where(.table-pin-rows thead) {
+      @apply sticky top-0 z-1;
     }
 
-    :where(.table-pin-rows tfoot tr) {
-      @apply bg-base-100 sticky bottom-0 z-1;
+    :where(.table-pin-rows tfoot) {
+      @apply sticky bottom-0 z-1;
+    }
+
+    :where(.table-pin-rows :is(thead, tfoot) tr) {
+      @apply bg-base-100;
     }
 
     :where(.table-pin-cols tr th) {


### PR DESCRIPTION
## Problem

Closes #4350

`table-pin-rows` makes every `thead tr` sticky at `top: 0`. With more than one header row they all pin to the same offset and overlap — only the last row stays visible. Same for a multi-row `tfoot` at `bottom: 0`.

The whole issue in four numbers (200px scroller, two-row head, `scrollTop: 200`):

```
before   h1 = 0..44    h2 = 0..44     ← same position, overlapping
after    h1 = 0..44    h2 = 44..88    ← stacked
```

## Fix

Make the row group sticky instead of each row, and keep the background on the rows:

```diff
-    :where(.table-pin-rows thead tr) {
-      @apply bg-base-100 sticky top-0 z-1;
+    :where(.table-pin-rows thead) {
+      @apply sticky top-0 z-1;
     }
 
-    :where(.table-pin-rows tfoot tr) {
-      @apply bg-base-100 sticky bottom-0 z-1;
+    :where(.table-pin-rows tfoot) {
+      @apply sticky bottom-0 z-1;
+    }
+
+    :where(.table-pin-rows :is(thead, tfoot) tr) {
+      @apply bg-base-100;
     }
```

Sticky row groups work in Chrome 91+, Firefox 59+ and Safari 14+, so this needs no new CSS feature. The reporter's own Play already contained this solution. Multi-row `tfoot` is fixed too: `156..200 / 157..200` → `113..157 / 157..200`.

*(Keeping the old per-row rule and adding a group rule was tried and rejected — it reintroduces the overlap while the group is unpinning.)*

## Before / After (Tailwind Play)

**https://play.tailwindcss.com/wyMNAFLaJv**

Two identical tables with a two-row `<thead>` and a two-row `<tfoot>`; scroll either one. In *Before* the "GROUP HEADER" row and the "Subtotal" row disappear entirely; in *After* every row stays visible. Play loads the released daisyUI, so the "After" table carries a small shim reproducing the patch.

## Compatibility — @pdanpdan's question from the issue thread

> *"Would it break existing apps? Maybe add `table-pin-head` / `table-pin-foot` instead?"*

**For a single-row head or foot the rendering is pixel-identical, before and after.** A single-row group's box *is* its row's box, so there is nothing for the change to move. Verified by hashing container screenshots across scroll offsets, for:

| fixture | result |
|---|---|
| single-row `thead` | **identical** ✅ |
| `table-zebra` + `table-pin-rows` | **identical** ✅ |
| the docs' interleaved multiple-`<thead>` section headers ([`+page.md:1136`](https://github.com/saadeghi/daisyui/blob/master/packages/docs/src/routes/(routes)/components/table/%2Bpage.md)) | **identical** ✅ |
| `table-pin-rows` + `table-pin-cols` ([`+page.md:1466`](https://github.com/saadeghi/daisyui/blob/master/packages/docs/src/routes/(routes)/components/table/%2Bpage.md)) | **identical** ✅ |

The multiple-`<thead>` demo can't regress by construction: for both a row and a row group the sticky containing block is the *table*, so each section header pins at `top: 0` and the later one paints over the earlier one — the "push-out" is that opaque swap, unchanged. And each of those `<thead>`s holds a single `<tr>`, so group and row are the same box.

For `table-pin-cols`, the corner `th` keeps its exact coordinates, stays pinned in both axes, and the pinned column still overlays scrolled body cells — the sticky stacking context just moves up one level from `tr` to `thead`, and the pinned `th` remains a positioned descendant inside it.

**The one observable difference**: CSS that targets `.table-pin-rows thead tr` to shift the pin offset (e.g. `top: 4rem` under a sticky page header, `[&_thead_tr]:top-16`) stops applying, because the `tr` is no longer the sticky element. Migration is one selector — target `thead` instead. If you'd rather have zero escape-hatch breakage, I've also measured a variant that keeps `position: sticky` (with no `top`/`bottom`) on the `tr`: same geometry everywhere, preserves that override, costs ~100 bytes. Happy to switch.

Tables that render *incorrectly* today (multi-row heads/feet) change by definition — that is the fix.

## Note — unrelated, out of scope

`table.css:52-54` nests `:where(.table-pin-cols tr th)` inside the `&:where(:nth-child(even))` block, so it compiles to `.table-zebra tbody tr:nth-child(2n) :where(.table-pin-cols tr th)` — a descendant selector that can only match a table nested inside a cell. That rule appears to be dead. Happy to file it separately.