### PR TITLE
fix(docs): retry the testimonials fetch on http errors, not just timeouts

### DIFF
--- a/packages/docs/src/routes/(routes)/+page.server.js
+++ b/packages/docs/src/routes/(routes)/+page.server.js
@@ -11,7 +11,8 @@ async function getTestimonials(retry = true) {
     }
     return await response.json()
   } catch (error) {
-    if (!signal.aborted || !retry) throw error
+    if (!retry) throw error
+    await new Promise((resolve) => setTimeout(resolve, 1000))
     return getTestimonials(false)
   }
 }


### PR DESCRIPTION
the homepage prerender fetches testimonials, and when that returned a 503 today the whole docs build failed. the retry added in 28e32653 only fires on the timeout path:

```
if (!signal.aborted || !retry) throw error
```

an http error finishes the fetch normally, so `signal.aborted` is false and it rethrows on the first attempt. so the most likely transient failure is the one case that never retries.

this retries once on any failure with a short pause. a healthy build still does a single request, and a sustained outage still fails loudly instead of hiding it.
