### PR TITLE
fix(tooltip): bubble keeps its own font weight on any host

### DIFF
--- a/packages/daisyui/src/components/tooltip.css
+++ b/packages/daisyui/src/components/tooltip.css
@@ -10,6 +10,7 @@
     &[data-tip]:before {
       @apply text-neutral-content rounded-field absolute max-w-[20rem] px-2 py-1 text-center whitespace-normal opacity-0;
       font-size: 0.875rem;
+      font-weight: 400;
       line-height: 1.25;
       background-color: var(--tt-bg);
       width: max-content;


### PR DESCRIPTION
the tooltip bubble inherits the host font weight, so a tip directly on a btn renders bold while the same tip on a wrapper renders normal. one declaration pins the bubble to the same look on any host.

example: https://play.tailwindcss.com/shVhOKHX8T

seen in #4709