### PR TITLE
docs: document the row-hover class on the table page

### DIFF
--- a/packages/docs/src/routes/(routes)/components/table/+page.md
+++ b/packages/docs/src/routes/(routes)/components/table/+page.md
@@ -14,6 +14,8 @@ classnames:
     desc: For <table> to make all the rows inside <thead> and <tfoot> sticky
   - class: table-pin-cols
     desc: For <table> to make all the <th> columns sticky
+  - class: row-hover
+    desc: For <tr> to highlight the row on hover
   size:
   - class: table-xs
     desc: Extra small size

--- a/skills/daisyui/components/table.md
+++ b/skills/daisyui/components/table.md
@@ -5,7 +5,7 @@ Table can be used to show a list of data in a table format
 
 #### Class Names:
 - Component: `table`
-- Modifier: `table-zebra`, `table-pin-rows`, `table-pin-cols`
+- Modifier: `table-zebra`, `table-pin-rows`, `table-pin-cols`, `row-hover`
 - Size: `table-xs`, `table-sm`, `table-md`, `table-lg`, `table-xl`
 
 #### Syntax


### PR DESCRIPTION
`row-hover` is in `table.css` and in the generated class list, but it isn't in the class table on the docs page, so there's no way to find it.

it's also nicer than doing it by hand because it's zebra aware: `base-200` normally, `base-300` inside `table-zebra` so it still reads against the stripes.

worth noting the "Table with a row that highlights on hover" example uses `hover:bg-base-300` rather than this class. happy to switch it over in a follow up if you want, i left it alone since it changes how that example looks.
