### PR TITLE
fix(docs): give the bare popover attribute a value in the JSX tab

### DIFF
--- a/packages/docs/src/lib/actions.svelte.js
+++ b/packages/docs/src/lib/actions.svelte.js
@@ -1,5 +1,19 @@
 import { prefix } from "$lib/stores"
 
+// A bare `popover` attribute means popover={true} in JSX, but React types it as an enumerated
+// string, so the attribute is dropped and the element is not a popover at all. Anchored on the end
+// of the span so it cannot match popovertarget.
+const barePopoverSpan = new RegExp(
+  '(<span style="color:var\\(--syntax-attr-name\\)">\\s*popover</span>)' +
+    '(?!<span style="color:var\\(--syntax-punctuation\\)">=</span>)',
+  "g",
+)
+const popoverValue =
+  '<span style="color:var(--syntax-punctuation)">=</span>' +
+  '<span style="color:var(--syntax-punctuation)">"</span>' +
+  '<span style="color:var(--syntax-attr-value)">auto</span>' +
+  '<span style="color:var(--syntax-punctuation)">"</span>'
+
 const replaceStrings = (content, replacements) => {
   const re = new RegExp(
     Object.keys(replacements)
@@ -103,6 +117,7 @@ export const htmlToJsx = (node) => {
 
   const update = () => {
     node.innerHTML = replaceStrings(originalContent, stringsToReplace)
+      .replace(barePopoverSpan, `$1${popoverValue}`)
       // fix the broken tabIndex={0} in JSX tab
       .replaceAll(
         'var(--syntax-punctuation)" tabIndex={0}>',


### PR DESCRIPTION
a bare `popover` is `popover={true}` in JSX, and react types it as a string (`"" | "auto" | "hint" | "manual"`), so it warns and drops the attribute. the copied modal ends up as a plain div.

react 19.2.8, client render: `hasAttribute("popover")` is false and `showPopover()` throws `NotSupportedError`. `modal.css` keys off `[popover]` and `:popover-open`, so it never shows either.

36 of them, on megamenu, modal and calendar. the hand-written jsx example already writes `popover="auto"`.
