### PR TITLE
feat(marquee): add marquee component for infinite scrolling content

### DIFF
--- a/packages/daisyui/build.js
+++ b/packages/daisyui/build.js
@@ -107,6 +107,7 @@ async function generateFiles() {
           "validator",
           "hover3d",
           "textrotate",
+          "marquee",
         ],
         layer: "utilities",
       }),

--- a/packages/daisyui/src/components/marquee.css
+++ b/packages/daisyui/src/components/marquee.css
@@ -1,0 +1,60 @@
+.marquee {
+  @layer daisyui.l1.l2.l3 {
+    @apply flex items-center overflow-hidden;
+    --marquee-duration: 30s;
+    --marquee-dir: 1;
+    &:dir(rtl) {
+      --marquee-dir: -1;
+    }
+
+    > * {
+      @apply flex shrink-0 items-center;
+      min-width: 100%;
+      animation: marquee var(--marquee-duration) linear infinite;
+      @media (prefers-reduced-motion: reduce) {
+        animation-play-state: paused;
+      }
+    }
+  }
+}
+
+.marquee-reverse {
+  @layer daisyui.l1.l2 {
+    > * {
+      animation-direction: reverse;
+    }
+  }
+}
+
+.marquee-vertical {
+  @layer daisyui.l1.l2 {
+    @apply flex-col;
+
+    > * {
+      @apply flex-col;
+      min-width: 0;
+      min-height: 100%;
+      animation-name: marquee-vertical;
+    }
+  }
+}
+
+.marquee-pause-hover {
+  @layer daisyui.l1.l2 {
+    &:hover > * {
+      animation-play-state: paused;
+    }
+  }
+}
+
+@keyframes marquee {
+  to {
+    translate: calc(var(--marquee-dir, 1) * -100%) 0;
+  }
+}
+
+@keyframes marquee-vertical {
+  to {
+    translate: 0 -100%;
+  }
+}

--- a/packages/docs/src/lib/data/navigation.yaml
+++ b/packages/docs/src/lib/data/navigation.yaml
@@ -193,6 +193,8 @@ sidebar:
           href: "/components/kbd/"
         - name: "List"
           href: "/components/list/"
+        - name: "Marquee"
+          href: "/components/marquee/"
         - name: "Stat"
           href: "/components/stat/"
         - name: "Status"

--- a/packages/docs/src/routes/(routes)/components/marquee/+page.md
+++ b/packages/docs/src/routes/(routes)/components/marquee/+page.md
@@ -1,0 +1,148 @@
+---
+title: Marquee
+desc: Marquee scrolls its content in an infinite loop. It pauses for reduced motion preference and scrolls the other way in RTL layouts automatically.
+source: https://raw.githubusercontent.com/saadeghi/daisyui/refs/heads/master/packages/daisyui/src/components/marquee.css
+layout: components
+classnames:
+  component:
+  - class: marquee
+    desc: Marquee container, needs two copies of the content
+  modifier:
+  - class: marquee-reverse
+    desc: Scrolls the other way
+  - class: marquee-vertical
+    desc: Scrolls vertically
+  - class: marquee-pause-hover
+    desc: Pauses the animation on hover
+---
+
+<script>
+  import Component from "$components/Component.svelte"
+  import Translate from "$components/Translate.svelte"
+</script>
+
+### ~Marquee
+#### Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden
+<div class="marquee bg-base-200 rounded-box max-w-md">
+  <div class="gap-8 pe-8 py-3">
+    <span class="badge badge-neutral">daisyUI</span>
+    <span class="badge badge-primary">Tailwind CSS</span>
+    <span class="badge badge-secondary">Components</span>
+    <span class="badge badge-accent">Themes</span>
+  </div>
+  <div class="gap-8 pe-8 py-3" aria-hidden="true">
+    <span class="badge badge-neutral">daisyUI</span>
+    <span class="badge badge-primary">Tailwind CSS</span>
+    <span class="badge badge-secondary">Components</span>
+    <span class="badge badge-accent">Themes</span>
+  </div>
+</div>
+
+```html
+<div class="$$marquee">
+  <div class="gap-8 pe-8 py-3">
+    <span class="$$badge $$badge-neutral">daisyUI</span>
+    <span class="$$badge $$badge-primary">Tailwind CSS</span>
+    <span class="$$badge $$badge-secondary">Components</span>
+    <span class="$$badge $$badge-accent">Themes</span>
+  </div>
+  <div class="gap-8 pe-8 py-3" aria-hidden="true">
+    <span class="$$badge $$badge-neutral">daisyUI</span>
+    <span class="$$badge $$badge-primary">Tailwind CSS</span>
+    <span class="$$badge $$badge-secondary">Components</span>
+    <span class="$$badge $$badge-accent">Themes</span>
+  </div>
+</div>
+```
+
+### ~Reverse direction, pause on hover
+<div class="marquee marquee-reverse marquee-pause-hover bg-base-200 rounded-box max-w-md">
+  <div class="gap-8 pe-8 py-3">
+    <span>One</span>
+    <span>Two</span>
+    <span>Three</span>
+    <span>Four</span>
+  </div>
+  <div class="gap-8 pe-8 py-3" aria-hidden="true">
+    <span>One</span>
+    <span>Two</span>
+    <span>Three</span>
+    <span>Four</span>
+  </div>
+</div>
+
+```html
+<div class="$$marquee $$marquee-reverse $$marquee-pause-hover">
+  <div class="gap-8 pe-8 py-3">
+    <span>One</span>
+    <span>Two</span>
+    <span>Three</span>
+    <span>Four</span>
+  </div>
+  <div class="gap-8 pe-8 py-3" aria-hidden="true">
+    <span>One</span>
+    <span>Two</span>
+    <span>Three</span>
+    <span>Four</span>
+  </div>
+</div>
+```
+
+### ~Vertical marquee
+<div class="marquee marquee-vertical bg-base-200 rounded-box h-32 w-64">
+  <div class="gap-4 pb-4 px-4">
+    <span>Great component library</span>
+    <span>Love the themes</span>
+    <span>So easy to use</span>
+  </div>
+  <div class="gap-4 pb-4 px-4" aria-hidden="true">
+    <span>Great component library</span>
+    <span>Love the themes</span>
+    <span>So easy to use</span>
+  </div>
+</div>
+
+```html
+<div class="$$marquee $$marquee-vertical h-32">
+  <div class="gap-4 pb-4 px-4">
+    <span>Great component library</span>
+    <span>Love the themes</span>
+    <span>So easy to use</span>
+  </div>
+  <div class="gap-4 pb-4 px-4" aria-hidden="true">
+    <span>Great component library</span>
+    <span>Love the themes</span>
+    <span>So easy to use</span>
+  </div>
+</div>
+```
+
+### ~Custom speed
+#### Set the duration of one full loop using the --marquee-duration CSS variable
+<div class="marquee [--marquee-duration:5s] bg-base-200 rounded-box max-w-md">
+  <div class="gap-8 pe-8 py-3">
+    <span>fast</span>
+    <span>faster</span>
+    <span>fastest</span>
+  </div>
+  <div class="gap-8 pe-8 py-3" aria-hidden="true">
+    <span>fast</span>
+    <span>faster</span>
+    <span>fastest</span>
+  </div>
+</div>
+
+```html
+<div class="$$marquee [--marquee-duration:5s]">
+  <div class="gap-8 pe-8 py-3">
+    <span>fast</span>
+    <span>faster</span>
+    <span>fastest</span>
+  </div>
+  <div class="gap-8 pe-8 py-3" aria-hidden="true">
+    <span>fast</span>
+    <span>faster</span>
+    <span>fastest</span>
+  </div>
+</div>
+```

--- a/packages/docs/src/translation/ar.components.json
+++ b/packages/docs/src/translation/ar.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API هو معيار HTML الجديد لإنشاء القوائم المنسدلة.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "يشبه Popover الحوار ولكنه لا يزال يسمح بالتركيز على عناصر الخلفية. يمكن الوصول إليه ويمكننا إغلاق Modal باستخدام مفتاح `Esc`.",
   "Rotates through 3 words, in 10 seconds": "تدور من خلال 3 كلمات، في 10 ثانية",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "الخدمات",
   "size of component or part": "حجم Component أو جزء",
   "Text labels for each button": "تسميات نصية لكل Button",

--- a/packages/docs/src/translation/bn.components.json
+++ b/packages/docs/src/translation/bn.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API হল ড্রপডাউন তৈরির জন্য নতুন HTML স্ট্যান্ডার্ড।",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "পপওভার ডায়ালগের মতো কিন্তু এটি এখনও পটভূমি উপাদানগুলিতে ফোকাস করার অনুমতি দেয়৷ এটি অ্যাক্সেসযোগ্য এবং আমরা `Esc` কী ব্যবহার করে Modal বন্ধ করতে পারি।",
   "Rotates through 3 words, in 10 seconds": "10 সেকেন্ডে 3টি শব্দের মাধ্যমে ঘোরে৷",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "সেবা",
   "size of component or part": "Component বা অংশের আকার",
   "Text labels for each button": "প্রতিটি Button এর জন্য পাঠ্য লেবেল",

--- a/packages/docs/src/translation/ca.components.json
+++ b/packages/docs/src/translation/ca.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API és el nou estàndard HTML per crear menús desplegables.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "El popover és similar al diàleg, però encara permet centrar-se en els elements de fons. És accessible i podem tancar el modal amb la tecla `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Gira 3 paraules, en 10 segons",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Serveis",
   "size of component or part": "mida del component o peça",
   "Text labels for each button": "Etiquetes de text per a cada Button",

--- a/packages/docs/src/translation/cs.components.json
+++ b/packages/docs/src/translation/cs.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API je nový standard HTML pro vytváření rozevíracích seznamů.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover je podobný dialogu, ale stále umožňuje zaostření na prvky pozadí. Je přístupný a modal můžeme zavřít klávesou `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Otočí 3 slova za 10 sekund",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Služby",
   "size of component or part": "velikost Component nebo části",
   "Text labels for each button": "Textové štítky pro každý Button",

--- a/packages/docs/src/translation/de.components.json
+++ b/packages/docs/src/translation/de.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Die Popover-API ist der neue HTML-Standard zum Erstellen von Dropdowns.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover ähnelt dem Dialog, ermöglicht aber dennoch die Fokussierung auf die Hintergrundelemente. Es ist zugänglich und wir können das Modal mit der Taste `Esc` schließen.",
   "Rotates through 3 words, in 10 seconds": "Dreht sich in 10 Sekunden durch 3 Wörter",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Dienstleistungen",
   "size of component or part": "Größe von Component oder Teil",
   "Text labels for each button": "Textbeschriftungen für jedes Button",

--- a/packages/docs/src/translation/el.components.json
+++ b/packages/docs/src/translation/el.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Το Popover API είναι το νέο πρότυπο HTML για τη δημιουργία αναπτυσσόμενων.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Το Popover είναι παρόμοιο με το παράθυρο διαλόγου, αλλά εξακολουθεί να επιτρέπει την εστίαση στα στοιχεία του φόντου. Είναι προσβάσιμο και μπορούμε να κλείσουμε το modal χρησιμοποιώντας το κλειδί `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Περιστρέφεται σε 3 λέξεις, σε 10 δευτερόλεπτα",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Services",
   "size of component or part": "μέγεθος εξαρτήματος ή εξαρτήματος",
   "Text labels for each button": "Ετικέτες κειμένου για κάθε κουμπί",

--- a/packages/docs/src/translation/en.components.json
+++ b/packages/docs/src/translation/en.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API is the new HTML standard for creating dropdowns.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.",
   "Rotates through 3 words, in 10 seconds": "Rotates through 3 words, in 10 seconds",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Services",
   "size of component or part": "size of component or part",
   "Text labels for each button": "Text labels for each button",

--- a/packages/docs/src/translation/es.components.json
+++ b/packages/docs/src/translation/es.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API es el nuevo estándar HTML para crear menús desplegables.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "La ventana emergente es similar al diálogo pero aún permite centrarse en los elementos del fondo. Es accesible y podemos cerrar el modal usando la tecla `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Gira 3 palabras, en 10 segundos.",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Servicios",
   "size of component or part": "tamaño del componente o pieza",
   "Text labels for each button": "Etiquetas de texto para cada Button",

--- a/packages/docs/src/translation/fa.components.json
+++ b/packages/docs/src/translation/fa.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API استاندارد جدید HTML برای ایجاد کرکره است.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover شبیه دیالوگ است، اما همچنان اجازه می دهد تا روی عناصر پس زمینه تمرکز کنید. در دسترس است و می‌توانیم Modal را با استفاده از کلید `Esc` ببندیم.",
   "Rotates through 3 words, in 10 seconds": "در 10 ثانیه از طریق 3 کلمه می چرخد",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "خدمات",
   "size of component or part": "اندازه Component یا قطعه",
   "Text labels for each button": "برچسب های متنی برای هر Button",

--- a/packages/docs/src/translation/fr.components.json
+++ b/packages/docs/src/translation/fr.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "L'API Popover est le nouveau standard HTML pour créer des listes déroulantes.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Le popover est similaire au dialogue mais il permet toujours de se concentrer sur les éléments d'arrière-plan. Il est accessible et nous pouvons fermer le modal en utilisant la touche `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Tourne sur 3 mots, en 10 secondes",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Prestations",
   "size of component or part": "taille de Component ou pièce",
   "Text labels for each button": "Étiquettes de texte pour chaque Button",

--- a/packages/docs/src/translation/he.components.json
+++ b/packages/docs/src/translation/he.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API הוא תקן HTML החדש ליצירת תפריטים נפתחים.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover דומה לדיאלוג אך הוא עדיין מאפשר התמקדות ברכיבי הרקע. זה נגיש ואנחנו יכולים לסגור את המודאל באמצעות מקש `Esc`.",
   "Rotates through 3 words, in 10 seconds": "מסתובב בין 3 מילים, תוך 10 שניות",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Services",
   "size of component or part": "גודל הרכיב או החלק",
   "Text labels for each button": "תוויות טקסט עבור כל כפתור",

--- a/packages/docs/src/translation/hu.components.json
+++ b/packages/docs/src/translation/hu.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "A Popover API a legördülő menük létrehozásának új HTML-szabványa.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "A popover hasonló a párbeszédablakhoz, de továbbra is lehetővé teszi a háttérelemekre való összpontosítást. Elérhető, és a Modal-t az `Esc` gombbal zárhatjuk be.",
   "Rotates through 3 words, in 10 seconds": "10 másodperc alatt 3 szón át forog",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Szolgáltatások",
   "size of component or part": "mérete Component vagy alkatrész",
   "Text labels for each button": "Szöveges címkék minden Button-hoz",

--- a/packages/docs/src/translation/id.components.json
+++ b/packages/docs/src/translation/id.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API adalah standar HTML baru untuk membuat dropdown.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover mirip dengan dialog tetapi masih memungkinkan pemfokusan pada elemen latar belakang. Ini dapat diakses dan kita dapat menutup modal menggunakan tombol `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Berputar melalui 3 kata, dalam 10 detik",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Layanan",
   "size of component or part": "ukuran Component atau sebagian",
   "Text labels for each button": "Label teks untuk setiap Button",

--- a/packages/docs/src/translation/it.components.json
+++ b/packages/docs/src/translation/it.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "L'API Popover è il nuovo standard HTML per la creazione di menu a discesa.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Il popover è simile al dialogo ma consente comunque di concentrarsi sugli elementi dello sfondo. È accessibile e possiamo chiudere la finestra modale utilizzando il tasto `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Ruota di 3 parole in 10 secondi",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Servizi",
   "size of component or part": "dimensione del componente o della parte",
   "Text labels for each button": "Etichette di testo per ogni Button",

--- a/packages/docs/src/translation/ja.components.json
+++ b/packages/docs/src/translation/ja.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API は、ドロップダウンを作成するための新しい HTML 標準です。",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "ポップオーバーはダイアログに似ていますが、それでも背景要素に焦点を当てることができます。アクセス可能であり、「`Esc`」キーを使用して Modal を閉じることができます。",
   "Rotates through 3 words, in 10 seconds": "10 秒で 3 つの単語をローテーションします",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "サービス",
   "size of component or part": "Componentまたは部品のサイズ",
   "Text labels for each button": "各 Button のテキスト ラベル",

--- a/packages/docs/src/translation/ko.components.json
+++ b/packages/docs/src/translation/ko.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API는 드롭다운 생성을 위한 새로운 HTML 표준입니다.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "팝오버는 대화 상자와 유사하지만 여전히 배경 요소에 집중할 수 있습니다. 액세스 가능하며 `Esc` 키를 사용하여 Modal를 닫을 수 있습니다.",
   "Rotates through 3 words, in 10 seconds": "10초 안에 3단어를 순환합니다.",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "서비스",
   "size of component or part": "Component 또는 부품의 크기",
   "Text labels for each button": "각 Button의 텍스트 라벨",

--- a/packages/docs/src/translation/ms.components.json
+++ b/packages/docs/src/translation/ms.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API ialah standard HTML baharu untuk membuat lungsur turun.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover adalah serupa dengan dialog tetapi ia masih membenarkan pemfokusan pada elemen latar belakang. Ia boleh diakses dan kami boleh menutup modal menggunakan kunci `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Berputar melalui 3 perkataan, dalam 10 saat",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Perkhidmatan",
   "size of component or part": "saiz Component atau bahagian",
   "Text labels for each button": "Label teks untuk setiap Button",

--- a/packages/docs/src/translation/pl.components.json
+++ b/packages/docs/src/translation/pl.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API to nowy standard HTML do tworzenia list rozwijanych.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover przypomina okno dialogowe, ale nadal pozwala skupić się na elementach tła. Jest dostępny i możemy zamknąć modal za pomocą klawisza `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Obraca się o 3 słowa w ciągu 10 sekund",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Usługi",
   "size of component or part": "rozmiar Component lub części",
   "Text labels for each button": "Etykiety tekstowe dla każdego Button",

--- a/packages/docs/src/translation/pt.components.json
+++ b/packages/docs/src/translation/pt.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "API Popover é o novo padrão HTML para criação de menus suspensos.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover é semelhante ao diálogo, mas ainda permite focar nos elementos de fundo. É acessível e podemos fechar o modal usando a tecla `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Gira através de 3 palavras, em 10 segundos",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Serviços",
   "size of component or part": "tamanho do componente ou peça",
   "Text labels for each button": "Etiquetas de texto para cada Button",

--- a/packages/docs/src/translation/ro.components.json
+++ b/packages/docs/src/translation/ro.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API este noul standard HTML pentru crearea listelor drop-down.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover este similar cu dialogul, dar permite totuși concentrarea asupra elementelor de fundal. Este accesibil și putem închide modal folosind tasta `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Se rotește prin 3 cuvinte, în 10 secunde",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Servicii",
   "size of component or part": "dimensiunea componentei sau a piesei",
   "Text labels for each button": "Etichete text pentru fiecare Button",

--- a/packages/docs/src/translation/ru.components.json
+++ b/packages/docs/src/translation/ru.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API — это новый стандарт HTML для создания раскрывающихся списков.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Поповер похож на диалог, но все же позволяет сосредоточиться на элементах фона. Он доступен, и мы можем закрыть Modal, используя клавишу `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Меняется на 3 слова за 10 секунд.",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Услуги",
   "size of component or part": "размер Component или детали",
   "Text labels for each button": "Текстовые метки для каждого Button",

--- a/packages/docs/src/translation/tr.components.json
+++ b/packages/docs/src/translation/tr.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API, açılır listeler oluşturmaya yönelik yeni HTML standardıdır.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover diyaloğa benzer ancak yine de arka plan öğelerine odaklanmaya izin verir. Erişilebilir ve `Esc` anahtarını kullanarak modeli kapatabiliriz.",
   "Rotates through 3 words, in 10 seconds": "3 kelimeyi 10 saniyede döndürür",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Services",
   "size of component or part": "bileşenin veya parçanın boyutu",
   "Text labels for each button": "Her düğme için metin etiketleri",

--- a/packages/docs/src/translation/uk.components.json
+++ b/packages/docs/src/translation/uk.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API — це новий стандарт HTML для створення спадних меню.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover схожий на діалогове вікно, але все ще дозволяє фокусуватися на елементах фону. Він доступний, і ми можемо закрити Modal за допомогою клавіші `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Переглядає 3 слова за 10 секунд",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Послуги",
   "size of component or part": "розмір Component або частина",
   "Text labels for each button": "Текстові мітки для кожного Button",

--- a/packages/docs/src/translation/ur.components.json
+++ b/packages/docs/src/translation/ur.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API ڈراپ ڈاؤن بنانے کا نیا HTML معیار ہے۔",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "پاپ اوور ڈائیلاگ کی طرح ہے لیکن یہ پھر بھی پس منظر کے عناصر پر توجہ مرکوز کرنے کی اجازت دیتا ہے۔ یہ قابل رسائی ہے اور ہم `Esc` کلید کا استعمال کرتے ہوئے موڈل کو بند کر سکتے ہیں۔",
   "Rotates through 3 words, in 10 seconds": "10 سیکنڈ میں، 3 الفاظ میں گھومتا ہے۔",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Services",
   "size of component or part": "جزو یا حصے کا سائز",
   "Text labels for each button": "ہر بٹن کے لیے ٹیکسٹ لیبل",

--- a/packages/docs/src/translation/vi.components.json
+++ b/packages/docs/src/translation/vi.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "API Popover là tiêu chuẩn HTML mới để tạo danh sách thả xuống.",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "Popover tương tự như hộp thoại nhưng vẫn cho phép tập trung vào các thành phần nền. Nó có thể truy cập được và chúng ta có thể đóng Modal bằng phím `Esc`.",
   "Rotates through 3 words, in 10 seconds": "Xoay qua 3 từ, trong 10 giây",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "Dịch vụ",
   "size of component or part": "kích thước của Component hoặc một phần",
   "Text labels for each button": "Nhãn văn bản cho mỗi Button",

--- a/packages/docs/src/translation/zh_hans.components.json
+++ b/packages/docs/src/translation/zh_hans.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API 是用于创建下拉菜单的新 HTML 标准。",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "弹出窗口类似于对话框，但它仍然允许关注背景元素。它是可以访问的，我们可以使用`Esc`键关闭 Modal。",
   "Rotates through 3 words, in 10 seconds": "10 秒内旋转 3 个单词",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "服务",
   "size of component or part": "Component或零件的尺寸",
   "Text labels for each button": "每个 Button 的文本标签",

--- a/packages/docs/src/translation/zh_hant.components.json
+++ b/packages/docs/src/translation/zh_hant.components.json
@@ -276,6 +276,8 @@
   "Popover API is the new HTML standard for creating dropdowns.": "Popover API 是用於建立下拉式選單的新 HTML 標準。",
   "Popover is similar to dialog but it still allows focusing on the background elements. It is accessible and we can close the modal using `Esc` key.": "彈出視窗類似於對話框，但它仍然允許關注背景元素。它是可以存取的，我們可以使用`Esc`鍵關閉 Modal。",
   "Rotates through 3 words, in 10 seconds": "10 秒內旋轉 3 個單字",
+  "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden": "Put two copies of the content inside the marquee, so the loop is seamless. Hide the second copy from screen readers using aria-hidden",
+  "Set the duration of one full loop using the --marquee-duration CSS variable": "Set the duration of one full loop using the --marquee-duration CSS variable",
   "Services": "服務",
   "size of component or part": "Component或零件的尺寸",
   "Text labels for each button": "每個 Button 的文字標籤",

--- a/skills/daisyui/components/marquee.md
+++ b/skills/daisyui/components/marquee.md
@@ -1,0 +1,23 @@
+### Marquee
+Use the marquee component to scroll content in an infinite loop, like a strip of logos or a ticker.
+
+[Marquee documentation](https://daisyui.com/components/marquee/)
+
+#### Class names
+- component: `marquee`
+- modifier: `marquee-reverse`, `marquee-vertical`, `marquee-pause-hover`
+
+#### Syntax
+```html
+<div class="marquee {MODIFIER}">
+  <div>{content}</div>
+  <div aria-hidden="true">{content}</div>
+</div>
+```
+
+#### Rules
+- `{MODIFIER}` is optional. It can include one or more modifier class names.
+- Put two identical copies of the content inside the marquee so the loop is seamless. Add `aria-hidden="true"` to the second copy so screen readers only read the content once.
+- Set the speed with the `--marquee-duration` CSS variable. It is the duration of one full loop, 30s by default.
+- `marquee-vertical` needs a height on the marquee container.
+- The scroll direction flips automatically in RTL layouts, and the animation pauses for users with reduced motion preference.


### PR DESCRIPTION
marquee is on the roadmap under Future. pure css: two copies of the content inside the container (second one aria-hidden), animation on the copies. modifiers: marquee-reverse, marquee-vertical, marquee-pause-hover, speed via --marquee-duration. flips direction automatically in RTL and pauses under prefers-reduced-motion. docs page, skill file and translation keys included.

demo on the published plugin with the proposed css: https://play.tailwindcss.com/8osowxZoNb
