### PR TITLE
fix(alert): count only direct children when choosing the grid columns

### DIFF
--- a/packages/daisyui/src/components/alert.css
+++ b/packages/daisyui/src/components/alert.css
@@ -26,7 +26,7 @@
           #0000
         ),
       0 4px 3px -2px oklch(0% 0 0 / calc(var(--depth) * 0.08));
-    &:has(:nth-child(2)) {
+    &:has(> :nth-child(2)) {
       grid-template-columns: auto minmax(auto, 1fr);
     }
   }
@@ -106,7 +106,7 @@
     grid-auto-flow: row;
     grid-template-columns: auto;
     text-align: center;
-    &:has(:nth-child(2)) {
+    &:has(> :nth-child(2)) {
       grid-template-columns: auto;
     }
   }
@@ -119,7 +119,7 @@
     grid-auto-flow: column;
     grid-template-columns: auto;
     text-align: start;
-    &:has(:nth-child(2)) {
+    &:has(> :nth-child(2)) {
       grid-template-columns: auto minmax(auto, 1fr);
     }
   }


### PR DESCRIPTION
same idea as #4682 and #4683, this time in `.alert`. `:has(:nth-child(2))` is a descendant match, so two elements inside the message (bold word, a link) add an empty second column and the text wraps a line early.

example: https://play.tailwindcss.com/l3PyGHnt4n (box 2 current, box 3 fixed)
