### PR TITLE
fix(plugin): a single exclude value also drops components whose name it contains

### DIFF
--- a/packages/daisyui/functions/pluginOptionsHandler.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.js
@@ -12,6 +12,16 @@ export const pluginOptionsHandler = (() => {
       prefix = "",
     } = options || {}
 
+    const toList = (value) =>
+      Array.isArray(value)
+        ? value
+        : String(value)
+            .split(",")
+            .map((item) => item.trim())
+            .filter(Boolean)
+    const includeList = include === undefined ? undefined : toList(include)
+    const excludeList = exclude === undefined ? undefined : toList(exclude)
+
     if (logs !== false && firstRun) {
       console.log(
         `${atob("Lyoh")} ${decodeURIComponent("%F0%9F%8C%BC")} ${atob("ZGFpc3lVSQ==")} ${packageVersion} ${atob("Ki8=")}`,
@@ -62,7 +72,7 @@ export const pluginOptionsHandler = (() => {
       if (themeArray.length === 1 && themeArray[0].includes("--default")) {
         const [themeName, ...flags] = themeArray[0].split(" ")
         applyTheme(themeName, flags)
-        return { include, exclude, prefix }
+        return { include: includeList, exclude: excludeList, prefix }
       }
 
       // default theme
@@ -92,6 +102,6 @@ export const pluginOptionsHandler = (() => {
       })
     }
 
-    return { include, exclude, prefix }
+    return { include: includeList, exclude: excludeList, prefix }
   }
 })()

--- a/packages/daisyui/functions/pluginOptionsHandler.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.js
@@ -12,15 +12,8 @@ export const pluginOptionsHandler = (() => {
       prefix = "",
     } = options || {}
 
-    const toList = (value) =>
-      Array.isArray(value)
-        ? value
-        : String(value)
-            .split(",")
-            .map((item) => item.trim())
-            .filter(Boolean)
-    const includeList = include === undefined ? undefined : toList(include)
-    const excludeList = exclude === undefined ? undefined : toList(exclude)
+    const excludeList =
+      typeof exclude === "string" ? exclude.split(",").map((item) => item.trim()) : exclude
 
     if (logs !== false && firstRun) {
       console.log(
@@ -72,7 +65,7 @@ export const pluginOptionsHandler = (() => {
       if (themeArray.length === 1 && themeArray[0].includes("--default")) {
         const [themeName, ...flags] = themeArray[0].split(" ")
         applyTheme(themeName, flags)
-        return { include: includeList, exclude: excludeList, prefix }
+        return { include, exclude: excludeList, prefix }
       }
 
       // default theme
@@ -102,6 +95,6 @@ export const pluginOptionsHandler = (() => {
       })
     }
 
-    return { include: includeList, exclude: excludeList, prefix }
+    return { include, exclude: excludeList, prefix }
   }
 })()

--- a/packages/daisyui/functions/pluginOptionsHandler.test.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.test.js
@@ -85,6 +85,23 @@ test("pluginOptionsHandler should return include, exclude, and prefix", () => {
   expect(result.prefix).toEqual("prefix")
 })
 
+test("pluginOptionsHandler should turn a single include or exclude value into a list", () => {
+  const options = { include: "menu", exclude: "megamenu" }
+
+  const result = pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
+
+  expect(result.include).toEqual(["menu"])
+  expect(result.exclude).toEqual(["megamenu"])
+})
+
+test("pluginOptionsHandler should split a comma separated exclude string", () => {
+  const options = { exclude: "table, status" }
+
+  const result = pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
+
+  expect(result.exclude).toEqual(["table", "status"])
+})
+
 test("pluginOptionsHandler should not create duplicate styles for single light theme", () => {
   mockAddBase.mockReset()
 

--- a/packages/daisyui/functions/pluginOptionsHandler.test.js
+++ b/packages/daisyui/functions/pluginOptionsHandler.test.js
@@ -85,12 +85,12 @@ test("pluginOptionsHandler should return include, exclude, and prefix", () => {
   expect(result.prefix).toEqual("prefix")
 })
 
-test("pluginOptionsHandler should turn a single include or exclude value into a list", () => {
+test("pluginOptionsHandler should turn a single exclude value into a list and leave include as it is", () => {
   const options = { include: "menu", exclude: "megamenu" }
 
   const result = pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
 
-  expect(result.include).toEqual(["menu"])
+  expect(result.include).toEqual("menu")
   expect(result.exclude).toEqual(["megamenu"])
 })
 
@@ -100,6 +100,15 @@ test("pluginOptionsHandler should split a comma separated exclude string", () =>
   const result = pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
 
   expect(result.exclude).toEqual(["table", "status"])
+})
+
+test("pluginOptionsHandler should pass a blank include and exclude through, which arrive as 0 from css", () => {
+  const options = { include: 0, exclude: 0 }
+
+  const result = pluginOptionsHandler(options, mockAddBase, mockThemesObject, "1.0.0")
+
+  expect(result.include).toEqual(0)
+  expect(result.exclude).toEqual(0)
 })
 
 test("pluginOptionsHandler should not create duplicate styles for single light theme", () => {


### PR DESCRIPTION
`exclude: megamenu;` also removes menu, `exclude: table;` also removes tab, same for status/stat, fileinput/input and radialprogress/progress. a single value reaches the plugin as a string and `exclude.includes(name)` becomes a substring check. comma lists come in as arrays and are fine. the handler now turns include and exclude into a list first.

single value: https://play.tailwindcss.com/DsHa2Oa2MH vs list: https://play.tailwindcss.com/lOXMrrTl1m (same menu, only the exclude form differs)

this is also why the preview bot's After playgrounds for megamenu PRs show an unstyled menu, the bot excludes megamenu.
