### PR TITLE
docs(calendar): quote the onchange handler so the HTML example parses

### DIFF
--- a/packages/docs/src/routes/(routes)/components/calendar/+page.md
+++ b/packages/docs/src/routes/(routes)/components/calendar/+page.md
@@ -99,7 +99,7 @@ import "cally";
   Pick a date
 </button>
 <div popover id="cally-popover1" class="$$dropdown bg-base-100 rounded-box shadow-lg" style="position-anchor:--cally1">
-  <calendar-date class="$$cally" onchange={document.getElementById('cally1').innerText = this.value}>
+  <calendar-date class="$$cally" onchange="document.getElementById('cally1').innerText = this.value">
     <svg aria-label="Previous" class="fill-current size-4" slot="previous" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.75 19.5 8.25 12l7.5-7.5"></path></svg>
     <svg aria-label="Next" class="fill-current size-4" slot="next" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"></path></svg>
     <calendar-month></calendar-month>


### PR DESCRIPTION
the cally example uses jsx braces inside a ```html fence, so the html tab hands you something a browser can't parse:

```
onchange={document.getElementById('cally1').innerText = this.value}
```

an unquoted attribute value ends at the first space, so that becomes three attributes: `onchange="{document.getElementById('cally1').innerText"`, plus junk ones named `=` and `this.value}`. the handler is a SyntaxError, so the button text never updates.

repro, the css attribute selectors only match if the browser really made those attributes: https://play.tailwindcss.com/eRo4n4Ycjd

quoting it fixes the html tab. the jsx tab wants `onChange={...}` which is a separate thing, not touched here.
