### PR TITLE
docs: add missing alt text to image examples so copied code matches the preview

### DIFF
--- a/packages/docs/src/routes/(routes)/components/avatar/+page.md
+++ b/packages/docs/src/routes/(routes)/components/avatar/+page.md
@@ -34,7 +34,7 @@ classnames:
 ```html
 <div class="$$avatar">
   <div class="w-24 rounded">
-    <img src="https://img.daisyui.com/images/profile/demo/batperson@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/batperson@192.webp" />
   </div>
 </div>
 ```
@@ -65,7 +65,7 @@ classnames:
 ```html
 <div class="$$avatar">
   <div class="w-32 rounded">
-    <img src="https://img.daisyui.com/images/profile/demo/superperson@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/superperson@192.webp" />
   </div>
 </div>
 <div class="$$avatar">
@@ -110,12 +110,12 @@ classnames:
 ```html
 <div class="$$avatar">
   <div class="w-24 rounded-xl">
-    <img src="https://img.daisyui.com/images/profile/demo/yellingwoman@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/yellingwoman@192.webp" />
   </div>
 </div>
 <div class="$$avatar">
   <div class="w-24 rounded-full">
-    <img src="https://img.daisyui.com/images/profile/demo/yellingcat@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/yellingcat@192.webp" />
   </div>
 </div>
 ```
@@ -141,17 +141,17 @@ classnames:
 ```html
 <div class="$$avatar">
   <div class="$$mask $$mask-heart w-24">
-    <img src="https://img.daisyui.com/images/profile/demo/distracted3@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/distracted3@192.webp" />
   </div>
 </div>
 <div class="$$avatar">
   <div class="$$mask $$mask-squircle w-24">
-    <img src="https://img.daisyui.com/images/profile/demo/distracted1@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/distracted1@192.webp" />
   </div>
 </div>
 <div class="$$avatar">
   <div class="$$mask $$mask-hexagon-2 w-24">
-    <img src="https://img.daisyui.com/images/profile/demo/distracted2@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/distracted2@192.webp" />
   </div>
 </div>
 ```
@@ -185,22 +185,22 @@ classnames:
 <div class="$$avatar-group -space-x-6">
   <div class="$$avatar">
     <div class="w-12">
-      <img src="https://img.daisyui.com/images/profile/demo/batperson@192.webp" />
+      <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/batperson@192.webp" />
     </div>
   </div>
   <div class="$$avatar">
     <div class="w-12">
-      <img src="https://img.daisyui.com/images/profile/demo/spiderperson@192.webp" />
+      <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/spiderperson@192.webp" />
     </div>
   </div>
   <div class="$$avatar">
     <div class="w-12">
-      <img src="https://img.daisyui.com/images/profile/demo/averagebulk@192.webp" />
+      <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/averagebulk@192.webp" />
     </div>
   </div>
   <div class="$$avatar">
     <div class="w-12">
-      <img src="https://img.daisyui.com/images/profile/demo/wonderperson@192.webp" />
+      <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/wonderperson@192.webp" />
     </div>
   </div>
 </div>
@@ -235,17 +235,17 @@ classnames:
 <div class="$$avatar-group -space-x-6">
   <div class="$$avatar">
     <div class="w-12">
-      <img src="https://img.daisyui.com/images/profile/demo/batperson@192.webp" />
+      <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/batperson@192.webp" />
     </div>
   </div>
   <div class="$$avatar">
     <div class="w-12">
-      <img src="https://img.daisyui.com/images/profile/demo/spiderperson@192.webp" />
+      <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/spiderperson@192.webp" />
     </div>
   </div>
   <div class="$$avatar">
     <div class="w-12">
-      <img src="https://img.daisyui.com/images/profile/demo/averagebulk@192.webp" />
+      <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/averagebulk@192.webp" />
     </div>
   </div>
   <div class="$$avatar $$avatar-placeholder">
@@ -267,7 +267,7 @@ classnames:
 ```html
 <div class="$$avatar">
   <div class="ring-primary ring-offset-base-100 w-24 rounded-full ring-2 ring-offset-2">
-    <img src="https://img.daisyui.com/images/profile/demo/spiderperson@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/spiderperson@192.webp" />
   </div>
 </div>
 ```
@@ -288,12 +288,12 @@ classnames:
 ```html
 <div class="$$avatar $$avatar-online">
   <div class="w-24 rounded-full">
-    <img src="https://img.daisyui.com/images/profile/demo/gordon@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/gordon@192.webp" />
   </div>
 </div>
 <div class="$$avatar $$avatar-offline">
   <div class="w-24 rounded-full">
-    <img src="https://img.daisyui.com/images/profile/demo/idiotsandwich@192.webp" />
+    <img alt="Tailwind-CSS-Avatar-component" src="https://img.daisyui.com/images/profile/demo/idiotsandwich@192.webp" />
   </div>
 </div>
 ```

--- a/packages/docs/src/routes/(routes)/components/carousel/+page.md
+++ b/packages/docs/src/routes/(routes)/components/carousel/+page.md
@@ -317,25 +317,25 @@ classnames:
 ```html
 <div class="$$carousel $$carousel-vertical rounded-box h-96">
   <div class="$$carousel-item h-full">
-    <img src="https://img.daisyui.com/images/stock/photo-1559703248-dcaaec9fab78.webp" />
+    <img alt="Free Tailwind CSS Slider" src="https://img.daisyui.com/images/stock/photo-1559703248-dcaaec9fab78.webp" />
   </div>
   <div class="$$carousel-item h-full">
-    <img src="https://img.daisyui.com/images/stock/photo-1565098772267-60af42b81ef2.webp" />
+    <img alt="Free Tailwind CSS Slider" src="https://img.daisyui.com/images/stock/photo-1565098772267-60af42b81ef2.webp" />
   </div>
   <div class="$$carousel-item h-full">
-    <img src="https://img.daisyui.com/images/stock/photo-1572635148818-ef6fd45eb394.webp" />
+    <img alt="Free Tailwind CSS Slider" src="https://img.daisyui.com/images/stock/photo-1572635148818-ef6fd45eb394.webp" />
   </div>
   <div class="$$carousel-item h-full">
-    <img src="https://img.daisyui.com/images/stock/photo-1494253109108-2e30c049369b.webp" />
+    <img alt="Free Tailwind CSS Slider" src="https://img.daisyui.com/images/stock/photo-1494253109108-2e30c049369b.webp" />
   </div>
   <div class="$$carousel-item h-full">
-    <img src="https://img.daisyui.com/images/stock/photo-1550258987-190a2d41a8ba.webp" />
+    <img alt="Free Tailwind CSS Slider" src="https://img.daisyui.com/images/stock/photo-1550258987-190a2d41a8ba.webp" />
   </div>
   <div class="$$carousel-item h-full">
-    <img src="https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.webp" />
+    <img alt="Free Tailwind CSS Slider" src="https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.webp" />
   </div>
   <div class="$$carousel-item h-full">
-    <img src="https://img.daisyui.com/images/stock/photo-1601004890684-d8cbf643f5f2.webp" />
+    <img alt="Free Tailwind CSS Slider" src="https://img.daisyui.com/images/stock/photo-1601004890684-d8cbf643f5f2.webp" />
   </div>
 </div>
 ```
@@ -370,36 +370,43 @@ classnames:
 <div class="$$carousel rounded-box w-96">
   <div class="$$carousel-item w-1/2">
     <img
+      alt="Tailwind CSS slide plugin"
       src="https://img.daisyui.com/images/stock/photo-1559703248-dcaaec9fab78.webp"
       class="w-full" />
   </div>
   <div class="$$carousel-item w-1/2">
     <img
+      alt="Tailwind CSS slide plugin"
       src="https://img.daisyui.com/images/stock/photo-1565098772267-60af42b81ef2.webp"
       class="w-full" />
   </div>
   <div class="$$carousel-item w-1/2">
     <img
+      alt="Tailwind CSS slide plugin"
       src="https://img.daisyui.com/images/stock/photo-1572635148818-ef6fd45eb394.webp"
       class="w-full" />
   </div>
   <div class="$$carousel-item w-1/2">
     <img
+      alt="Tailwind CSS slide plugin"
       src="https://img.daisyui.com/images/stock/photo-1494253109108-2e30c049369b.webp"
       class="w-full" />
   </div>
   <div class="$$carousel-item w-1/2">
     <img
+      alt="Tailwind CSS slide plugin"
       src="https://img.daisyui.com/images/stock/photo-1550258987-190a2d41a8ba.webp"
       class="w-full" />
   </div>
   <div class="$$carousel-item w-1/2">
     <img
+      alt="Tailwind CSS slide plugin"
       src="https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.webp"
       class="w-full" />
   </div>
   <div class="$$carousel-item w-1/2">
     <img
+      alt="Tailwind CSS slide plugin"
       src="https://img.daisyui.com/images/stock/photo-1601004890684-d8cbf643f5f2.webp"
       class="w-full" />
   </div>
@@ -436,36 +443,43 @@ classnames:
 <div class="$$carousel $$carousel-center bg-neutral rounded-box max-w-md space-x-4 p-4">
   <div class="$$carousel-item">
     <img
+      alt="Tailwind CSS component"
       src="https://img.daisyui.com/images/stock/photo-1559703248-dcaaec9fab78.webp"
       class="rounded-box" />
   </div>
   <div class="$$carousel-item">
     <img
+      alt="Tailwind CSS component"
       src="https://img.daisyui.com/images/stock/photo-1565098772267-60af42b81ef2.webp"
       class="rounded-box" />
   </div>
   <div class="$$carousel-item">
     <img
+      alt="Tailwind CSS component"
       src="https://img.daisyui.com/images/stock/photo-1572635148818-ef6fd45eb394.webp"
       class="rounded-box" />
   </div>
   <div class="$$carousel-item">
     <img
+      alt="Tailwind CSS component"
       src="https://img.daisyui.com/images/stock/photo-1494253109108-2e30c049369b.webp"
       class="rounded-box" />
   </div>
   <div class="$$carousel-item">
     <img
+      alt="Tailwind CSS component"
       src="https://img.daisyui.com/images/stock/photo-1550258987-190a2d41a8ba.webp"
       class="rounded-box" />
   </div>
   <div class="$$carousel-item">
     <img
+      alt="Tailwind CSS component"
       src="https://img.daisyui.com/images/stock/photo-1559181567-c3190ca9959b.webp"
       class="rounded-box" />
   </div>
   <div class="$$carousel-item">
     <img
+      alt="Tailwind CSS component"
       src="https://img.daisyui.com/images/stock/photo-1601004890684-d8cbf643f5f2.webp"
       class="rounded-box" />
   </div>
@@ -501,21 +515,25 @@ classnames:
 <div class="$$carousel w-full">
   <div id="item1" class="$$carousel-item w-full">
     <img
+      alt="Tailwind CSS gallery"
       src="https://img.daisyui.com/images/stock/photo-1625726411847-8cbb60cc71e6.webp"
       class="w-full" />
   </div>
   <div id="item2" class="$$carousel-item w-full">
     <img
+      alt="Tailwind CSS gallery"
       src="https://img.daisyui.com/images/stock/photo-1609621838510-5ad474b7d25d.webp"
       class="w-full" />
   </div>
   <div id="item3" class="$$carousel-item w-full">
     <img
+      alt="Tailwind CSS gallery"
       src="https://img.daisyui.com/images/stock/photo-1414694762283-acccc27bca85.webp"
       class="w-full" />
   </div>
   <div id="item4" class="$$carousel-item w-full">
     <img
+      alt="Tailwind CSS gallery"
       src="https://img.daisyui.com/images/stock/photo-1665553365602-b2fb8e5d1707.webp"
       class="w-full" />
   </div>
@@ -567,6 +585,7 @@ classnames:
 <div class="$$carousel w-full">
   <div id="slide1" class="$$carousel-item relative w-full">
     <img
+      alt="Tailwind CSS slide example"
       src="https://img.daisyui.com/images/stock/photo-1625726411847-8cbb60cc71e6.webp"
       class="w-full" />
     <div class="absolute left-5 right-5 top-1/2 flex -translate-y-1/2 transform justify-between">
@@ -576,6 +595,7 @@ classnames:
   </div>
   <div id="slide2" class="$$carousel-item relative w-full">
     <img
+      alt="Tailwind CSS slide example"
       src="https://img.daisyui.com/images/stock/photo-1609621838510-5ad474b7d25d.webp"
       class="w-full" />
     <div class="absolute left-5 right-5 top-1/2 flex -translate-y-1/2 transform justify-between">
@@ -585,6 +605,7 @@ classnames:
   </div>
   <div id="slide3" class="$$carousel-item relative w-full">
     <img
+      alt="Tailwind CSS slide example"
       src="https://img.daisyui.com/images/stock/photo-1414694762283-acccc27bca85.webp"
       class="w-full" />
     <div class="absolute left-5 right-5 top-1/2 flex -translate-y-1/2 transform justify-between">
@@ -594,6 +615,7 @@ classnames:
   </div>
   <div id="slide4" class="$$carousel-item relative w-full">
     <img
+      alt="Tailwind CSS slide example"
       src="https://img.daisyui.com/images/stock/photo-1665553365602-b2fb8e5d1707.webp"
       class="w-full" />
     <div class="absolute left-5 right-5 top-1/2 flex -translate-y-1/2 transform justify-between">

--- a/packages/docs/src/routes/(routes)/components/hero/+page.md
+++ b/packages/docs/src/routes/(routes)/components/hero/+page.md
@@ -63,6 +63,7 @@ classnames:
 <div class="$$hero bg-base-200 min-h-screen">
   <div class="$$hero-content flex-col lg:flex-row">
     <img
+      alt="Tailwind CSS hero component"
       src="https://img.daisyui.com/images/stock/photo-1635805737707-575885ab0820.webp"
       class="max-w-sm rounded-lg shadow-2xl"
     />
@@ -95,6 +96,7 @@ classnames:
 <div class="$$hero bg-base-200 min-h-screen">
   <div class="$$hero-content flex-col lg:flex-row-reverse">
     <img
+      alt="Tailwind CSS hero component"
       src="https://img.daisyui.com/images/stock/photo-1635805737707-575885ab0820.webp"
       class="max-w-sm rounded-lg shadow-2xl"
     />

--- a/packages/docs/src/routes/(routes)/components/hover-gallery/+page.md
+++ b/packages/docs/src/routes/(routes)/components/hover-gallery/+page.md
@@ -48,10 +48,10 @@ The first image is visible by default, the other image will create invisible col
 
 ```html
 <figure class="$$hover-gallery max-w-60">
-  <img src="https://img.daisyui.com/images/stock/daisyui-hat-1.webp" />
-  <img src="https://img.daisyui.com/images/stock/daisyui-hat-2.webp" />
-  <img src="https://img.daisyui.com/images/stock/daisyui-hat-3.webp" />
-  <img src="https://img.daisyui.com/images/stock/daisyui-hat-4.webp" />
+  <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-1.webp" />
+  <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-2.webp" />
+  <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-3.webp" />
+  <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-4.webp" />
 </figure>
 ```
 
@@ -76,10 +76,10 @@ The first image is visible by default, the other image will create invisible col
 ```html
 <div class="$$card $$card-sm bg-base-200 max-w-60 shadow">
   <figure class="$$hover-gallery">
-    <img src="https://img.daisyui.com/images/stock/daisyui-hat-1.webp" />
-    <img src="https://img.daisyui.com/images/stock/daisyui-hat-2.webp" />
-    <img src="https://img.daisyui.com/images/stock/daisyui-hat-3.webp" />
-    <img src="https://img.daisyui.com/images/stock/daisyui-hat-4.webp" />
+    <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-1.webp" />
+    <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-2.webp" />
+    <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-3.webp" />
+    <img alt="Tailwind CSS image hover gallery" src="https://img.daisyui.com/images/stock/daisyui-hat-4.webp" />
   </figure>
   <div class="$$card-body">
     <h2 class="$$card-title flex justify-between">

--- a/packages/docs/src/routes/(routes)/components/list/+page.md
+++ b/packages/docs/src/routes/(routes)/components/list/+page.md
@@ -77,7 +77,7 @@ classnames:
   <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">Most played songs this week</li>
   
   <li class="$$list-row">
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/></div>
     <div>
       <div>Dio Lupa</div>
       <div class="text-xs uppercase font-semibold opacity-60">Remaining Reason</div>
@@ -91,7 +91,7 @@ classnames:
   </li>
   
   <li class="$$list-row">
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/4@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/4@94.webp"/></div>
     <div>
       <div>Ellie Beilish</div>
       <div class="text-xs uppercase font-semibold opacity-60">Bears of a fever</div>
@@ -105,7 +105,7 @@ classnames:
   </li>
   
   <li class="$$list-row">
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/3@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/3@94.webp"/></div>
     <div>
       <div>Sabrino Gardener</div>
       <div class="text-xs uppercase font-semibold opacity-60">Cappuccino</div>
@@ -169,7 +169,7 @@ classnames:
   
   <li class="$$list-row">
     <div class="text-4xl font-thin opacity-30 tabular-nums">01</div>
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/></div>
     <div class="$$list-col-grow">
       <div>Dio Lupa</div>
       <div class="text-xs uppercase font-semibold opacity-60">Remaining Reason</div>
@@ -181,7 +181,7 @@ classnames:
   
   <li class="$$list-row">
     <div class="text-4xl font-thin opacity-30 tabular-nums">02</div>
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/4@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/4@94.webp"/></div>
     <div class="$$list-col-grow">
       <div>Ellie Beilish</div>
       <div class="text-xs uppercase font-semibold opacity-60">Bears of a fever</div>
@@ -193,7 +193,7 @@ classnames:
   
   <li class="$$list-row">
     <div class="text-4xl font-thin opacity-30 tabular-nums">03</div>
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/3@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/3@94.webp"/></div>
     <div class="$$list-col-grow">
       <div>Sabrino Gardener</div>
       <div class="text-xs uppercase font-semibold opacity-60">Cappuccino</div>
@@ -267,7 +267,7 @@ classnames:
   <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">Most played songs this week</li>
   
   <li class="$$list-row">
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/1@94.webp"/></div>
     <div>
       <div>Dio Lupa</div>
       <div class="text-xs uppercase font-semibold opacity-60">Remaining Reason</div>
@@ -284,7 +284,7 @@ classnames:
   </li>
   
   <li class="$$list-row">
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/4@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/4@94.webp"/></div>
     <div>
       <div>Ellie Beilish</div>
       <div class="text-xs uppercase font-semibold opacity-60">Bears of a fever</div>
@@ -301,7 +301,7 @@ classnames:
   </li>
   
   <li class="$$list-row">
-    <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/3@94.webp"/></div>
+    <div><img class="size-10 rounded-box" alt="Tailwind CSS list item" src="https://img.daisyui.com/images/profile/demo/3@94.webp"/></div>
     <div>
       <div>Sabrino Gardener</div>
       <div class="text-xs uppercase font-semibold opacity-60">Cappuccino</div>

--- a/packages/docs/src/routes/(routes)/components/mask/+page.md
+++ b/packages/docs/src/routes/(routes)/components/mask/+page.md
@@ -56,6 +56,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-squircle"
+  alt="Squircle CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -66,6 +67,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-heart"
+  alt="Heart CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -76,6 +78,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-hexagon"
+  alt="Hexagon CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -86,6 +89,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-hexagon-2"
+  alt="Hexagon-2 CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -96,6 +100,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-decagon"
+  alt="Decagon CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -106,6 +111,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-pentagon"
+  alt="Pentagon CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -116,6 +122,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-diamond"
+  alt="Diamond CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -126,6 +133,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-square"
+  alt="Square CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -136,6 +144,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-circle"
+  alt="Circle CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -145,6 +154,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-star"
+  alt="Star CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -155,6 +165,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-star-2"
+  alt="Star-2 CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -165,6 +176,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-triangle"
+  alt="Triangle CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -175,6 +187,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-triangle-2"
+  alt="Triangle-2 CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -185,6 +198,7 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-triangle-3"
+  alt="Triangle-3 CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 
@@ -195,5 +209,6 @@ classnames:
 ```html
 <img
   class="$$mask $$mask-triangle-4"
+  alt="Triangle-4 CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```

--- a/packages/docs/src/routes/(routes)/components/stack/+page.md
+++ b/packages/docs/src/routes/(routes)/components/stack/+page.md
@@ -54,9 +54,9 @@ classnames:
 
 ```html
 <div class="$$stack w-48">
-  <img src="https://img.daisyui.com/images/stock/photo-1572635148818-ef6fd45eb394.webp" class="rounded-box" />
-  <img src="https://img.daisyui.com/images/stock/photo-1565098772267-60af42b81ef2.webp" class="rounded-box" />
-  <img src="https://img.daisyui.com/images/stock/photo-1559703248-dcaaec9fab78.webp" class="rounded-box" />
+  <img alt="Tailwind CSS example 1" src="https://img.daisyui.com/images/stock/photo-1572635148818-ef6fd45eb394.webp" class="rounded-box" />
+  <img alt="Tailwind CSS example 2" src="https://img.daisyui.com/images/stock/photo-1565098772267-60af42b81ef2.webp" class="rounded-box" />
+  <img alt="Tailwind CSS example 3" src="https://img.daisyui.com/images/stock/photo-1559703248-dcaaec9fab78.webp" class="rounded-box" />
 </div>
 ```
 

--- a/packages/docs/src/routes/(routes)/components/stat/+page.md
+++ b/packages/docs/src/routes/(routes)/components/stat/+page.md
@@ -133,7 +133,7 @@ classnames:
     <div class="$$stat-figure text-secondary">
       <div class="$$avatar $$avatar-online">
         <div class="w-16 rounded-full">
-          <img src="https://img.daisyui.com/images/profile/demo/anakeen@192.webp" />
+          <img alt="Tailwind CSS stat example component" src="https://img.daisyui.com/images/profile/demo/anakeen@192.webp" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
every preview in these examples has an `alt`, but 84 images in the copy-paste code blocks don't, so the code you copy differs from the example above it. this adds the missing ones by taking each image's `alt` from its own preview, so no existing value changes.

avatar 17, carousel 29, mask 15, list 9, hover-gallery 8, stack 3, hero 2, stat 1. everything except the added `alt` is byte identical, and no preview is touched. mask is the useful check: all 15 examples share one `src` but each code block picked up its own shape name.

on the second half of #4667, whether these should become descriptive (`Black cap with a daisy logo, front view` instead of `Tailwind CSS image hover gallery`): this PR deliberately doesn't touch that, since it would mean rewriting the previews too and the current values look chosen for image search. happy to follow up either way, i went through all 33 images so the descriptions are ready.

closes: #4667
