### PR TITLE
fix(docs): convert tabindex="-1" to tabIndex={-1} in the JSX tab

### DIFF
--- a/packages/docs/src/lib/actions.svelte.js
+++ b/packages/docs/src/lib/actions.svelte.js
@@ -79,6 +79,8 @@ export const htmlToJsx = (node) => {
       '<span style="color:var(--syntax-token)"><span style="color:var(--syntax-token)"><span style="color:var(--syntax-punctuation)"&lt;</span>br /</span><span style="color:var(--syntax-punctuation)"&gt;</span></span>',
     '<span style="color:var(--syntax-punctuation)">"</span><span style="color:var(--syntax-attr-value)">0</span><span style="color:var(--syntax-punctuation)">"</span>':
       '<span style="color:var(--syntax-punctuation)">{</span><span style="color:var(--syntax-attr-value)">0</span><span style="color:var(--syntax-punctuation)">}</span>',
+    '<span style="color:var(--syntax-punctuation)">"</span><span style="color:var(--syntax-attr-value)">-1</span><span style="color:var(--syntax-punctuation)">"</span>':
+      '<span style="color:var(--syntax-punctuation)">{</span><span style="color:var(--syntax-attr-value)">-1</span><span style="color:var(--syntax-punctuation)">}</span>',
     tabindex: "tabIndex",
     "clip-rule": "clipRule",
     "fill-opacity": "fillOpacity",


### PR DESCRIPTION
`tabindex="0"` converts to `tabIndex={0}` but `tabindex="-1"` stays a string, so the copied code fails to typecheck: `Type 'string' is not assignable to type 'number'`.

both sit on adjacent lines on /components/dropdown/#dropdown-on-hover

mirrors the existing `"0"` rule. `-1` only ever appears on tabindex in the docs, so nothing else changes.

close #4686
