### PR TITLE
fix: select open arrow should only be shown when open

### DIFF
--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -73,6 +73,9 @@
       outline: 2px solid var(--input-color);
       outline-offset: 2px;
       isolation: isolate;
+    }
+
+    &:open {
       background-image:
         linear-gradient(135deg, #0000 50%, currentColor 50%),
         linear-gradient(45deg, currentColor 50%, #0000 50%);


### PR DESCRIPTION
It was wrongly shown also on focus/focus-within