### PR TITLE
feat(swap): swap between any number of items with swap-multi

### DIFF
--- a/packages/daisyui/src/components/swap.css
+++ b/packages/daisyui/src/components/swap.css
@@ -70,6 +70,36 @@
   }
 }
 
+.swap-multi {
+  @layer daisyui.l1 {
+    > input {
+      @apply col-start-1 row-start-1 size-full cursor-pointer opacity-0;
+      z-index: 1;
+    }
+
+    > input:first-child {
+      z-index: 2;
+    }
+
+    > input:checked {
+      z-index: 0;
+    }
+
+    /* the input after the checked pair is on top, so every click shows the next item */
+    > input:checked + * + input {
+      z-index: 2;
+    }
+
+    > input + * {
+      @apply pointer-events-none opacity-0;
+    }
+
+    > input:checked + * {
+      @apply opacity-100;
+    }
+  }
+}
+
 .swap-rotate {
   @layer daisyui.l1 {
     .swap-on,

--- a/packages/daisyui/src/components/swap.css
+++ b/packages/daisyui/src/components/swap.css
@@ -97,6 +97,12 @@
     > input:checked + * {
       @apply opacity-100;
     }
+
+    /* the inputs are invisible, so show keyboard focus on the swap itself */
+    &:has(> input:focus-visible) {
+      outline: 2px solid currentColor;
+      outline-offset: 2px;
+    }
   }
 }
 

--- a/packages/docs/src/routes/(routes)/components/swap/+page.md
+++ b/packages/docs/src/routes/(routes)/components/swap/+page.md
@@ -17,6 +17,8 @@ classnames:
   modifier:
   - class: swap-active
     desc: Activates the swap (no need for checkbox)
+  - class: swap-multi
+    desc: Swap between any number of items using radio inputs
   style:
   - class: swap-rotate
     desc: Adds rotate effect to swap
@@ -190,4 +192,31 @@ classnames:
   <div class="$$swap-on">🥳</div>
   <div class="$$swap-off">😭</div>
 </label>
+```
+
+### ~Swap between multiple items
+#### Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group
+
+<div class="swap swap-multi text-6xl">
+  <input type="radio" name="swap-mood" aria-label="Happy" autocomplete="off" checked="checked" />
+  <div>😀</div>
+  <input type="radio" name="swap-mood" aria-label="Cool" autocomplete="off" />
+  <div>😎</div>
+  <input type="radio" name="swap-mood" aria-label="Surprised" autocomplete="off" />
+  <div>🤯</div>
+  <input type="radio" name="swap-mood" aria-label="Sleepy" autocomplete="off" />
+  <div>😴</div>
+</div>
+
+```html
+<div class="$$swap $$swap-multi text-6xl">
+  <input type="radio" name="swap-mood" aria-label="Happy" autocomplete="off" checked="checked" />
+  <div>😀</div>
+  <input type="radio" name="swap-mood" aria-label="Cool" autocomplete="off" />
+  <div>😎</div>
+  <input type="radio" name="swap-mood" aria-label="Surprised" autocomplete="off" />
+  <div>🤯</div>
+  <input type="radio" name="swap-mood" aria-label="Sleepy" autocomplete="off" />
+  <div>😴</div>
+</div>
 ```

--- a/packages/docs/src/translation/ar.components.json
+++ b/packages/docs/src/translation/ar.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "يعمل Modal مع Checkbox المخفي ويمكن لـ Labels Toggle وCheckbox حتى نتمكن من استخدام علامة Label أخرى مع فئة \"Modal-backdrop\" التي تغطي الشاشة حتى نتمكن من إغلاق Modal عند النقر بالخارج",
   "Dialog modal with a close button at corner": "حوار Modal مع إغلاق Button في الزاوية",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "بدلاً من العمل بالنقر، فإنه يظهر عنصر Swap-on إذا قمت بإضافة Swap-active Class name. يمكنك إضافة أو إزالة فئة Swap النشطة باستخدام JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "هناك 3 طرق لاستخدام القوائم المنسدلة",
   "Method 1. details and summary": "الطريقة الأولى: التفاصيل والملخص",
   "Method 2. popover API and anchor positioning": "الطريقة الثانية: واجهة برمجة التطبيقات المنبثقة وتحديد موضع المرساة",

--- a/packages/docs/src/translation/bn.components.json
+++ b/packages/docs/src/translation/bn.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal একটি লুকানো Checkbox এর সাথে কাজ করে এবং Labelগুলি Checkbox কে Toggle করতে পারে তাই আমরা 'Modal-ব্যাকড্রপ' ক্লাস সহ আরেকটি Label ট্যাগ ব্যবহার করতে পারি যা স্ক্রীনকে কভার করে যাতে বাইরে ক্লিক করলে আমরা Modal বন্ধ করতে পারি",
   "Dialog modal with a close button at corner": "Modal ডায়ালগ কোণে একটি কাছাকাছি Button সহ",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "ক্লিকের সাথে কাজ করার পরিবর্তে, আপনি Swap- সক্রিয় Class name যোগ করলে এটি Swap-অন আইটেম দেখায়। আপনি JS ব্যবহার করে Swap- সক্রিয় ক্লাস যোগ করতে বা সরাতে পারেন",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "একটি ড্রপডাউন ব্যবহার করার জন্য 3টি পদ্ধতি রয়েছে",
   "Method 1. details and summary": "পদ্ধতি 1. বিশদ বিবরণ এবং সারাংশ",
   "Method 2. popover API and anchor positioning": "পদ্ধতি 2. পপওভার API এবং অ্যাঙ্কর পজিশনিং",

--- a/packages/docs/src/translation/ca.components.json
+++ b/packages/docs/src/translation/ca.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal funciona amb una casella de selecció oculta i els labels poden activar la casella de selecció perquè puguem utilitzar un altre label amb la classe 'modal-backdrop' que cobreix la pantalla perquè puguem tancar el modal quan fem clic fora",
   "Dialog modal with a close button at corner": "Modal de diàleg amb un botó de tancament a la cantonada.",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "En lloc de funcionar amb el clic, mostra l'element d'intercanvi si afegeix la classe swap-active. Pots afegir o eliminar la classe swap-active mitjançant JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Hi ha 3 mètodes per utilitzar un menú desplegable",
   "Method 1. details and summary": "Mètode 1. detalls i resum",
   "Method 2. popover API and anchor positioning": "Mètode 2. API popover i posicionament d'ancoratge",

--- a/packages/docs/src/translation/cs.components.json
+++ b/packages/docs/src/translation/cs.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal okno funguje se skrytým checkboxem a štítky mohou přepínat checkbox, takže můžeme použít další štítek s třídou 'modal-backdrop', který pokrývá obrazovku, takže můžeme zavřít Modal okno při kliknutí mimo",
   "Dialog modal with a close button at corner": "Dialogové Modal okno s tlačítkem zavření v rohu",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Místo práce s kliknutím zobrazuje položku swap-on, pokud přidáte název třídy swap-active. Můžete přidat nebo odebrat třídu swap-active pomocí JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Existují 3 způsoby, jak použít rozevírací seznamy",
   "Method 1. details and summary": "Metoda 1. podrobnosti a shrnutí",
   "Method 2. popover API and anchor positioning": "Metoda 2. Popover API a umístění kotvy",

--- a/packages/docs/src/translation/de.components.json
+++ b/packages/docs/src/translation/de.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal funktioniert mit einer versteckten Checkbox, und Labels können die Checkbox mit Toggle umschalten. So können wir ein weiteres Label-Tag mit der Klasse 'modal-backdrop' verwenden, das den Bildschirm abdeckt, damit wir das Modal schließen können, wenn außerhalb geklickt wird",
   "Dialog modal with a close button at corner": "Dialog Modal mit einem schließenden Button an der Ecke",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Anstatt mit einem Klick zu arbeiten, wird das Swap-on-Element angezeigt, wenn Sie Swap-aktives Class name hinzufügen. Sie können die Swap-aktive Klasse mithilfe von JS hinzufügen oder entfernen",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Es gibt drei Methoden, Dropdowns zu verwenden",
   "Method 1. details and summary": "Methode 1. Details und Zusammenfassung",
   "Method 2. popover API and anchor positioning": "Methode 2. Popover-API und Ankerpositionierung",

--- a/packages/docs/src/translation/el.components.json
+++ b/packages/docs/src/translation/el.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Το Modal λειτουργεί με ένα κρυφό πλαίσιο ελέγχου και οι ετικέτες μπορούν να αλλάξουν το πλαίσιο ελέγχου, ώστε να μπορούμε να χρησιμοποιήσουμε μια άλλη ετικέτα με την κλάση 'modal-backdrop' που καλύπτει την οθόνη, ώστε να μπορούμε να κλείσουμε το modal όταν κάνουμε κλικ έξω",
   "Dialog modal with a close button at corner": "Modal διαλόγου με κουμπί κλεισίματος στη γωνία",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Αντί να λειτουργεί με κλικ, εμφανίζει το στοιχείο swap-on εάν προσθέσετε όνομα κλάσης swap-active. Μπορείτε να προσθέσετε ή να αφαιρέσετε κλάση swap-active χρησιμοποιώντας το JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Υπάρχουν 3 μέθοδοι για να χρησιμοποιήσετε ένα αναπτυσσόμενο μενού",
   "Method 1. details and summary": "Μέθοδος 1. λεπτομέρειες και περίληψη",
   "Method 2. popover API and anchor positioning": "Μέθοδος 2. popover API και τοποθέτηση αγκύρωσης",

--- a/packages/docs/src/translation/en.components.json
+++ b/packages/docs/src/translation/en.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside",
   "Dialog modal with a close button at corner": "Dialog modal with a close button at corner",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "There are 3 methods to use a dropdowns",
   "Method 1. details and summary": "Method 1. details and summary",
   "Method 2. popover API and anchor positioning": "Method 2. popover API and anchor positioning",

--- a/packages/docs/src/translation/es.components.json
+++ b/packages/docs/src/translation/es.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal funciona con un Checkbox oculto y los Label pueden Toggle el Checkbox, por lo que podemos usar otra etiqueta Label con la clase 'Modal-backdrop' que cubre la pantalla para que podamos cerrar el Modal cuando se hace clic afuera.",
   "Dialog modal with a close button at corner": "Diálogo Modal con un cierre Button en la esquina",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "En lugar de trabajar con un clic, muestra el elemento Swap activado si agrega Class name activo Swap. Puede agregar o eliminar la clase activa Swap usando JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Hay 3 métodos para usar menús desplegables",
   "Method 1. details and summary": "Método 1. detalles y resumen",
   "Method 2. popover API and anchor positioning": "Método 2. API popover y posicionamiento de anclaje",

--- a/packages/docs/src/translation/fa.components.json
+++ b/packages/docs/src/translation/fa.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "مودال با یک checkbox پنهان کار می‌کند و برچسب‌ها می‌توانند checkbox را تغییر دهند، بنابراین می‌توانیم از برچسب دیگری با کلاس 'modal-backdrop' استفاده کنیم که صفحه را می‌پوشاند تا بتوانیم هنگام کلیک در بیرون، مودال را ببندیم",
   "Dialog modal with a close button at corner": "مودال Dialog با دکمه بستن در گوشه",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "به جای کار با کلیک، اگر نام کلاس swap-active را اضافه کنید، آیتم swap-on را نشان می‌دهد. می‌توانید کلاس swap-active را با استفاده از JS اضافه یا حذف کنید",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "3 روش برای استفاده از dropdown وجود دارد",
   "Method 1. details and summary": "روش 1. details و summary",
   "Method 2. popover API and anchor positioning": "روش 2. popover API و موقعیت‌یابی anchor",

--- a/packages/docs/src/translation/fr.components.json
+++ b/packages/docs/src/translation/fr.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "La fenêtre modale fonctionne avec une checkbox cachée et les étiquettes peuvent activer/désactiver la checkbox. Nous pouvons utiliser un autre tag d'étiquette avec la classe 'modal-backdrop' qui couvre l'écran, ce qui nous permet de fermer la fenêtre modale lorsque l'on clique à l'extérieur",
   "Dialog modal with a close button at corner": "Fenêtre modale de dialogue avec un bouton de fermeture dans le coin",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Au lieu de fonctionner avec un clic, il affiche l'élément swap-on si vous ajoutez le nom de la classe swap-active. Vous pouvez ajouter ou supprimer la classe swap-active en utilisant JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Il existe 3 méthodes pour utiliser une liste déroulante",
   "Method 1. details and summary": "Méthode 1. détails et résumé",
   "Method 2. popover API and anchor positioning": "Méthode 2. API popover et positionnement de l'ancre",

--- a/packages/docs/src/translation/he.components.json
+++ b/packages/docs/src/translation/he.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal עובד עם תיבת סימון נסתרת ותוויות יכולות לשנות את תיבת הסימון כדי שנוכל להשתמש בתגית תווית אחרת עם מחלקה ' modal-backdrop ' המכסה את המסך כדי שנוכל לסגור את המודאל כאשר לוחצים עליו בחוץ",
   "Dialog modal with a close button at corner": "מודל דיאלוג עם כפתור סגירה בפינה",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "במקום לעבוד עם קליק, הוא מציג פריט swap-on אם תוסיף את שם המחלקה swap-active. אתה יכול להוסיף או להסיר מחלקה swap-active באמצעות JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "ישנן 3 שיטות להשתמש בתפריטים נפתחים",
   "Method 1. details and summary": "שיטה 1. פירוט וסיכום",
   "Method 2. popover API and anchor positioning": "שיטה 2. popover API ומיקום עוגן",

--- a/packages/docs/src/translation/hu.components.json
+++ b/packages/docs/src/translation/hu.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "A modal egy rejtett checkbox-szal működik, és a címkék (label) képesek kapcsolgatni ezt a checkbox-ot, így használhatunk egy másik label taget modal-backdrop osztállyal, amely lefedi a képernyőt — így a modal bezárható, ha a háttérre kattintunk",
   "Dialog modal with a close button at corner": "Dialog modal bezáró gombbal a sarokban",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Kattintás helyett a swap-on elem akkor jelenik meg, ha hozzáadod a swap-active osztálynevet. A swap-active osztályt JS segítségével hozzáadhatod vagy eltávolíthatod",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Három módszer van a dropdown használatára:",
   "Method 1. details and summary": "1. Módszer: details és summary",
   "Method 2. popover API and anchor positioning": "2. Módszer: Popover API és anchor pozicionálás",

--- a/packages/docs/src/translation/id.components.json
+++ b/packages/docs/src/translation/id.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal bekerja dengan Checkbox yang tersembunyi dan Label dapat Toggle Checkbox sehingga kita dapat menggunakan tag Label lain dengan kelas 'Modal-backdrop' yang menutupi layar sehingga kita dapat menutup Modal ketika diklik di luar",
   "Dialog modal with a close button at corner": "Dialog Modal dengan Button dekat di sudut",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Alih-alih bekerja dengan klik, ini menampilkan item Swap-on jika Anda menambahkan Swap-aktif Class name. Anda dapat menambah atau menghapus kelas aktif Swap menggunakan JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Ada 3 metode untuk menggunakan dropdown",
   "Method 1. details and summary": "Metode 1. detail dan ringkasan",
   "Method 2. popover API and anchor positioning": "Metode 2. API popover dan penentuan posisi jangkar",

--- a/packages/docs/src/translation/it.components.json
+++ b/packages/docs/src/translation/it.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal funziona con un Checkbox nascosto e Label può Toggle Checkbox quindi possiamo usare un altro tag Label con la classe 'Modal-backdrop' che copre lo schermo in modo da poter chiudere Modal quando si fa clic all'esterno",
   "Dialog modal with a close button at corner": "Dialogo Modal con una Button ravvicinata all'angolo",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Invece di lavorare con il clic, mostra l'elemento Swap-on se aggiungi Class name attivo Swap. Puoi aggiungere o rimuovere la classe attiva Swap utilizzando JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Esistono 3 metodi per utilizzare un menu a discesa",
   "Method 1. details and summary": "Metodo 1. dettagli e riepilogo",
   "Method 2. popover API and anchor positioning": "Metodo 2. API popover e posizionamento dell'ancora",

--- a/packages/docs/src/translation/ja.components.json
+++ b/packages/docs/src/translation/ja.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "このモーダルは、チェックボックスをトグルすることのできる隠しチェックボックスと隠しラベルを含んでいます。そのため、スクリーン全体を覆うクラス名'modal-backdrop'を持った別のラベルタグを使用できます。したがって、モーダル範囲外をクリックするとモーダルが閉じます。",
   "Dialog modal with a close button at corner": "コーナーでクローズ Button を伴うダイアログ Modal",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "クリックで作動する代わりに、クラス名swap-activeを付与することでswap-onアイテムを表示します。クラスswap-activeはJavaScriptを使用して追加または削除することができます。",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "ドロップダウンを使用するには 3 つの方法があります",
   "Method 1. details and summary": "方法1. 詳細と概要",
   "Method 2. popover API and anchor positioning": "方法 2. ポップオーバー API とアンカーの位置決め",

--- a/packages/docs/src/translation/ko.components.json
+++ b/packages/docs/src/translation/ko.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal는 숨겨진 Checkbox와 함께 작동하며 Label는 Checkbox를 Toggle할 수 있으므로 화면을 덮는 'Modal-backdrop' 클래스가 있는 다른 Label 태그를 사용할 수 있으므로 외부를 클릭하면 Modal를 닫을 수 있습니다.",
   "Dialog modal with a close button at corner": "모서리에 닫기 버튼이 있는 대화 상자 모달",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Instead of working with click, it shows swap-on item if you add swap-active class name. JS를 사용하여 스왑 활성 클래스를 추가하거나 제거할 수 있습니다.",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "드롭다운을 사용하는 방법에는 3가지가 있습니다.",
   "Method 1. details and summary": "방법 1. 세부정보 및 요약",
   "Method 2. popover API and anchor positioning": "방법 2. 팝오버 API 및 앵커 위치 지정",

--- a/packages/docs/src/translation/ms.components.json
+++ b/packages/docs/src/translation/ms.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal berfungsi dengan Checkbox tersembunyi dan Labels boleh Toggle Checkbox supaya kami boleh menggunakan teg Label lain dengan kelas 'Modal-tirai latar' yang menutup skrin supaya kami boleh menutup Modal apabila diklik di luar",
   "Dialog modal with a close button at corner": "Dialog Modal dengan Button dekat di sudut",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Daripada bekerja dengan klik, ia menunjukkan item Swap-on jika anda menambah Swap-active Class name. Anda boleh menambah atau mengalih keluar kelas Swap-aktif menggunakan JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Terdapat 3 kaedah untuk menggunakan dropdown",
   "Method 1. details and summary": "Kaedah 1. butiran dan ringkasan",
   "Method 2. popover API and anchor positioning": "Kaedah 2. popover API dan penentududukan sauh",

--- a/packages/docs/src/translation/pl.components.json
+++ b/packages/docs/src/translation/pl.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal działa z ukrytym checkboxem, a etykiety mogą przełączać checkbox, więc możemy użyć innego tagu label z klasą 'modal-backdrop', który pokrywa ekran, aby zamknąć modal po kliknięciu na zewnątrz",
   "Dialog modal with a close button at corner": "Modal dialogowy z przyciskiem zamknięcia w rogu",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Zamiast działać na kliknięcie, pokazuje element swap-on, jeśli dodasz klasę swap-active. Możesz dodawać lub usuwać klasę swap-active za pomocą JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Istnieją 3 metody korzystania z list rozwijanych",
   "Method 1. details and summary": "Metoda 1. szczegóły i podsumowanie",
   "Method 2. popover API and anchor positioning": "Metoda 2. Popover API i pozycjonowanie kotwicy",

--- a/packages/docs/src/translation/pt.components.json
+++ b/packages/docs/src/translation/pt.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal funciona com um Checkbox oculto e Labels podem Toggle o Checkbox para que possamos usar outra tag Label com classe 'Modal-backdrop' que cobre a tela para que possamos fechar o Modal quando clicado fora",
   "Dialog modal with a close button at corner": "Diálogo Modal com um Button próximo no canto",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Em vez de trabalhar com clique, ele mostra o item Swap ativado se você adicionar Class name ativo Swap. Você pode adicionar ou remover a classe ativa Swap usando JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Existem 3 métodos para usar menus suspensos",
   "Method 1. details and summary": "Método 1. detalhes e resumo",
   "Method 2. popover API and anchor positioning": "Método 2. API popover e posicionamento de âncora",

--- a/packages/docs/src/translation/ro.components.json
+++ b/packages/docs/src/translation/ro.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal funcționează cu un Checkbox ascuns și Label-urile pot Toggle Checkbox, astfel încât să putem folosi o altă etichetă Label cu clasa „Modal-backdrop” care acoperă ecranul, astfel încât să putem închide Modal când facem clic în exterior",
   "Dialog modal with a close button at corner": "Dialog Modal cu un Button apropiat la colț",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "În loc să lucreze cu clic, acesta arată elementul Swap-on dacă adăugați Swap-activ Class name. Puteți adăuga sau elimina clasa activă Swap folosind JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Există 3 metode de a utiliza meniurile derulante",
   "Method 1. details and summary": "Metoda 1. detalii și rezumat",
   "Method 2. popover API and anchor positioning": "Metoda 2. API popover și poziționarea ancorelor",

--- a/packages/docs/src/translation/ru.components.json
+++ b/packages/docs/src/translation/ru.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal работает со скрытым Checkbox, а Label может использовать Toggle для Checkbox, поэтому мы можем использовать другой тег Label с классом Modal-backdrop, который закрывает экран, чтобы мы могли закрыть Modal при нажатии снаружи.",
   "Dialog modal with a close button at corner": "Диалог Modal с закрытым Button в углу",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Вместо работы по щелчку отображается элемент Swap-on, если вы добавляете Swap-активный Class name. Вы можете добавить или удалить активный класс Swap с помощью JS.",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Существует 3 способа использования раскрывающихся списков.",
   "Method 1. details and summary": "Способ 1. подробности и краткое содержание",
   "Method 2. popover API and anchor positioning": "Способ 2. API popover и позиционирование привязки",

--- a/packages/docs/src/translation/tr.components.json
+++ b/packages/docs/src/translation/tr.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal gizli bir onay kutusuyla çalışır ve etiketler onay kutusunu değiştirebilir, böylece ekranı kaplayan ' modal-backdrop ' sınıfına sahip başka bir etiket etiketi kullanabiliriz, böylece dışarıya tıklandığında kipi kapatabiliriz",
   "Dialog modal with a close button at corner": "Köşede kapat düğmesi bulunan diyalog modeli",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Tıklamayla çalışmak yerine swap-active sınıf adını eklerseniz swap-on öğesini gösterir. JS'i kullanarak swap-active sınıfını ekleyebilir veya kaldırabilirsiniz",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Açılır menüyü kullanmanın 3 yöntemi vardır",
   "Method 1. details and summary": "Yöntem 1. ayrıntılar ve özet",
   "Method 2. popover API and anchor positioning": "Yöntem 2. açılır pencere API ve bağlantı konumlandırma",

--- a/packages/docs/src/translation/uk.components.json
+++ b/packages/docs/src/translation/uk.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal працює з прихованим Checkbox, а Labels може Toggle Checkbox, щоб ми могли використовувати інший тег Label із класом «Modal-backdrop», який закриває екран, щоб ми могли закрити Modal, коли клацнемо зовні",
   "Dialog modal with a close button at corner": "Діалог Modal із закритим Button у кутку",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Замість роботи з клацанням, він показує елемент Swap-on, якщо ви додаєте Swap-active Class name. Ви можете додати або видалити Swap-активний клас за допомогою JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Існує 3 способи використання спадних меню",
   "Method 1. details and summary": "Спосіб 1. деталі та резюме",
   "Method 2. popover API and anchor positioning": "Спосіб 2. Popover API і позиціонування прив’язки",

--- a/packages/docs/src/translation/ur.components.json
+++ b/packages/docs/src/translation/ur.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal ایک چھپے ہوئے چیک باکس کے ساتھ کام کرتا ہے اور لیبل چیک باکس کو ٹوگل کر سکتے ہیں تاکہ ہم 'modal-backdrop' کلاس کے ساتھ ایک اور لیبل ٹیگ استعمال کر سکیں جو اسکرین کا احاطہ کرتا ہے تاکہ باہر کلک کرنے پر ہم موڈل کو بند کر سکیں",
   "Dialog modal with a close button at corner": "کونے میں بند بٹن کے ساتھ ڈائیلاگ موڈل",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "کلک کے ساتھ کام کرنے کے بجائے، اگر آپ swap-active کلاس کا نام شامل کرتے ہیں تو یہ swap-on آئٹم دکھاتا ہے۔ آپ JS کا استعمال کرتے ہوئے swap-active کلاس کو شامل یا ہٹا سکتے ہیں۔",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "ڈراپ ڈاؤن استعمال کرنے کے 3 طریقے ہیں۔",
   "Method 1. details and summary": "طریقہ 1. تفصیلات اور خلاصہ",
   "Method 2. popover API and anchor positioning": "طریقہ 2. پاپ اوور API اور اینکر پوزیشننگ",

--- a/packages/docs/src/translation/vi.components.json
+++ b/packages/docs/src/translation/vi.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal hoạt động với Checkbox ẩn và Label có thể Toggle Checkbox để chúng ta có thể sử dụng một thẻ Label khác có lớp 'Modal-backdrop' che phủ màn hình để chúng ta có thể đóng Modal khi nhấp vào bên ngoài",
   "Dialog modal with a close button at corner": "Hộp thoại Modal có Button đóng ở góc",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "Thay vì làm việc với nhấp chuột, nó hiển thị mục Swap-on nếu bạn thêm Swap-active Class name. Bạn có thể thêm hoặc xóa lớp hoạt động Swap bằng JS",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "Có 3 phương pháp để sử dụng menu thả xuống",
   "Method 1. details and summary": "Cách 1. chi tiết và tóm tắt",
   "Method 2. popover API and anchor positioning": "Phương pháp 2. API popover và định vị neo",

--- a/packages/docs/src/translation/zh_hans.components.json
+++ b/packages/docs/src/translation/zh_hans.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "对话框通过一个隐藏的复选框工作，标签可以切换复选框的状态。因此，我们可以使用另一个带有 'modal-backdrop' 类的标签来覆盖屏幕，这样当点击对话框外部时就可以关闭它。",
   "Dialog modal with a close button at corner": "在角落带有关闭按钮的对话框",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "此方式不依赖于点击，而是通过添加 swap-active 类名来显示 swap-on 项。您可以使用 JS 来添加或移除 swap-active 类。",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "有 3 种方法可以使用下拉菜单",
   "Method 1. details and summary": "方法 1. details 和 summary 标签",
   "Method 2. popover API and anchor positioning": "方法 2. Popover API 和锚点定位",

--- a/packages/docs/src/translation/zh_hant.components.json
+++ b/packages/docs/src/translation/zh_hant.components.json
@@ -89,6 +89,7 @@
   "Modal works with a hidden checkbox and labels can toggle the checkbox so we can use another label tag with 'modal-backdrop' class that covers the screen so we can close the modal when clicked outside": "Modal 與隱藏的 Checkbox 配合使用，Label 可以 Toggle Checkbox，因此我們可以使用另一個帶有「Modal-backdrop」類別的 Label 標籤來覆蓋螢幕，這樣我們就可以在點擊外部時關閉 Modal",
   "Dialog modal with a close button at corner": "對話 Modal，轉角處有一個關閉的 Button",
   "Instead of working with click, it shows swap-on item if you add swap-active class name. You can add or remove swap-active class using JS": "如果您新增 Swap-active Class name，它會顯示 Swap-on 項目，而不是使用點擊。您可以使用 JS 新增或刪除 Swap-active 類",
+  "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group": "Add radio inputs before each item and every click shows the next item. Arrow keys work too, because it is a radio group",
   "There are 3 methods to use a dropdowns": "有 3 種使用下拉式選單的方法",
   "Method 1. details and summary": "方法一、詳情及總結",
   "Method 2. popover API and anchor positioning": "方法2.popover API和anchor定位",

--- a/skills/daisyui/components/swap.md
+++ b/skills/daisyui/components/swap.md
@@ -6,7 +6,7 @@ Use the swap component to change the visibility of two elements. Control the swa
 #### Class names
 - component: `swap`
 - part: `swap-on`, `swap-off`, `swap-indeterminate`
-- modifier: `swap-active`
+- modifier: `swap-active`, `swap-multi`
 - style: `swap-rotate`, `swap-flip`
 
 #### Syntax
@@ -31,3 +31,4 @@ Class name:
 - `{MODIFIER}` is optional. It can include one modifier class name and one style class name.
 - Use only a hidden checkbox to control the swap state. As an alternative, use JavaScript to add or remove the `swap-active` class.
 - To show content when the checkbox is indeterminate, use the `swap-indeterminate` class.
+- To swap between more than two items, use the `swap-multi` class and put a radio input before each item. Every click shows the next item.


### PR DESCRIPTION
"swap with multiple items" from the roadmap. put a radio input before each item, the checked one shows its item and the input after it sits on top, so every click shows the next item and it wraps around. pure css, arrow keys work too since it is a radio group, classic 2-state swap untouched.

demo: https://play.tailwindcss.com/LmMO71fCSL
