### PR TITLE
fix(megamenu): lock page scroll while the fullscreen menu is open

### DIFF
--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -179,6 +179,9 @@
       @starting-style {
         @apply opacity-0;
       }
+      :root:has(&) {
+        --page-scroll-lock: ;
+      }
       [popovertarget] {
         @apply pointer-events-none;
         font-size: 0.875rem;

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -164,7 +164,6 @@
         background-color: var(--mm-backdrop, oklch(0% 0 0/ 0.4));
       }
       border-inline-width: 0;
-      position-area: block-end;
       top: 0;
       inset-inline-start: 0;
       max-block-size: 80svh;

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -242,7 +242,6 @@
     @apply relative w-full flex-col items-start rounded-none opacity-0;
     background-color: var(--color-base-100);
     border-inline-width: 0;
-    position-area: block-end;
     max-block-size: calc(100% - 0.25rem);
     --mm-backdrop: transparent;
     translate: 0 -0.5rem;

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -164,6 +164,7 @@
         background-color: var(--mm-backdrop, oklch(0% 0 0/ 0.4));
       }
       border-inline-width: 0;
+      position-area: block-end;
       top: 0;
       inset-inline-start: 0;
       max-block-size: 80svh;
@@ -242,6 +243,7 @@
     @apply relative w-full flex-col items-start rounded-none opacity-0;
     background-color: var(--color-base-100);
     border-inline-width: 0;
+    position-area: block-end;
     max-block-size: calc(100% - 0.25rem);
     --mm-backdrop: transparent;
     translate: 0 -0.5rem;


### PR DESCRIPTION
the fullscreen megamenu state has a backdrop but the page behind it keeps scrolling. modal and drawer both set --page-scroll-lock for this, megamenu just missed it.

bug: https://play.tailwindcss.com/S4VXxIOFnB
with the fix: https://play.tailwindcss.com/mCeZbLKGUB
