### PR TITLE
docs: fix typo in blueprint-1.5 blog post

### DIFF
--- a/packages/docs/src/routes/(routes)/blog/(posts)/blueprint-1.5/+page.md
+++ b/packages/docs/src/routes/(routes)/blog/(posts)/blueprint-1.5/+page.md
@@ -101,7 +101,7 @@ This is prevents a generic UI. Blueprint understands the direction from the prod
 
 <img src="https://img.daisyui.com/images/emoji/0800_woman-teacher_1f469-200d-1f3eb.png" alt="Page Architect" class="lg:ms-4 my-4 block size-48 rounded-box border border-base-300 bg-base-200 p-8 lg:float-end lg:-rotate-2" width="192" height="192" loading="lazy" />
 
-The [Page Architect](/blueprint/workflow/#4-page-architect) MCP tool chooses from 211 page architectures. Each page architecture covers a specific UI's purpose, sections, content heirarchy, actions, navigation, behavior, interaction states, and edge cases.
+The [Page Architect](/blueprint/workflow/#4-page-architect) MCP tool chooses from 211 page architectures. Each page architecture covers a specific UI's purpose, sections, content hierarchy, actions, navigation, behavior, interaction states, and edge cases.
 
 Without a plan, agents tend to improvise one section at a time. That produces pages made of individually plausible blocks without a flow. The Page Architect MCP tool gives the agent a complete route through the page and includes the components where it's needed.
 


### PR DESCRIPTION
Typo in the Blueprint 1.5 blog post: `heirarchy` -> `hierarchy`.

It is the only instance of that spelling under `packages/docs/src`.
