### PR TITLE
fix(megamenu): prevent overflow in vertical mode on close

### DIFF
--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -191,6 +191,10 @@
       [popover] {
         @apply relative block max-h-none overflow-visible bg-transparent opacity-100;
         border: none;
+
+        &:first-of-type {
+          @apply w-full;
+        }
       }
     }
   }

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -275,10 +275,8 @@
   }
 
   @layer daisyui.l1 {
-    &:not([popover]:popover-open) {
-      @apply overflow-y-auto;
-      max-block-size: 80svh;
-    }
+    @apply overflow-y-auto;
+    max-block-size: 80svh;
   }
 }
 

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -273,6 +273,13 @@
       border: none;
     }
   }
+
+  @layer daisyui.l1 {
+    &:not([popover]:popover-open) {
+      @apply overflow-y-auto;
+      max-block-size: 80svh;
+    }
+  }
 }
 
 .megamenu-xs {

--- a/packages/daisyui/src/components/megamenu.css
+++ b/packages/daisyui/src/components/megamenu.css
@@ -280,7 +280,14 @@
 
   @layer daisyui.l1 {
     @apply overflow-y-auto;
+
     max-block-size: 80svh;
+    @supports (max-block-size: -webkit-fill-available) {
+      max-block-size: -webkit-fill-available;
+    }
+    @supports (max-block-size: stretch) {
+      max-block-size: stretch;
+    }
   }
 }
 


### PR DESCRIPTION
When closing the popover in vertical mode the content shortly overflows.

v1: https://play.tailwindcss.com/vmJfSGmKUG
v2: https://play.tailwindcss.com/ETuchscioH - updated example with full-width first popover on wide screen
v3: https://play.tailwindcss.com/nBzv9Qx9Ib - updated with auto height for popover: works on chrome and safari (with @support guards); in firefox it's not needed because it auto forces the popover to stay on screen (ignores the anchor)