### PR TITLE
docs: add "Use daisyUI with Stimulus" guide

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/install/stimulus/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/stimulus/+page.md
@@ -1,6 +1,6 @@
 ---
 title: Use daisyUI with Stimulus
-desc: How to use daisyUI components with Stimulus controllers
+desc: How to install and use daisyUI with Stimulus
 ---
 
 <script>
@@ -9,235 +9,67 @@ desc: How to use daisyUI components with Stimulus controllers
 
 > :INFO:
 >
-> daisyUI components are pure CSS and work without any JavaScript.
-> This page is about the extra behavior you might want once Stimulus is already part of your stack, like persisting a theme or closing a dropdown after a click.
+> Stimulus does not handle CSS, so daisyUI is installed the same way as in any other project.  
+> If you use Rails, follow the [Rails install guide](/docs/install/rails/) instead, because Stimulus already comes with Rails.
 
-### 1. Add daisyUI
+### 1. Install
 
-daisyUI needs no Stimulus-specific setup. Follow the guide for whatever builds your CSS.
+Initialize a new Node project in the current directory using `npm init -y` if it's not a Node project already.
 
-<div class="tabs tabs-lift max-sm:tabs-sm">
-  <input type="radio" name="install_options" class="tab" aria-label="Rails" checked="checked" />
-  <div class="tab-content bg-base-100 border-base-300 px-6 py-3">
-
-Stimulus ships with Rails 7 and later. Follow the [Rails install guide](/docs/install/rails/) to add Tailwind CSS and daisyUI, then put your controllers in `app/javascript/controllers/`.
-
-  </div>
-
-  <input type="radio" name="install_options" class="tab" aria-label="Vite or another bundler" />
-  <div class="tab-content bg-base-100 border-base-300 px-6 py-3">
-
-Follow the [Vite install guide](/docs/install/vite/) for Tailwind CSS and daisyUI, then add Stimulus.
+Install Tailwind CSS CLI and daisyUI
 
 ```sh:Terminal
-npm install @hotwired/stimulus
+npm install tailwindcss@latest @tailwindcss/cli@latest daisyui@latest
 ```
 
-Register your controllers explicitly.
+### 2. Add Tailwind CSS and daisyUI
 
-```js:src/application.js
-import { Application } from "@hotwired/stimulus"
-import ModalController from "./controllers/modal_controller"
-
-window.Stimulus = Application.start()
-Stimulus.register("modal", ModalController)
-```
-
-  </div>
-
-  <input type="radio" name="install_options" class="tab" aria-label="No build step" />
-  <div class="tab-content bg-base-100 border-base-300 px-6 py-3">
-
-Build your CSS with the [Tailwind CSS CLI](/docs/install/cli/), then load Stimulus from a CDN as a module.
-
-```html:index.html
-<script type="module">
-  import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"
-  window.Stimulus = Application.start()
-
-  Stimulus.register("modal", class extends Controller {
-    static targets = ["dialog"]
-    open() { this.dialogTarget.showModal() }
-    close() { this.dialogTarget.close() }
-  })
-</script>
-```
-
-  </div>
-</div>
-
-### 2. Persist the theme
-
-[Theme Controller](/components/theme-controller/) changes the theme with CSS only. To keep the choice across page loads, save it and restore it yourself.
-
-Restore the theme in a script in your `<head>`, before anything renders. A Stimulus controller connects after the first paint, so restoring it in `connect()` shows a flash of the old theme.
-
-```html
-<script>
-  ;(() => {
-    const theme = localStorage.getItem("theme")
-    if (theme) document.documentElement.setAttribute("data-theme", theme)
-  })()
-</script>
-```
-
-The controller keeps localStorage and the input in sync.
-
-```js:app/javascript/controllers/theme_controller.js
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  static targets = ["input"]
-  static values = { storageKey: { type: String, default: "theme" } }
-
-  connect() {
-    const saved = localStorage.getItem(this.storageKeyValue)
-    if (!saved) return
-
-    this.inputTargets.forEach((input) => {
-      input.checked = input.value === saved
-    })
-  }
-
-  save(event) {
-    const input = event.target
-
-    if (input.checked) {
-      localStorage.setItem(this.storageKeyValue, input.value)
-      document.documentElement.setAttribute("data-theme", input.value)
-    } else {
-      localStorage.removeItem(this.storageKeyValue)
-      document.documentElement.removeAttribute("data-theme")
-    }
-  }
-}
-```
-
-```html:index.html
-<div data-controller="theme" data-action="change->theme#save">
-  <input type="checkbox" value="synthwave" class="toggle theme-controller" data-theme-target="input" />
-</div>
-```
-
-The theme you name has to be enabled, otherwise nothing happens. daisyUI enables `light` and `dark` by default.
+Add Tailwind CSS and daisyUI to your CSS file.
 
 ```postcss:app.css
-@plugin "daisyui" {
-  themes: light --default, dark --prefersdark, synthwave;
+@import "tailwindcss";
+@plugin "daisyui";
+```
+
+### 3. Build CSS
+
+Add a script to your package.json to build the CSS.
+
+```json:package.json
+{
+  "scripts": {
+    "build:css": "npx @tailwindcss/cli -i app.css -o public/output.css"
+  },
 }
 ```
 
-### 3. Open and close a modal
+Run the script to build the CSS file
 
-The [modal](/components/modal/) is a native `<dialog>` element. A target avoids relying on a global element ID.
-
-```js:app/javascript/controllers/modal_controller.js
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  static targets = ["dialog"]
-
-  open() {
-    this.dialogTarget.showModal()
-  }
-
-  close() {
-    this.dialogTarget.close()
-  }
-}
+```sh:Terminal
+npm run build:css
 ```
 
-```html:index.html
-<div data-controller="modal">
-  <button class="btn" data-action="modal#open">open modal</button>
-  <dialog class="modal" data-modal-target="dialog">
-    <div class="modal-box">
-      <h3 class="text-lg font-bold">Hello!</h3>
-      <div class="modal-action">
-        <button class="btn" data-action="modal#close">Close</button>
-      </div>
-    </div>
-    <form method="dialog" class="modal-backdrop">
-      <button>close</button>
-    </form>
-  </dialog>
-</div>
+This command creates a `public/output.css` file with the compiled CSS. You can link this file to your HTML file.
+
+```html:public/index.html
+<link href="./output.css" rel="stylesheet">
 ```
 
-Esc and the backdrop still close it without any extra code.
+### 4. Add Stimulus
 
-### 4. Close a dropdown
+Load Stimulus from a CDN and start the application.
 
-A [dropdown](/components/dropdown/) built from `details` and `summary` stays open after you click an item. Remove the `open` attribute to close it.
-
-```js:app/javascript/controllers/dropdown_controller.js
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  close() {
-    this.element.removeAttribute("open")
-  }
-
-  closeOnOutsideClick(event) {
-    if (this.element.contains(event.target)) return
-
-    this.close()
-  }
-}
+```html:public/index.html
+<script type="module">
+  import { Application } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"
+  window.Stimulus = Application.start()
+</script>
 ```
 
-```html:index.html
-<details class="dropdown" data-controller="dropdown" data-action="click@window->dropdown#closeOnOutsideClick">
-  <summary class="btn m-1">open menu</summary>
-  <ul class="menu dropdown-content bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" data-action="click->dropdown#close">
-    <li><a>Item 1</a></li>
-    <li><a>Item 2</a></li>
-  </ul>
-</details>
+If you use a bundler, install `@hotwired/stimulus` with npm and import it from the package name instead.
+
+Now you can use daisyUI class names!
+
+```html:public/index.html
+<button class="btn btn-primary">Hello daisyUI!</button>
 ```
-
-The [popover method](/components/dropdown/#method-2-popover-api-and-anchor-positioning-new) dismisses itself and needs no controller.
-
-### 5. Dismiss a toast
-
-```js:app/javascript/controllers/toast_controller.js
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  static values = { delay: { type: Number, default: 3000 } }
-
-  connect() {
-    this.timeout = setTimeout(() => this.element.remove(), this.delayValue)
-  }
-
-  disconnect() {
-    clearTimeout(this.timeout)
-  }
-}
-```
-
-```html:index.html
-<div class="toast toast-end" data-controller="toast" data-toast-delay-value="3000">
-  <div class="alert alert-success">
-    <span>Message sent successfully.</span>
-  </div>
-</div>
-```
-
-`disconnect()` clears the timer when Turbo removes the element, so nothing is left scheduled against a detached node.
-
-### 6. Notes for Turbo
-
-If you use Turbo Drive or Turbo morphing (`turbo_refreshes_with method: :morph`), a couple of things behave differently than a plain page load.
-
-> :WARNING:
->
-> A morph refresh can make the whole page stop responding to clicks if a modal is open. Your server's HTML has no `open` attribute on the `<dialog>`, so a morph strips it: `dialog.open` becomes `false`. But the element stays in the browser's top layer, still holding a full-viewport `.modal-backdrop` that is now just `visibility: hidden` and `pointer-events: none`. Every click on the page then hits that invisible backdrop instead of your content, and nothing is logged to the console, so it looks like the page has simply frozen. Add `data-turbo-permanent` and an `id` to the dialog to exclude it from morphing. With that in place the dialog stays open through the morph and still closes and reopens normally afterward.
-
-```html:index.html
-<dialog id="my-modal" class="modal" data-modal-target="dialog" data-turbo-permanent>
-```
-
-**Turbo Drive Back can restore a modal that no longer behaves like one.** Go back to a page that had an open modal, and `dialog.open` comes back `true` with the page still scroll-locked, but the dialog is not re-entered into the browser's top layer. Escape no longer closes it, although the Close button still works. No fix for this has been tested yet.
-
-**An open dropdown just closes during a morph.** No mitigation needed.

--- a/packages/docs/src/routes/(routes)/docs/install/stimulus/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/install/stimulus/+page.md
@@ -1,0 +1,243 @@
+---
+title: Use daisyUI with Stimulus
+desc: How to use daisyUI components with Stimulus controllers
+---
+
+<script>
+  import Translate from "$components/Translate.svelte"
+</script>
+
+> :INFO:
+>
+> daisyUI components are pure CSS and work without any JavaScript.
+> This page is about the extra behavior you might want once Stimulus is already part of your stack, like persisting a theme or closing a dropdown after a click.
+
+### 1. Add daisyUI
+
+daisyUI needs no Stimulus-specific setup. Follow the guide for whatever builds your CSS.
+
+<div class="tabs tabs-lift max-sm:tabs-sm">
+  <input type="radio" name="install_options" class="tab" aria-label="Rails" checked="checked" />
+  <div class="tab-content bg-base-100 border-base-300 px-6 py-3">
+
+Stimulus ships with Rails 7 and later. Follow the [Rails install guide](/docs/install/rails/) to add Tailwind CSS and daisyUI, then put your controllers in `app/javascript/controllers/`.
+
+  </div>
+
+  <input type="radio" name="install_options" class="tab" aria-label="Vite or another bundler" />
+  <div class="tab-content bg-base-100 border-base-300 px-6 py-3">
+
+Follow the [Vite install guide](/docs/install/vite/) for Tailwind CSS and daisyUI, then add Stimulus.
+
+```sh:Terminal
+npm install @hotwired/stimulus
+```
+
+Register your controllers explicitly.
+
+```js:src/application.js
+import { Application } from "@hotwired/stimulus"
+import ModalController from "./controllers/modal_controller"
+
+window.Stimulus = Application.start()
+Stimulus.register("modal", ModalController)
+```
+
+  </div>
+
+  <input type="radio" name="install_options" class="tab" aria-label="No build step" />
+  <div class="tab-content bg-base-100 border-base-300 px-6 py-3">
+
+Build your CSS with the [Tailwind CSS CLI](/docs/install/cli/), then load Stimulus from a CDN as a module.
+
+```html:index.html
+<script type="module">
+  import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"
+  window.Stimulus = Application.start()
+
+  Stimulus.register("modal", class extends Controller {
+    static targets = ["dialog"]
+    open() { this.dialogTarget.showModal() }
+    close() { this.dialogTarget.close() }
+  })
+</script>
+```
+
+  </div>
+</div>
+
+### 2. Persist the theme
+
+[Theme Controller](/components/theme-controller/) changes the theme with CSS only. To keep the choice across page loads, save it and restore it yourself.
+
+Restore the theme in a script in your `<head>`, before anything renders. A Stimulus controller connects after the first paint, so restoring it in `connect()` shows a flash of the old theme.
+
+```html
+<script>
+  ;(() => {
+    const theme = localStorage.getItem("theme")
+    if (theme) document.documentElement.setAttribute("data-theme", theme)
+  })()
+</script>
+```
+
+The controller keeps localStorage and the input in sync.
+
+```js:app/javascript/controllers/theme_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input"]
+  static values = { storageKey: { type: String, default: "theme" } }
+
+  connect() {
+    const saved = localStorage.getItem(this.storageKeyValue)
+    if (!saved) return
+
+    this.inputTargets.forEach((input) => {
+      input.checked = input.value === saved
+    })
+  }
+
+  save(event) {
+    const input = event.target
+
+    if (input.checked) {
+      localStorage.setItem(this.storageKeyValue, input.value)
+      document.documentElement.setAttribute("data-theme", input.value)
+    } else {
+      localStorage.removeItem(this.storageKeyValue)
+      document.documentElement.removeAttribute("data-theme")
+    }
+  }
+}
+```
+
+```html:index.html
+<div data-controller="theme" data-action="change->theme#save">
+  <input type="checkbox" value="synthwave" class="toggle theme-controller" data-theme-target="input" />
+</div>
+```
+
+The theme you name has to be enabled, otherwise nothing happens. daisyUI enables `light` and `dark` by default.
+
+```postcss:app.css
+@plugin "daisyui" {
+  themes: light --default, dark --prefersdark, synthwave;
+}
+```
+
+### 3. Open and close a modal
+
+The [modal](/components/modal/) is a native `<dialog>` element. A target avoids relying on a global element ID.
+
+```js:app/javascript/controllers/modal_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dialog"]
+
+  open() {
+    this.dialogTarget.showModal()
+  }
+
+  close() {
+    this.dialogTarget.close()
+  }
+}
+```
+
+```html:index.html
+<div data-controller="modal">
+  <button class="btn" data-action="modal#open">open modal</button>
+  <dialog class="modal" data-modal-target="dialog">
+    <div class="modal-box">
+      <h3 class="text-lg font-bold">Hello!</h3>
+      <div class="modal-action">
+        <button class="btn" data-action="modal#close">Close</button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
+</div>
+```
+
+Esc and the backdrop still close it without any extra code.
+
+### 4. Close a dropdown
+
+A [dropdown](/components/dropdown/) built from `details` and `summary` stays open after you click an item. Remove the `open` attribute to close it.
+
+```js:app/javascript/controllers/dropdown_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  close() {
+    this.element.removeAttribute("open")
+  }
+
+  closeOnOutsideClick(event) {
+    if (this.element.contains(event.target)) return
+
+    this.close()
+  }
+}
+```
+
+```html:index.html
+<details class="dropdown" data-controller="dropdown" data-action="click@window->dropdown#closeOnOutsideClick">
+  <summary class="btn m-1">open menu</summary>
+  <ul class="menu dropdown-content bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" data-action="click->dropdown#close">
+    <li><a>Item 1</a></li>
+    <li><a>Item 2</a></li>
+  </ul>
+</details>
+```
+
+The [popover method](/components/dropdown/#method-2-popover-api-and-anchor-positioning-new) dismisses itself and needs no controller.
+
+### 5. Dismiss a toast
+
+```js:app/javascript/controllers/toast_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { delay: { type: Number, default: 3000 } }
+
+  connect() {
+    this.timeout = setTimeout(() => this.element.remove(), this.delayValue)
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+}
+```
+
+```html:index.html
+<div class="toast toast-end" data-controller="toast" data-toast-delay-value="3000">
+  <div class="alert alert-success">
+    <span>Message sent successfully.</span>
+  </div>
+</div>
+```
+
+`disconnect()` clears the timer when Turbo removes the element, so nothing is left scheduled against a detached node.
+
+### 6. Notes for Turbo
+
+If you use Turbo Drive or Turbo morphing (`turbo_refreshes_with method: :morph`), a couple of things behave differently than a plain page load.
+
+> :WARNING:
+>
+> A morph refresh can make the whole page stop responding to clicks if a modal is open. Your server's HTML has no `open` attribute on the `<dialog>`, so a morph strips it: `dialog.open` becomes `false`. But the element stays in the browser's top layer, still holding a full-viewport `.modal-backdrop` that is now just `visibility: hidden` and `pointer-events: none`. Every click on the page then hits that invisible backdrop instead of your content, and nothing is logged to the console, so it looks like the page has simply frozen. Add `data-turbo-permanent` and an `id` to the dialog to exclude it from morphing. With that in place the dialog stays open through the morph and still closes and reopens normally afterward.
+
+```html:index.html
+<dialog id="my-modal" class="modal" data-modal-target="dialog" data-turbo-permanent>
+```
+
+**Turbo Drive Back can restore a modal that no longer behaves like one.** Go back to a page that had an open modal, and `dialog.open` comes back `true` with the page still scroll-locked, but the dialog is not re-entered into the browser's top layer. Escape no longer closes it, although the Close button still works. No fix for this has been tested yet.
+
+**An open dropdown just closes during a morph.** No mitigation needed.


### PR DESCRIPTION
Closes #4648

Adds `/docs/install/stimulus/`, following the "Use daisyUI with HTMX" precedent rather than the install-guide format, since Stimulus does not touch CSS.

Setup is a short tabbed section that links to the existing Rails, Vite, and CLI guides instead of repeating them. The body covers what isn't documented anywhere today: persisting the theme controller, driving a `<dialog>` modal without an inline `onclick`, closing a `<details>` dropdown, and dismissing a toast.

The Turbo section turned up something worth knowing: after a morph refresh with a modal open, the morph strips `open` from the `<dialog>` (the server HTML doesn't have it), but the element stays in the browser's top layer holding a full-viewport backdrop. Every click on the page then hits an invisible backdrop, nothing is logged to the console, and it just looks frozen. Adding `data-turbo-permanent` and an `id` fixes it, and I tested that rather than assuming it.

Every sample was verified in a running browser before I wrote it up: the four controllers in a Tailwind CLI plus CDN-Stimulus page (22 Playwright assertions), and the Turbo behavior in a Rails 8 app with `turbo_refreshes_with method: :morph` (30 checks). Where something I expected to break didn't, I left it out rather than padding the page. One behavior is described with no fix, because I couldn't verify one.

You mentioned you'd add the logo, so I haven't touched `frameworks.yaml`. Here it is inline if it saves you a step, with the `width`, `height` and `class` attributes dropped to match the other entries in that file:

LOGO source: https://stimulus.hotwired.dev/

```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60"><g fill="#D9C6A4"><path d="M1.76 1.85885e-08H58.2399C58.7016 -6.70275e-05 59.1447 0.181237 59.474 0.50484C59.8032 0.828443 59.9921 1.26844 59.9999 1.73V7.37823C59.9999 7.87239 59.9999 8.11947 59.9038 8.30822C59.8192 8.47424 59.6842 8.60923 59.5182 8.69382C59.3294 8.78999 59.0823 8.78999 58.5882 8.78999H45.92C44.7722 8.83556 43.6502 9.14343 42.64 9.68999L15.64 25.55C14.6261 26.0964 13.5008 26.4042 12.35 26.45H1.41176C0.9176 26.45 0.670518 26.45 0.481773 26.3538C0.315747 26.2692 0.180765 26.1342 0.0961706 25.9682C0 25.7795 0 25.5324 0 25.0382V17.2717C0 16.7776 0 16.5305 0.0961706 16.3418C0.180765 16.1757 0.315747 16.0408 0.481773 15.9562C0.670518 15.86 0.9176 15.86 1.41176 15.86H12.35C13.5001 15.9106 14.6243 16.2181 15.64 16.76L18.64 18.51C19.1037 18.7494 19.6181 18.8743 20.14 18.8743C20.6619 18.8743 21.1762 18.7494 21.64 18.51L25.48 16.25C25.6438 16.1661 25.7812 16.0386 25.8772 15.8815C25.9732 15.7245 26.024 15.544 26.024 15.36C26.024 15.1759 25.9732 14.9955 25.8772 14.8384C25.7812 14.6814 25.6438 14.5539 25.48 14.47L17.4 9.71999C16.3879 9.17798 15.2669 8.8704 14.12 8.81999H1.41176C0.9176 8.81999 0.670518 8.81999 0.481773 8.72382C0.315747 8.63923 0.180765 8.50424 0.0961706 8.33822C0 8.14947 0 7.90239 0 7.40823V1.76C0 1.29322 0.185428 0.845555 0.515492 0.515492C0.845555 0.185428 1.29322 1.85885e-08 1.76 1.85885e-08Z"/><path d="M47.65 15.8799C46.4998 15.9305 45.3757 16.238 44.36 16.7799L17.36 32.6499C16.3479 33.1919 15.2269 33.4994 14.08 33.5499H1.41176C0.9176 33.5499 0.670518 33.5499 0.481773 33.646C0.315747 33.7306 0.180765 33.8656 0.0961706 34.0316C0 34.2204 0 34.4674 0 34.9616V42.7281C0 43.2222 0 43.4693 0.0961706 43.6581C0.180765 43.8241 0.315747 43.9591 0.481773 44.0437C0.670518 44.1398 0.9176 44.1398 1.41176 44.1398H12.35C13.5001 44.0892 14.6243 43.7817 15.64 43.2398L42.64 27.3699C43.652 26.8278 44.773 26.5203 45.92 26.4699H58.5882C59.0823 26.4699 59.3294 26.4699 59.5182 26.3737C59.6842 26.2891 59.8192 26.1541 59.9038 25.9881C59.9999 25.7993 59.9999 25.5523 59.9999 25.0581V17.2916C59.9999 16.7975 59.9999 16.5504 59.9038 16.3616C59.8192 16.1956 59.6842 16.0606 59.5182 15.976C59.3294 15.8799 59.0823 15.8799 58.5882 15.8799H47.65Z"/><path d="M47.65 33.56C46.4998 33.6106 45.3757 33.9182 44.36 34.46L17.36 50.32C16.3497 50.8666 15.2277 51.1744 14.08 51.22H1.41176C0.9176 51.22 0.670518 51.22 0.481773 51.3162C0.315747 51.4008 0.180765 51.5358 0.0961706 51.7018C0 51.8905 0 52.1376 0 52.6318V58.28C0.0129646 58.739 0.203789 59.175 0.532182 59.4959C0.860576 59.8168 1.30083 59.9976 1.76 60H58.2399C58.7042 59.9974 59.1488 59.8125 59.4781 59.4852C59.8073 59.1578 59.9947 58.7142 59.9999 58.25V52.6018C59.9999 52.1076 59.9999 51.8605 59.9038 51.6718C59.8192 51.5058 59.6842 51.3708 59.5182 51.2862C59.3294 51.19 59.0823 51.19 58.5882 51.19H45.88C44.7322 51.1444 43.6102 50.8366 42.6 50.29L34.52 45.55C34.3536 45.4671 34.2136 45.3394 34.1157 45.1813C34.0179 45.0232 33.966 44.8409 33.966 44.655C33.966 44.4691 34.0179 44.2868 34.1157 44.1287C34.2136 43.9706 34.3536 43.843 34.52 43.76L38.36 41.51C38.8237 41.2706 39.3381 41.1457 39.86 41.1457C40.3819 41.1457 40.8962 41.2706 41.36 41.51L44.36 43.25C45.3739 43.7964 46.4991 44.1042 47.65 44.15H58.5882C59.0823 44.15 59.3294 44.15 59.5182 44.0538C59.6842 43.9693 59.8192 43.8343 59.9038 43.6682C59.9999 43.4795 59.9999 43.2324 59.9999 42.7383V34.9718C59.9999 34.4776 59.9999 34.2305 59.9038 34.0418C59.8192 33.8758 59.6842 33.7408 59.5182 33.6562C59.3294 33.56 59.0823 33.56 58.5882 33.56H47.65Z"/></g></svg>
```

One thing to check on your side: the mark's own color is `#D9C6A4`, which reads well on the dark theme but is fairly light on white. If the grid needs better contrast in light mode, swapping the fill for `currentColor` would work, since all three paths share the one `<g fill>`.
