### PR TITLE
refactor(input,select): remove redundant isolation on focus

### DIFF
--- a/packages/daisyui/src/components/input.css
+++ b/packages/daisyui/src/components/input.css
@@ -85,7 +85,6 @@
       box-shadow: 0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000);
       outline: 2px solid var(--input-color);
       outline-offset: 2px;
-      isolation: isolate;
     }
 
     /* increase font size in iOS so the page won't zoom */

--- a/packages/daisyui/src/components/select.css
+++ b/packages/daisyui/src/components/select.css
@@ -72,7 +72,6 @@
       box-shadow: 0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000);
       outline: 2px solid var(--input-color);
       outline-offset: 2px;
-      isolation: isolate;
     }
 
     &:open {


### PR DESCRIPTION
First of the three PRs @pdanpdan asked for in [#4642](https://github.com/saadeghi/daisyui/pull/4642#issuecomment-5156748718) — the `input` / `select` pair. `textarea` / `file-input` / `otp` and `btn` follow separately.

Full investigation notes: [#4642 (comment)](https://github.com/saadeghi/daisyui/pull/4642#issuecomment-5156680741)

## Why these two are a no-op

`.input` and `.select` are **already `position: relative`** ([`input.css:3`](https://github.com/saadeghi/daisyui/blob/master/packages/daisyui/src/components/input.css), [`select.css:3`](https://github.com/saadeghi/daisyui/blob/master/packages/daisyui/src/components/select.css)). A positioned element is already painted in step 8 of CSS 2.1 Appendix E, which is the same step a positioned sibling lands in — so `isolation: isolate` cannot change sibling paint order for them. It never could.

The join seam is owned by the `z-index` that `.join` sets on `:focus` / `:hover`, not by `isolation`. The history says the same thing: #3722 (`78bf76dd`) added `z-index: 1` **on top of** the existing `isolation` precisely because isolation alone didn't fix the seam, and #4320 (`5a37a131`) then moved that `z-index` onto `.join`. `isolation` was never the mechanism here.

## Demo

**https://play.tailwindcss.com/X7SH1MDer1**

Toggle "Remove isolation" at the top — nothing changes. Covers a join of inputs, a join of selects, mixed `btn | input | btn` and `btn | select | btn` joins, and a focused `.input` overlapped outside a join by a positioned `.tooltip`.

## Verification

Ablated against the real built CSS in Chromium, comparing the focus-ring pixels on **both** seams and `elementsFromPoint` at each seam:

| fixture | screenshot | paint order |
|---|---|---|
| join of 3× `.input`, middle focused | identical | identical |
| join of 3× `.select`, middle focused | identical | identical |
| `btn \| input \| btn` | identical | identical |
| `btn \| select \| btn` | identical | identical |
| #4618 tooltip inside a join | identical | identical |
| focused `.input` + overlapping `.tooltip` (no join) | identical | identical |
| focused `.input` + overlapping `.input` (no join) | identical | identical |

`isolation` count in the built `daisyui.css` goes 73 → 61 (6 responsive copies × 2 declarations); `textarea`, `file-input`, `otp` and `btn` are untouched. #4320 and #4618 both still hold.

## One semantic change worth stating

An absolutely-positioned descendant inside a focused `label.input` is no longer trapped by the stacking context. That's an improvement for a tooltip or dropdown placed *inside* an input, but it is a real difference rather than a pure no-op, so I'm flagging it rather than burying it.