### PR TITLE
fix(checkbox): style aria-checked="mixed" like :indeterminate

### DIFF
--- a/packages/daisyui/src/components/checkbox.css
+++ b/packages/daisyui/src/components/checkbox.css
@@ -62,7 +62,8 @@
       }
     }
 
-    &:indeterminate {
+    &:indeterminate,
+    &[aria-checked="mixed"] {
       background-color: var(
         --input-color,
         color-mix(in oklab, var(--color-base-content) 20%, #0000)


### PR DESCRIPTION
aria-checked="mixed" looked unchecked, now it gets the indeterminate style, same as aria-checked="true" already gets the checked style.

example: https://play.tailwindcss.com/qcDlh0IVx9
