### PR TITLE
docs: fix $$ placement so responsive examples work with a configured prefix

### DIFF
--- a/packages/docs/src/routes/(routes)/components/drawer/+page.md
+++ b/packages/docs/src/routes/(routes)/components/drawer/+page.md
@@ -283,7 +283,7 @@ You can check/uncheck the checkbox using JavaScript or by clicking the `label` t
       <ul class="$$menu w-full grow">
         <!-- List item -->
         <li>
-          <button class="$$is-drawer-close:tooltip $$is-drawer-close:tooltip-right" data-tip="Homepage">
+          <button class="$$is-drawer-close:$$tooltip $$is-drawer-close:$$tooltip-right" data-tip="Homepage">
             <!-- Home icon -->
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor" class="my-1.5 inline-block size-4"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"></path><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path></svg>
             <span class="$$is-drawer-close:hidden">Homepage</span>
@@ -292,7 +292,7 @@ You can check/uncheck the checkbox using JavaScript or by clicking the `label` t
 
         <!-- List item -->
         <li>
-          <button class="$$is-drawer-close:tooltip $$is-drawer-close:tooltip-right" data-tip="Settings">
+          <button class="$$is-drawer-close:$$tooltip $$is-drawer-close:$$tooltip-right" data-tip="Settings">
             <!-- Settings icon -->
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor" class="my-1.5 inline-block size-4"><path d="M20 7h-9"></path><path d="M14 17H5"></path><circle cx="17" cy="17" r="3"></circle><circle cx="7" cy="7" r="3"></circle></svg>
             <span class="$$is-drawer-close:hidden">Settings</span>

--- a/packages/docs/src/routes/(routes)/components/footer/+page.md
+++ b/packages/docs/src/routes/(routes)/components/footer/+page.md
@@ -238,7 +238,7 @@ classnames:
 </footer>
 
 ```html
-<footer class="$$footer $$sm:footer-horizontal bg-neutral text-neutral-content p-10">
+<footer class="$$footer sm:$$footer-horizontal bg-neutral text-neutral-content p-10">
   <aside>
     <svg
       width="50"
@@ -307,7 +307,7 @@ classnames:
 </footer>
 
 ```html
-<footer class="$$footer $$sm:footer-horizontal $$footer-center bg-base-300 text-base-content p-4">
+<footer class="$$footer sm:$$footer-horizontal $$footer-center bg-base-300 text-base-content p-4">
   <aside>
     <p>Copyright © {new Date().getFullYear()} - All right reserved by ACME Industries Ltd</p>
   </aside>

--- a/packages/docs/src/routes/(routes)/components/label/+page.md
+++ b/packages/docs/src/routes/(routes)/components/label/+page.md
@@ -158,17 +158,17 @@ classnames:
 
 ```html
 <label class="$$floating-label">
-  <input type="text" placeholder="Input" class="$$input $$input-xs $$sm:input-sm $$md:input-md $$lg:input-lg $$xl:input-xl" value="Placeholder" />
+  <input type="text" placeholder="Input" class="$$input $$input-xs sm:$$input-sm md:$$input-md lg:$$input-lg xl:$$input-xl" value="Placeholder" />
   <span>Input</span>
 </label>
 
 <label class="$$floating-label">
-  <textarea placeholder="Textarea" class="$$textarea $$textarea-xs $$sm:textarea-sm $$md:textarea-md $$lg:textarea-lg $$xl:textarea-xl">Placeholder</textarea>
+  <textarea placeholder="Textarea" class="$$textarea $$textarea-xs sm:$$textarea-sm md:$$textarea-md lg:$$textarea-lg xl:$$textarea-xl">Placeholder</textarea>
   <span>Textarea</span>
 </label>
 
 <label class="$$floating-label">
-  <select class="$$select $$select-xs $$sm:select-sm $$md:select-md $$lg:select-lg $$xl:select-xl">
+  <select class="$$select $$select-xs sm:$$select-sm md:$$select-md lg:$$select-lg xl:$$select-xl">
     <option disabled selected>Placeholder</option>
     <option>Option</option>
   </select>

--- a/packages/docs/src/routes/(routes)/components/tooltip/+page.md
+++ b/packages/docs/src/routes/(routes)/components/tooltip/+page.md
@@ -307,7 +307,7 @@ classnames:
 </div>
 
 ```html
-<div class="$$lg:tooltip" data-tip="hello">
+<div class="lg:$$tooltip" data-tip="hello">
   <button class="$$btn">Hover me</button>
 </div>
 ```
@@ -320,7 +320,7 @@ classnames:
 </div>
 
 ```html
-<div class="$$tooltip $$tooltip-start $$md:tooltip-right $$md:tooltip-center" data-tip="hello">
+<div class="$$tooltip $$tooltip-start md:$$tooltip-right md:$$tooltip-center" data-tip="hello">
   <button class="$$btn">Hover me</button>
 </div>
 ```


### PR DESCRIPTION
With a prefix configured, `$$sm:footer-horizontal` compiles to `d-sm:footer-horizontal` which doesn't exist, so the responsive modifier silently does nothing. Moved `$$` after the variant. The drawer examples also needed `$$` on the class after `is-drawer-close:`.

Output is byte identical with the default empty prefix.

close #4663
