### PR TITLE
fix(dock): don't force dock layout onto script/style/template children

### DIFF
--- a/packages/daisyui/src/components/dock.css
+++ b/packages/daisyui/src/components/dock.css
@@ -5,7 +5,7 @@
     height: 4rem;
     height: calc(4rem + env(safe-area-inset-bottom));
     padding-bottom: env(safe-area-inset-bottom);
-    > * {
+    > *:not(:where(script, style, template)) {
       @apply rounded-box relative mb-2 flex h-full max-w-32 shrink-1 basis-full cursor-pointer flex-col items-center justify-center gap-px bg-transparent;
       transition: opacity 0.2s ease-out;
       @media (hover: hover) {


### PR DESCRIPTION
same thing #4561 fixed for footer. `.dock > *` hands every direct child the dock's flex sizing, so a build inlined `<script>` or a `<template>` turns into a visible nav item and eats a whole slot.

example: https://play.tailwindcss.com/0ROnYg8f24

measured: script, template and style all render `flex` at 128x55 instead of staying `display: none`.

fix is `> *:not(:where(script, style, template))`. the `:where()` is load bearing, plain `:not(script, style, template)` raises specificity and starts winning over child styles, it moved `.btn` gap inside `.fab` from 6px to 8px when i tried it that way.
