### PR TITLE
fix(otp): digits after the first sit one border width right of the box centre

### DIFF
--- a/packages/daisyui/src/components/otp.css
+++ b/packages/daisyui/src/components/otp.css
@@ -21,7 +21,8 @@
     > input {
       @apply pointer-events-none start-0 z-1 m-0 appearance-none border-0 bg-transparent p-0 outline-0;
       field-sizing: content;
-      padding-inline-start: calc(var(--otp-ch) * 0.5 + var(--border));
+      padding-inline-start: calc(var(--otp-ch) * 0.5 - 1px);
+      text-indent: 1px;
       line-height: 1;
       letter-spacing: calc(var(--stride) - var(--otp-ch));
       font-variant-numeric: tabular-nums;
@@ -74,12 +75,9 @@
         0 1px color-mix(in oklab, var(--input-color) calc(var(--depth) * 10%), #0000) inset,
         0 -1px oklch(100% 0 0 / calc(var(--depth) * 0.1)) inset;
       &:nth-child(1) {
-        left: 1px;
+        left: 0;
         @supports (font: -apple-system-body) {
-          left: 2px;
-        }
-        @supports (-moz-appearance: none) {
-          left: 0px;
+          left: 1px;
         }
       }
       &:nth-child(2) {
@@ -130,7 +128,7 @@
       outline: 2px solid #0000;
       outline-offset: 1px;
       z-index: 10;
-      margin-inline-start: calc(-1 * (var(--otp-gap) + var(--otp-ch) * 0.5 + var(--border)));
+      margin-inline-start: calc(-1 * (var(--otp-gap) + var(--otp-ch) * 0.5));
     }
 
     &:focus-within {


### PR DESCRIPTION
digits after the first sit 1px right of their box centre, 2px on themes with a 2px border. the input's padding-inline-start includes var(--border), so the whole text run is offset by the border and only the first box compensates, with a hard-coded left: 1px.

that 1px is really the caret: an empty field-sizing input is 1px wide, and the :after marker that follows the input needs it only while nothing is typed. this drops the border term from the padding and the :after margin, sets the first box to left: 0, and moves 1px of the inset from padding to text-indent (counts for typed text, not for the empty input). checked in chrome and firefox.

play, lower two rows restate the fix: https://play.tailwindcss.com/5aiPsIjP9r
