### PR TITLE
fix: checkbox/radio .btn color when checked

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -63,14 +63,14 @@
         content: var(--tw-content);
       }
     }
-  }
 
-  @layer daisyui.l1 {
     &:where(:checked:not(.filter [type="radio"].btn)) {
       --btn-color: var(--color-primary);
       --btn-fg: var(--color-primary-content);
     }
+  }
 
+  @layer daisyui.l1 {
     @media (hover: hover) {
       &:hover {
         --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 7%);


### PR DESCRIPTION
broken in c2b19c43054ef42f9d4bcdbcdaf0554d100a0597 when the default color for checked was moved in daisyui.l1 - now all checkbox/radio `.btn` show as primary when checked

example: https://play.tailwindcss.com/h4aYDd3uj2