### PR TITLE
fix(skeleton): mirror the shimmer direction in RTL

### DIFF
--- a/packages/daisyui/src/components/skeleton.css
+++ b/packages/daisyui/src/components/skeleton.css
@@ -13,6 +13,9 @@
 
     @media (prefers-reduced-motion: no-preference) {
       animation: skeleton 1.8s ease-in-out infinite;
+      &:dir(rtl) {
+        animation-direction: reverse;
+      }
     }
   }
 }


### PR DESCRIPTION
the skeleton shimmer animates background-position, which is physical, so in RTL it still sweeps left to right while everything else reads right to left. one line plays the same animation reversed for :dir(rtl). reduced motion is untouched.

bug and fix: https://play.tailwindcss.com/4yhPZYykkR
