### PR TITLE
fix(join): keep the border overlap for join items inside a wrapper

### DIFF
--- a/packages/daisyui/src/utilities/join.css
+++ b/packages/daisyui/src/utilities/join.css
@@ -4,6 +4,8 @@
   --join-se: 0;
   --join-es: 0;
   --join-ee: 0;
+  --join-ml: 0;
+  --join-mt: 0;
   --join-v: 0;
   --join-h: 1;
 
@@ -38,6 +40,11 @@
       --join-es: var(--radius-field);
       --join-ee: var(--radius-field);
     }
+
+    :where(:scope > :not(:first-child)) {
+      --join-ml: calc(var(--border, 1px) * -1 * var(--join-h));
+      --join-mt: calc(var(--border, 1px) * -1 * var(--join-v));
+    }
   }
 }
 
@@ -58,9 +65,9 @@
   border-end-start-radius: var(--join-es);
   border-end-end-radius: var(--join-ee);
 
-  &:not(:first-child, :disabled, [disabled], .btn-disabled) {
-    margin-inline-start: calc(var(--border, 1px) * -1 * var(--join-h));
-    margin-block-start: calc(var(--border, 1px) * -1 * var(--join-v));
+  &:not(:disabled, [disabled], .btn-disabled) {
+    margin-inline-start: var(--join-ml, 0);
+    margin-block-start: var(--join-mt, 0);
   }
 
   &:is(:disabled, [disabled], .btn-disabled) {


### PR DESCRIPTION
a join item inside a wrapper (like a tooltip) misses the negative margin, so each seam shows a double border. the radius vars already handle wrapped items, now the margin does too.

example: https://play.tailwindcss.com/1xhtLZD53I

seen in #4709