### PR TITLE
docs: remove mask-square which was removed from the library in v5

### DIFF
--- a/packages/docs/src/routes/(routes)/components/mask/+page.md
+++ b/packages/docs/src/routes/(routes)/components/mask/+page.md
@@ -22,8 +22,6 @@ classnames:
     desc: pentagon
   - class: mask-diamond
     desc: diamond
-  - class: mask-square
-    desc: square
   - class: mask-circle
     desc: circle
   - class: mask-star
@@ -123,17 +121,6 @@ classnames:
 <img
   class="$$mask $$mask-diamond"
   alt="Diamond CSS mask"
-  src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
-```
-
-
-### ~Square
-<img alt="Square CSS mask" class="mask mask-square w-40 h-40" src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
-
-```html
-<img
-  class="$$mask $$mask-square"
-  alt="Square CSS mask"
   src="https://img.daisyui.com/images/stock/photo-1567653418876-5bb0e566e1c2.webp" />
 ```
 

--- a/packages/docs/src/routes/(routes)/docs/upgrade/+page@(routes).md
+++ b/packages/docs/src/routes/(routes)/docs/upgrade/+page@(routes).md
@@ -213,7 +213,7 @@ Example:
 
 ### Mask
 
-- Removed `mask-parallelogram`, `mask-parallelogram-2`, `mask-parallelogram-3`, and `mask-parallelogram-4`. These mask styles are no longer included in the library. If you need them, [manually use the CSS](https://github.com/saadeghi/daisyui/blob/ff313a45cea023c852903138ea032ac2d0a217f4/src/components/styled/mask.css#L23)
+- Removed `mask-square`, `mask-parallelogram`, `mask-parallelogram-2`, `mask-parallelogram-3`, and `mask-parallelogram-4`. These mask styles are no longer included in the library. If you need them, [manually use the CSS](https://github.com/saadeghi/daisyui/blob/ff313a45cea023c852903138ea032ac2d0a217f4/src/components/styled/mask.css#L23)
 
 ### Menu
 

--- a/skills/daisyui/components/mask.md
+++ b/skills/daisyui/components/mask.md
@@ -5,7 +5,7 @@ A mask crops the content of an element to a common shape.
 
 #### Class names
 - component: `mask`
-- style: `mask-squircle`, `mask-heart`, `mask-hexagon`, `mask-hexagon-2`, `mask-decagon`, `mask-pentagon`, `mask-diamond`, `mask-square`, `mask-circle`, `mask-star`, `mask-star-2`, `mask-triangle`, `mask-triangle-2`, `mask-triangle-3`, `mask-triangle-4`
+- style: `mask-squircle`, `mask-heart`, `mask-hexagon`, `mask-hexagon-2`, `mask-decagon`, `mask-pentagon`, `mask-diamond`, `mask-circle`, `mask-star`, `mask-star-2`, `mask-triangle`, `mask-triangle-2`, `mask-triangle-3`, `mask-triangle-4`
 - modifier: `mask-half-1`, `mask-half-2`
 
 #### Syntax


### PR DESCRIPTION
mask-square was removed in the v5 rewrite (6b9cf7c2) but the mask page, the skill file and the upgrade guide still list it. the example renders unmasked. removed it from the docs and added it to the upgrade note next to the parallelograms.