### PR TITLE
fix(docs): slice the skill endpoints on a heading that still exists

### DIFF
--- a/packages/docs/src/lib/scripts/skillEndpointHeadings.test.js
+++ b/packages/docs/src/lib/scripts/skillEndpointHeadings.test.js
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const docsRoot = resolve(scriptDir, "../../..")
+const repoRoot = resolve(docsRoot, "../..")
+
+// The SKILL.md and llms.txt endpoints slice the root SKILL.md on literal headings.
+// A renamed heading makes the slice silently fall back to the whole file, which
+// duplicates the sections that are appended separately.
+const endpointFiles = ["src/routes/SKILL.md/+server.js", "src/routes/llms.txt/+server.js"]
+
+const rootSkill = readFileSync(join(repoRoot, "skills/daisyui/SKILL.md"), "utf-8")
+
+const headings = endpointFiles.flatMap((file) => {
+  const content = readFileSync(join(docsRoot, file), "utf-8")
+  const matches = content.matchAll(/rootSkillContent\.indexOf\("([^"]+)"\)/g)
+  return [...matches].map((match) => ({ file, heading: match[1] }))
+})
+
+test("Finds the headings that the skill endpoints slice on", () => {
+  expect(headings.length).toBeGreaterThan(0)
+})
+
+test("Every heading a skill endpoint slices on exists in the root SKILL.md", () => {
+  headings.forEach(({ file, heading }) => {
+    if (!rootSkill.includes(heading)) {
+      throw new Error(
+        `${file} slices skills/daisyui/SKILL.md on "${heading}", which is not in that file`,
+      )
+    }
+  })
+})

--- a/packages/docs/src/routes/SKILL.md/+server.js
+++ b/packages/docs/src/routes/SKILL.md/+server.js
@@ -30,7 +30,7 @@ const componentFiles = orderedSkillFiles.filter((path) =>
 )
 
 const rootSkillContent = skillModules["../../../../../skills/daisyui/SKILL.md"]
-const rootReferencesStart = rootSkillContent.indexOf("## Mandatory reference")
+const rootReferencesStart = rootSkillContent.indexOf("## References that you must read")
 const rootProtocolStart = rootSkillContent.indexOf("### Component discovery protocol")
 const rootIntro =
   rootReferencesStart === -1

--- a/packages/docs/src/routes/llms.txt/+server.js
+++ b/packages/docs/src/routes/llms.txt/+server.js
@@ -30,7 +30,7 @@ const componentFiles = orderedSkillFiles.filter((path) =>
 )
 
 const rootSkillContent = skillModules["../../../../../skills/daisyui/SKILL.md"]
-const rootReferencesStart = rootSkillContent.indexOf("## Mandatory reference")
+const rootReferencesStart = rootSkillContent.indexOf("## References that you must read")
 const rootProtocolStart = rootSkillContent.indexOf("### Component discovery protocol")
 const rootIntro =
   rootReferencesStart === -1


### PR DESCRIPTION
`/llms.txt` and `/SKILL.md` slice the root SKILL.md on `## Mandatory reference`. that heading was renamed to `## References that you must read` in 10682b5a, which touched 73 skill files but not these two, so `indexOf` returns -1 and the slice quietly falls back to the whole file.

the served output ends up 3.6x too long: `### Component discovery protocol` shows up twice, and it still carries the references section and the hardcoded component list, both of which get replaced by the real files right after.

added a test that fails if an endpoint slices on a heading the skill file doesn't have, so the next rename is loud instead of silent.
