### PR TITLE
fix(fab): labels render at 16px instead of 14px when daisyui has a prefix

### DIFF
--- a/packages/daisyui/src/components/fab.css
+++ b/packages/daisyui/src/components/fab.css
@@ -2,7 +2,9 @@
   @layer daisyui.l1.l2.l3 {
     /* select-none: stop Safari from selecting the trigger/labels on the click
        that toggles :focus-within (also emits the -webkit- prefix Safari needs). */
-    @apply pointer-events-none fixed end-4 bottom-4 z-999 flex flex-col-reverse items-end gap-2 text-sm whitespace-nowrap select-none;
+    @apply pointer-events-none fixed end-4 bottom-4 z-999 flex flex-col-reverse items-end gap-2 whitespace-nowrap select-none;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
     > * {
       @apply pointer-events-auto flex items-center gap-2;
       &:hover,


### PR DESCRIPTION
with `prefix: "d-"` the labels next to the fab buttons come out at 16px instead of the 14px you get without a prefix.

the fab is the only component that uses `text-sm` through @apply. that compiles to tailwind's `--text-sm` variable and the prefix step renames it to `--d-text-sm`, which doesn't exist. every other component just writes the rem values, so this does the same.

repro with prefix d-, the second fab has the fix: https://play.tailwindcss.com/fbfm9rqI5W
