### PR TITLE
fix(avatar): chat avatar is centered instead of bottom aligned when using the cdn file

### DIFF
--- a/packages/daisyui/src/components/avatar.css
+++ b/packages/daisyui/src/components/avatar.css
@@ -11,7 +11,7 @@
 
 .avatar {
   @layer daisyui.l1.l2.l3 {
-    @apply relative inline-flex align-middle self-center;
+    @apply relative inline-flex align-middle;
 
     & > div {
       @apply block aspect-square overflow-hidden;
@@ -20,6 +20,9 @@
     img {
       @apply h-full w-full object-cover;
     }
+  }
+  @layer daisyui.l1.l2.l3.l4 {
+    @apply self-center;
   }
 }
 


### PR DESCRIPTION
if you load daisyui from the cdn file the avatar in a chat bubble floats to the middle instead of sitting at the bottom like the docs show. the plugin build is fine, which is why nobody noticed on daisyui.com.

turns out `.avatar` and `.chat-image` both set `align-self` at the same level, and in the packed css the avatar rule just happens to come last and win. this moves the avatar default one layer down so the chat one wins no matter the order.

repro with the cdn file, the second chat has the fix: https://play.tailwindcss.com/gqg4K0Ukhs
