### PR TITLE
fix(breadcrumbs): focus ring is clipped on the first and last item

### DIFF
--- a/packages/daisyui/src/components/breadcrumbs.css
+++ b/packages/daisyui/src/components/breadcrumbs.css
@@ -1,11 +1,11 @@
 .breadcrumbs {
   @layer daisyui.l1.l2.l3 {
-    @apply max-w-full overflow-x-auto py-2;
+    @apply -ms-1 max-w-full overflow-x-auto py-2;
 
     > menu,
     > ul,
     > ol {
-      @apply flex min-h-min min-w-max items-center px-1 whitespace-nowrap;
+      @apply flex min-h-min items-center ps-1 whitespace-nowrap;
 
       > li {
         @apply flex items-center;

--- a/packages/daisyui/src/components/breadcrumbs.css
+++ b/packages/daisyui/src/components/breadcrumbs.css
@@ -5,7 +5,7 @@
     > menu,
     > ul,
     > ol {
-      @apply flex min-h-min items-center whitespace-nowrap;
+      @apply flex min-h-min min-w-max items-center px-1 whitespace-nowrap;
 
       > li {
         @apply flex items-center;


### PR DESCRIPTION
the list scrolls with no inline padding, so the focus ring of the first crumb (and the last one after scrolling) is cut off. 4px padding on the list gives it room, `min-width: max-content` keeps that padding after the last item. text moves 4px inward.

example: https://play.tailwindcss.com/6DmfYSbFaI
