### PR TITLE
fix(docs): reset scroll instantly on navigation so Firefox lands at the top

### DIFF
--- a/packages/docs/src/routes/(routes)/+layout.svelte
+++ b/packages/docs/src/routes/(routes)/+layout.svelte
@@ -4,7 +4,7 @@
   import Search from "$components/Search.svelte"
   import { page } from "$app/stores"
   import { defaultLang, langs, loadRouteTranslations, setLang } from "$lib/i18n.svelte.js"
-  import { onNavigate } from "$app/navigation"
+  import { afterNavigate, onNavigate } from "$app/navigation"
   import minimalAnalytics from "@minimal-analytics/ga4"
   const { track } = minimalAnalytics
 
@@ -33,6 +33,11 @@
   }
 
   onNavigate((navigation) => {
+    // SvelteKit resets the scroll with `scrollTo(0, 0)`, which follows the CSS
+    // `scroll-behavior`. Firefox drops an in-flight smooth scroll when the DOM is
+    // swapped, so the new page keeps the old offset. Reset instantly instead.
+    document.documentElement.style.scrollBehavior = "auto"
+
     track("G-10F40JCSMZ")
 
     const routeTranslations = navigation.to?.url
@@ -48,6 +53,12 @@
         await navigation.complete
       })
     })
+  })
+
+  afterNavigate(() => {
+    // The scroll reset already ran, so smooth scrolling is safe again for
+    // in-page anchors.
+    document.documentElement.style.scrollBehavior = "smooth"
   })
 
   $effect(() => {


### PR DESCRIPTION
closes #3568

Reported by @AiAe, and confirmed since by @rsyring and @codayon: on Firefox, scrolling down a docs page and then clicking a link to another page leaves you part-way down the new page instead of at the top.

## Root cause

Two things combine:

1. [`+layout.svelte:62`](https://github.com/saadeghi/daisyui/blob/master/packages/docs/src/routes/(routes)/%2Blayout.svelte#L62) sets `scroll-behavior: smooth` on `<html>` **permanently**, on mount. On the live site the root element really does carry `style="scroll-padding-top: 5rem; scroll-behavior: smooth;"`.
2. SvelteKit resets the scroll with a bare `scrollTo(0, 0)` — no `behavior` argument, so it follows that CSS value. From `@sveltejs/kit/src/runtime/client/client.js`:

```js
// Here we use `scrollIntoView` on the element instead of `scrollTo`
// because it natively supports the `scroll-margin` and `scroll-behavior`
// CSS properties.
...
} else {
    scrollTo(0, 0);
}
```

So **every** navigation animates back to the top. Firefox drops an in-flight smooth scroll when the DOM is swapped and the document height changes, and the position ends up clamped to the new page's maximum scroll.

That matches @sulimanbenhalim's observation that it depends on the source scroll position and the destination page height — and it explains why the `window.scrollTo(0, 0)` he tried didn't help: that call gets smooth-scrolled too.

## The fix

Drop to `scroll-behavior: auto` for the duration of the navigation, and restore `smooth` afterwards.

Ordering is what makes this safe, and it is fixed by SvelteKit's client:

| `client.js` | what happens |
| --- | --- |
| ~1909 | `onNavigate` callbacks are awaited — **before** the DOM swap |
| ~2013 | `scrollTo(0, 0)` — the reset |
| ~2042 | `after_navigate_callbacks` fire |

So `auto` is in place before the reset, and `smooth` comes back only after it.

**In-page anchors keep smooth scrolling.** A hash-only navigation on the same pathname returns early in `client.js` and never reaches `navigate()`, so `onNavigate` doesn't fire for table-of-contents links at all. Measured below rather than assumed.

## Verification

Built the docs twice from this branch — once with the patch, once without — served both `build/` directories locally and drove real browsers. Scrolled each source page to the bottom, clicked a visible link, waited, and read `window.scrollY`.

**Firefox 150**

| case | before | after |
| --- | --- | --- |
| `/docs/themes/` → `/docs/base/` (long → short) | **y = 889** ❌ | **y = 0** ✅ |
| `/docs/colors/` → `/docs/base/` (long → short) | **y = 889** ❌ | **y = 0** ✅ |
| `/docs/base/` → `/docs/themes/` (short → long) | y = 0 ✅ | y = 0 ✅ |
| `/docs/install/` → `/docs/use/` (similar heights) | **y = 1010** ❌ | **y = 0** ✅ |

`889` is exactly `1789 − 900` — the new page's height minus the viewport, i.e. the old offset clamped. The smooth scroll never ran.

Note the third row: short → long was already fine, so the fix isn't papering over a general regression, and the fourth row shows this isn't only about long → short pages.

**Chromium 151** — all four cases `y = 0` both before and after. No regression.

**In-page anchor smoothness** — clicked a TOC link and sampled `scrollY` every 40 ms:

| | before | after |
| --- | --- | --- |
| Firefox | 13 distinct intermediate positions → smooth | 13 → **still smooth** |
| Chromium | 11 → smooth | 10 → **still smooth** |

An instant jump would show 2 or fewer distinct values.

**Tests** — `bun test src` in `packages/docs`: 120 pass, 1 fail. That one failure (`verifyBuild.test.js`, a Windows path-separator assertion comparing `docs\example\index.html` against `docs/example/index.html`) is pre-existing — I confirmed it fails identically with my change shelved. `bun run lang:validate` passes.

## One intentional behaviour change

A link to an anchor **on a different page** (`/docs/foo/#bar`) is handled by SvelteKit with `deep_linked.scrollIntoView()`, which also follows `scroll-behavior`. With this change it jumps instantly instead of animating. Animating from the top of a freshly loaded page down to the anchor is arguably the odd behaviour, and it is the same code path that hits the Firefox interruption bug — but flagging it since it is a visible difference.
