### PR TITLE
docs(join): drop the --join-ss/se/es/ee rows from the internal variables table

### DIFF
--- a/packages/docs/src/routes/(routes)/docs/utilities/+page.md
+++ b/packages/docs/src/routes/(routes)/docs/utilities/+page.md
@@ -274,10 +274,6 @@ If you are using a prefix for daisyUI, these CSS variables will be prefixed with
 |                 | `--glass-text-shadow-opacity` | opacity of the glass text shadow                         |
 | Join            | `--join-h`                    | horizontal join direction                                |
 |                 | `--join-v`                    | vertical join direction                                  |
-|                 | `--join-ss`                   | start start border radius of the join                    |
-|                 | `--join-se`                   | start end border radius of the join                      |
-|                 | `--join-es`                   | end start border radius of the join                      |
-|                 | `--join-ee`                   | end end border radius of the join                        |
 
 ### Examples of customizing component specific CSS variables
 


### PR DESCRIPTION
Addresses the **documentation half** of #4616 (thanks @pdanpdan).

Deliberately **not** using `closes` — the other half of that issue is a proposal for a new public API (`--join-r` / `--join-r-ss` …), which is a maintainer call and hasn't been answered yet. This PR only stops the docs from pointing at four variables that cannot actually be customized, so the issue should stay open for the API discussion.

## Why these four rows are misleading

The table they sit in is introduced with:

> For advanced use: These CSS variables are being used internally for a specific components. You probably won't need to customize them, **but you can if you want to.**

For `--join-ss` / `--join-se` / `--join-es` / `--join-ee` that last part isn't true.

Measured on released daisyUI 5.7.16 in Chromium — `--join-ss/se/es/ee: 30px`, reading the computed `border-*-radius` of each item:

| where the variables are set | first item | middle item | last item |
| --- | --- | --- | --- |
| **on `.join`** | `4px \| 0 \| 4px \| 0` — **ignored** | `30px` all round — applied | `0 \| 4px \| 0 \| 4px` — **ignored** |
| on each `.join-item` | `4px \| 0 \| 4px \| 0` (left alone) | `30px` all round | `30px` all round — applied |

So setting them on the container doesn't do nothing — it does something worse: only the middle items pick the value up, and the join renders with mismatched corners.

The cause is in [`join.css`](https://github.com/saadeghi/daisyui/blob/master/packages/daisyui/src/utilities/join.css#L21-L40): `:where(:scope > :first-child)`, `:last-child` and `:only-child` **re-declare** all four variables on the items themselves, so the value inherited from `.join` is always overridden on exactly the items whose corners are visible.

Setting them on a `.join-item` does work — but as @pdanpdan points out in the issue, at that point it is no different from writing `border-radius` on the item, so the variable buys you nothing.

Given the table explicitly invites customization, listing four variables where customization is either broken or pointless seemed worth removing rather than annotating.

## Something else I noticed (not changed here)

While measuring I found that `--join-h` / `--join-v` have a similar trap: setting them on `.join` propagates correctly and produces margins and radii **identical** to `.join-vertical`, but `flex-direction` stays `row` — so you get vertical-join geometry on a horizontally laid out join. Changing direction needs the `.join-vertical` / `.join-horizontal` classes, which are documented on the join component page.

I left those two rows untouched: the issue is specifically about `--join-(ss|se|es|ee)`, and unlike those, `--join-h`/`--join-v` are genuinely useful if you also set `flex-direction` yourself. Happy to follow up if you'd like them reworded.

## Translations

No translation changes. Table rows are stored as whole-line keys (e.g. `en.docs.json` has the entire `` |                 | `--join-ss` … `` line as a key), so **removing** rows adds no new keys — whereas rewording them would have meant adding new English strings to all 27 locales. `bun run lang:prune` reports nothing to prune and `bun run lang:validate` passes.

`bun test src` in `packages/docs`: 120 pass, 1 fail — that failure (`verifyBuild.test.js`, a Windows path-separator assertion) is pre-existing, confirmed identical with this change shelved.
