### PR TITLE
fix(pr-preview): wrap inlined PR css in @layer utilities to match the plugin's cascade

### DIFF
--- a/packages/tailwind-play-share/pr-preview.mjs
+++ b/packages/tailwind-play-share/pr-preview.mjs
@@ -482,7 +482,10 @@ export function buildAfterCss(excludeNames, cssFiles) {
   const changedCss = cssFiles
     .map(({ componentName, css }) => `/* PR component: ${componentName} */\n${css.trimEnd()}`)
     .join("\n\n")
-  return `${plugin}\n${changedCss ? `\n${changedCss}\n` : ""}`
+  const wrappedCss = changedCss
+    ? `@layer utilities {\n${changedCss.replace(/^(?=.)/gm, "  ")}\n}`
+    : ""
+  return `${plugin}\n${wrappedCss ? `\n${wrappedCss}\n` : ""}`
 }
 
 export function buildPreviewInputs(baseSha, headSha) {

--- a/packages/tailwind-play-share/pr-preview.test.mjs
+++ b/packages/tailwind-play-share/pr-preview.test.mjs
@@ -239,7 +239,7 @@ describe("Tailwind Play inputs", () => {
     expect(buildBeforeCss()).toBe('@import "tailwindcss";\n@plugin "daisyui";\n')
   })
 
-  test("excludes changed components and appends their PR CSS", () => {
+  test("excludes changed components and appends their PR CSS inside the utilities layer so markup utilities keep beating component styles like they do in the plugin", () => {
     expect(
       buildAfterCss(
         ["button", "card", "toggle"],
@@ -253,11 +253,21 @@ describe("Tailwind Play inputs", () => {
   exclude: button, card, toggle;
 }
 
-/* PR component: button */
-.btn { color: red; }
+@layer utilities {
+  /* PR component: button */
+  .btn { color: red; }
 
-/* PR component: toggle */
-.toggle { color: blue; }
+  /* PR component: toggle */
+  .toggle { color: blue; }
+}
+`)
+  })
+
+  test("emits no utilities layer block when the PR only deletes component files", () => {
+    expect(buildAfterCss(["button"], [])).toBe(`@import "tailwindcss";
+@plugin "daisyui" {
+  exclude: button;
+}
 `)
   })
 


### PR DESCRIPTION
the After playground pastes the changed component css at the top level, so its @layer daisyui.* becomes a new layer declared after utilities and starts beating markup utilities. the plugin nests component css inside @layer utilities, where utilities win. wrapping the pasted css the same way makes the preview match real plugin behavior.

visible on #4710's links: [before](https://play.tailwindcss.com/WpSDVytTAz) renders the docs menu at 224px (w-56 wins), [after](https://play.tailwindcss.com/nuhwgKMtxn) renders it 81px because the menu's own w-fit overrides w-56. same result with the unchanged master css pasted, so it's the harness, not that PR.
