### PR TITLE
refactor(otp): remove redundant isolation on focus-within

### DIFF
--- a/packages/daisyui/src/components/otp.css
+++ b/packages/daisyui/src/components/otp.css
@@ -134,7 +134,6 @@
     }
 
     &:focus-within {
-      isolation: isolate;
       --input-color: var(--color-base-content);
       > span {
         box-shadow: 0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000);


### PR DESCRIPTION
> **Corrected.** The first version of this PR also removed `isolation` from `textarea`, `file-input` and `button`. That was wrong — I re-tested against a plain *static* overlapping sibling and those three declarations **do** change paint order. Only `.otp` is genuinely a no-op, so this PR is now one line. Details and evidence in the comment below.

Part of the 3-PR split @pdanpdan asked for in https://github.com/saadeghi/daisyui/pull/4642#issuecomment-5156748718.

- PR 1 (`input` + `select`): #4656 — still valid, both are already `position: relative`
- **this PR**: `otp` only
- there is no third PR: `.btn`'s two `isolation` declarations turned out to be load-bearing (see below)

## The change

```diff
     &:focus-within {
-      isolation: isolate;
       --input-color: var(--color-base-content);
```

`.otp` already establishes a stacking context via
[`clip-path: inset(-3.5px 3.5px -3.5px -3.5px)`](https://github.com/saadeghi/daisyui/blob/master/packages/daisyui/src/components/otp.css#L7)
on the base class, so the `isolation: isolate` added on `:focus-within` can never
have an effect — the element is already isolated in every state.

## Play demo

**https://play.tailwindcss.com/KWt5JfPqu2**

Play ships released daisyUI, which still has the declaration, so the checkbox at
the top neutralises exactly the line this PR removes:

```css
.apply-change:has(:checked) + div {
  .otp { &:focus-within { isolation: auto; } }
}
```

Click into each field and toggle — plain `.otp`, `.otp` under an open tooltip,
`.otp` overlapped by a static sibling, and `.otp-joined` are all unaffected.

## Verification

Built `master` and this branch and compared the two `daisyui.css` files headlessly
(Chromium, `hover: hover` forced, 3 samples per side, transitions and caret blink
disabled to remove flake). Screenshots **and** `document.elementsFromPoint()` at
both seams are identical for:

- `.otp` focused, standalone
- `.otp` focused, overlapped by an open `.tooltip`
- `.otp` focused, overlapped by a plain static `<div>` with a negative margin
- `.otp-joined`

The two builds differ by exactly `-108` bytes = 1 declaration × 6 responsive copies × 18 bytes,
and stripping `isolation: isolate` from both makes them byte-identical, so nothing else moved.
