### PR TITLE
fix(label): keep the floating label anchored to its corner in RTL

### DIFF
--- a/packages/daisyui/src/components/label.css
+++ b/packages/daisyui/src/components/label.css
@@ -51,6 +51,9 @@
         scale: 0.75;
         pointer-events: auto;
       }
+      :dir(rtl)::placeholder {
+        translate: 12.5% calc(-50% - 0.125em);
+      }
       > span {
         @apply opacity-100;
         top: 0;
@@ -58,6 +61,9 @@
         scale: 0.75;
         pointer-events: auto;
         z-index: 2;
+        &:dir(rtl) {
+          translate: 12.5% calc(-50% - 0.125em);
+        }
       }
     }
     &:has(:disabled, [disabled]) {


### PR DESCRIPTION
the floated label scales to 0.75 and shifts translate: -12.5% so its start edge stays in place. the translate is physical though, so in RTL the label drifts away from the corner by 25% of its width. flipped it for RTL, and the matching ::placeholder rule too so the focus transition moves the same way.

bug + fix: https://play.tailwindcss.com/GwlGlCzIms
