### PR TITLE
fix(otp): monospace font is lost when daisyui has a prefix

### DIFF
--- a/packages/daisyui/src/components/otp.css
+++ b/packages/daisyui/src/components/otp.css
@@ -1,6 +1,17 @@
 .otp {
   @layer daisyui.l1.l2.l3 {
-    @apply relative inline-flex font-mono;
+    @apply relative inline-flex;
+    font-family: var(
+      --font-mono,
+      ui-monospace,
+      SFMono-Regular,
+      Menlo,
+      Monaco,
+      Consolas,
+      "Liberation Mono",
+      "Courier New",
+      monospace
+    );
     /* OTP codes read left-to-right (digits are bidi-LTR), so keep the boxes and
        the input aligned by pinning the component to LTR even inside dir="rtl". */
     direction: ltr;


### PR DESCRIPTION
with `prefix: "d-"` the otp loses its mono font: `@apply font-mono` becomes `var(--d-font-mono)`, which doesn't exist. same cause as #4729. this sets font-family with tailwind's mono stack as the var() fallback.

play: https://play.tailwindcss.com/7X4C8oNyv1
