### PR TITLE
fix: force LTR for special case input types

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -50,10 +50,6 @@
     input {
       @apply relative inline-flex text-start;
 
-      &[type="number"] {
-        @apply text-end;
-      }
-
       &[type="url"],
       &[type="tel"],
       &[type="email"],

--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -48,13 +48,17 @@
 
     input&,
     input {
-      @apply relative inline-flex;
+      @apply relative inline-flex text-start;
+
+      &[type="number"] {
+        @apply text-end;
+      }
 
       &[type="url"],
-      &[type="email"] {
-        /* don't use direction. it breaks join */
-        /*direction: ltr;*/
-        text-align: left;
+      &[type="tel"],
+      &[type="email"],
+      &[type="number"] {
+        direction: ltr;
       }
 
       &::-webkit-datetime-edit,
@@ -117,6 +121,18 @@
 
     &:has(> input[disabled]) > input[disabled] {
       @apply cursor-not-allowed;
+    }
+  }
+
+  &[type="url"],
+  &[type="tel"],
+  &[type="email"],
+  &[type="number"] {
+    &:dir(rtl) {
+      border-start-start-radius: var(--join-se, var(--radius-field));
+      border-start-end-radius: var(--join-ss, var(--radius-field));
+      border-end-start-radius: var(--join-ee, var(--radius-field));
+      border-end-end-radius: var(--join-es, var(--radius-field));
     }
   }
 }


### PR DESCRIPTION
According to https://simplelocalize.io/blog/posts/rtl-design-guide-developers/#forms-in-rtl some types of input should be LTR always (email, tel, url, number).

Changes:
- defaults text align to start for all except number (where it is end)
- apply LTR direction for all special types
- fix join border radius for special types

example: https://play.tailwindcss.com/xYeuSceT4C

close #4644