### PR TITLE
docs: redraw the build flow diagram in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,14 +30,14 @@ daisyUI welcomes contributions from anyone willing to help 🤝
 ## Contribute translations
 
 - You can help add or fix translations by using the [Fink localization editor](https://fink.inlang.com/github.com/saadeghi/daisyui?ref=badge)
-- Submit the translation by opening a pull request ([see guide](https://inlang.com/g/6ddyhpoi/guide-nilsjacobsen-contributeTranslationsWithFink))
+- Submit the translation by opening a pull request ([Fink docs](https://inlang.com/m/tdozzpar/app-inlang-finkLocalizationEditor))
 
 ## Building on local
 
 ### To build the daisyUI node package locally:
 
-1. [[Fork](https://github.com/saadeghi/daisyui/fork) and] clone the repo on local – only fork the master branch
-2. [Install Bun](https://bun.sh/) if you don't have it:
+1. [Fork](https://github.com/saadeghi/daisyui/fork) and clone the repo (only fork the master branch)
+2. [Install Bun](https://bun.sh/) if you don't have it
 3. Install dependencies:
   ```
   bun install
@@ -54,8 +54,8 @@ daisyUI welcomes contributions from anyone willing to help 🤝
 
 ### To run the [documentation site](https://daisyui.com/) on local:
 
-1. [[Fork](https://github.com/saadeghi/daisyui/fork) and] clone the repo on local – only fork the master branch
-2. [Install Bun](https://bun.sh/) if you don't have it:
+1. [Fork](https://github.com/saadeghi/daisyui/fork) and clone the repo (only fork the master branch)
+2. [Install Bun](https://bun.sh/) if you don't have it
 3. Install dependencies:
   ```
   bun install
@@ -100,181 +100,64 @@ packages
 ### packages/daisyui workflow
 
 ```mermaid
----
-title: daisyUI build flow
----
-graph TD
+%%{init: {"theme": "base", "themeVariables": {"textColor": "#ecf9ff", "titleColor": "#ecf9ff", "lineColor": "#7e8792", "clusterBkg": "#191e24", "clusterBorder": "#15191e", "edgeLabelBackground": "#191e24", "primaryColor": "#1d232a", "primaryTextColor": "#ecf9ff", "primaryBorderColor": "#323940"}, "flowchart": {"nodeSpacing": 30, "rankSpacing": 50}}}%%
+flowchart LR
+  subgraph src["src/"]
+    direction LR
+    themesSrc["themes/*.css"]
+    baseSrc["base/*.css"]
+    componentsSrc["components/*.css"]
+    utilitiesSrc["utilities/*.css"]
+  end
 
-    subgraph Build["src/"]
-        E[Themes]
-        F[base]
-        G[components]
-        H[utilities]
-    end
+  build(["build.js"])
 
-    Build
+  subgraph generated["generated"]
+    css["*.css"]
+    classJson["components/*/class.json"]
+    index["*/index.js"]
+    object["*/object.js"]
+  end
 
+  subgraph cssOut["CSS"]
+    cdn["daisyui.css (CDN)"]
+    themesCss["themes.css"]
+    chunks["chunks.css"]
+  end
 
-    Build
+  subgraph plugin["@plugin 'daisyui'"]
+    imports["imports.js"]
+    pluginIndex["index.js"]
+  end
 
+  functions["functions/<br>plugin.js<br>pluginOptionsHandler.js<br>variables.js<br>nestCssLayers.js"]
 
+  subgraph themePlugin["@plugin 'daisyui/theme'"]
+    themeObject["theme/object.js"]
+    themeIndex["theme/index.js<br>(themePlugin.js)"]
+  end
 
-    subgraph FinalPackage["components/"]
+  src --> build --> generated
+  css --> cdn & chunks
+  css -- "theme/*.css" --> themesCss
+  index --> imports --> pluginIndex
+  functions --> pluginIndex
+  object -- "theme/*/object.js" --> themeObject --> themeIndex
 
-        E
-        E
-        E
-        F
-        F
-        F
-        G
-        J12[components/*.css]
-        G
-        J13[components/*/index.js]
-        G
-        J14[components/*/object.js]
-        G
-        J15["*/class.json"]
-        H
-        H
-        H
-    end
-
-    FinalPackage
-	J13
-	J12
-	J12
-	subgraph s1["CSS"]
-		J2["daisyui.css - CDN"]
-		J3["themes.css"]
-		J4["chunks.css"]
-	end
-	J4
-	J12 --- J4
-	J4
-	J4
-	J4
-	J3
-	J12["*.css"] --- J2
-	J2
-	J2
-	J2
-	J2
-	J2
-	subgraph s2["@plugin "daisyui""]
-		J19["import.js"]
-		J1["index.js - Plugin"]
-	end
-	J1
-	J19
-	J19
-	J19
-	J13 --- J19
-	J19 --- J1["index.js"]
-	subgraph s3["utilities/"]
-		J16["utilities/*.css"]
-		J17["utilities/*/index.js"]
-		J18["utilities/*/object.js"]
-	end
-	H
-	J18["*/object.js"]
-	J17 --- J19
-	H
-	J17["*/index.js"]
-	J16 --- J2
-	J16 --- J4
-	H
-	J16["*.css"]
-	subgraph s4["base/"]
-		J11["base/*/object.js"]
-		J9["base/*.css"]
-		J10["base/*/index.js"]
-	end
-	subgraph s5["colors/"]
-		J5["colors/*.css"]
-	end
-	subgraph s6["themes/"]
-		J6["theme/*.css"]
-		J8["theme/*/object.js"]
-		J7["theme/*/index.js"]
-	end
-	J10 --- J19
-	F
-	J10
-	J9 --- J2
-	J9 --- J4
-	F
-	J9["*.css"]
-	F
-	J11
-	J7 --- J19["imports.js"]
-	E
-	J7
-	E
-	J8
-	J6 --- J2
-	J6 --- J3
-	J6 --- J4
-	E["themes"]
-	J6["*.css"]
-	J5 --- J2["daisyui.css"]
-	J5 --- J4
-	J5
-	J8["*/object.js"] --- J7["*/index.js"]
-	J14["*/object.js"] --- J13["*/index.js"]
-	J11["*/object.js"] --- J10["*/index.js"]
-	J5
-	J18 --- J17
-	subgraph s7["build"]
-		n3@{ label: "Rectangle" }
-	end
-	Build
-	J5
-	s7
-	s5
-	subgraph s8["functions/"]
-		n10["...other build functions"]
-		D["functions/variables.css"]
-		n8["variables.js"]
-		n7["themeOrder.js"]
-		n6["pluginOptionsHandler.js"]
-		n5["plugin.js"]
-		n4["addPrefix.js"]
-		n1["themePlugin.js"]
-	end
-	n1
-	H["utilities/*.css"] --- s3
-	G["components/*.css"] --- FinalPackage
-	F["base/*.css"] --- s4
-	E["themes/*.css"] --- s6
-	n3@{ shape: "flip-tri", label: "build.js" } --- Build
-	n4 --- J1
-	n8 --- J1
-	n5 --- J1
-	n6 --- J1
-	n7 --- n6
-	subgraph s9["@plugin "daisyui/theme""]
-		n2["theme/index.js"]
-		n9["/object.js"]
-	end
-	n1 --- n2["/index.js"]
-	J8 --- n9
-	D["variables.css"] --> J5["*.css"]
-	style J1 fill:#FFDE59,color:#000000
-	style n2 color:#000000,fill:#FFDE59
-	n5 --- n1
-	n9 --- n1
-	n4
-	J7
-	n4 --- J17
-	n4 --- J10
-	n4 --- J13
-	style J12 fill:#5E17EB,color:#FFFFFF
-	style J16 fill:#5E17EB,color:#FFFFFF
-	style J9 fill:#5E17EB,color:#FFFFFF
-	style J5 fill:#5E17EB,color:#FFFFFF
-	style J6 fill:#5E17EB,color:#FFFFFF
-	style J3 fill:#5E17EB,color:#FFFFFF
-	style J2 fill:#5E17EB,color:#FFFFFF
-	style J4 fill:#5E17EB,color:#FFFFFF
+  classDef file fill:#1d232a,stroke:#323940,color:#ecf9ff,rx:6px,ry:6px
+  classDef css fill:#605dff,stroke:#605dff,color:#edf1fe,rx:6px,ry:6px
+  classDef entry fill:#fcb700,stroke:#fcb700,color:#793205,font-weight:bold,rx:6px,ry:6px
+  classDef step fill:#09090b,stroke:#323940,color:#e4e4e7,font-weight:bold
+  classDef list fill:#1d232a,stroke:#323940,color:#ecf9ff,rx:8px,ry:8px,text-align:left
+  class themesSrc,baseSrc,componentsSrc,utilitiesSrc,classJson,index,object,imports,themeObject file
+  class css,cdn,themesCss,chunks css
+  class pluginIndex,themeIndex entry
+  class build step
+  class functions list
+  style src fill:#191e24,stroke:#15191e,rx:8px,ry:8px
+  style generated fill:#191e24,stroke:#323940,stroke-dasharray:6 4,rx:8px,ry:8px
+  style cssOut fill:#191e24,stroke:#15191e,rx:8px,ry:8px
+  style plugin fill:#191e24,stroke:#15191e,rx:8px,ry:8px
+  style themePlugin fill:#191e24,stroke:#15191e,rx:8px,ry:8px
+  linkStyle default stroke:#7e8792,stroke-width:1.5px
 ```


### PR DESCRIPTION
the build flow diagram on the contributing tab was pretty hard to read, so i had a go at redrawing it: same flow, a bit simplified, left to right with one arrow per relation, colors from the dark theme. just an idea of how it could look, what do you think? happy to change it or drop it if you prefer the original.

also fixed the dead inlang link, the literal `[Fork and]` brackets and a stray colon in the setup steps.

rendered: https://github.com/sulimanbenhalim/daisyui/blob/fix-contributing-lists/.github/CONTRIBUTING.md#packagesdaisyui-workflow
