### PR TITLE
fix(docs): stop renaming anchor-name and position-anchor inside style values

### DIFF
--- a/packages/docs/src/lib/actions.svelte.js
+++ b/packages/docs/src/lib/actions.svelte.js
@@ -97,8 +97,6 @@ export const htmlToJsx = (node) => {
     // keep before popovertarget, which is a prefix of it and would match first
     popovertargetaction: "popoverTargetAction",
     popovertarget: "popoverTarget",
-    "anchor-name": "anchorName",
-    "position-anchor": "positionAnchor",
   }
 
   const update = () => {


### PR DESCRIPTION
the JSX tab turns `style="anchor-name:--cally1"` into `style="anchorName:--cally1"`, which isn't a css property, so the copied style does nothing.

these two are css properties, never html attributes, so the entries can only ever match inside a style value. react warns on the camelCase form when it is used as a prop.

the hand-written jsx example on the same page already writes `style={{ anchorName: "--rdp" }}`.
