### PR TITLE
fix(menu): hide icons and badges inside the open summary of a paged menu

### DIFF
--- a/packages/daisyui/src/components/menu.css
+++ b/packages/daisyui/src/components/menu.css
@@ -229,6 +229,9 @@
       &:not(:active){
         transition-duration: 0s;
       }
+      & > * {
+        @apply hidden;
+      }
       &:before {
         --tw-content: "Back";
         content: var(--tw-content);


### PR DESCRIPTION
menu-paged turns the open summary into a Back button with font-size: 0, but that only hides text. an icon or a badge inside the summary keeps its own size and shows up next to Back.

bug and fix: https://play.tailwindcss.com/qXE3oACb9F
