### PR TITLE
fix: prevent duplicated CSS rules generated after upgrade from tailwindcss from 4.3.1 to 4.3.3

### DIFF
--- a/packages/daisyui/functions/compileAndExtractStyles.js
+++ b/packages/daisyui/functions/compileAndExtractStyles.js
@@ -14,11 +14,18 @@ export async function loadThemes() {
 }
 
 export async function compileAndExtractStyles(styleContent, defaultTheme, theme) {
+  // Tailwind 4.3.x hoists `@layer daisyui.*` at-rules nested inside selectors to
+  // the top level when resolving `@apply`, flattening the layer nesting. This
+  // later makes `addComponents` emit duplicated compound/descendant selectors.
+  // Swap them for an at-rule Tailwind leaves untouched, then restore the name.
+  const layerPlaceholder = "@daisyui-layer daisyui"
+  const preparedContent = styleContent.replaceAll("@layer daisyui", layerPlaceholder)
+
   const compiledContent = (
     await compile(
       `
     @layer theme{${defaultTheme}${theme}}
-    @layer wrapperStart{${styleContent}}
+    @layer wrapperStart{${preparedContent}}
     @layer wrapperEnd
   `,
       {
@@ -50,5 +57,8 @@ export async function compileAndExtractStyles(styleContent, defaultTheme, theme)
     throw new Error("Invalid wrapper structure in compiled content")
   }
 
-  return compiledContent.substring(openingBraceIndex + 1, closingBraceIndex).trim()
+  return compiledContent
+    .substring(openingBraceIndex + 1, closingBraceIndex)
+    .trim()
+    .replaceAll(layerPlaceholder, "@layer daisyui")
 }

--- a/packages/daisyui/functions/compileAndExtractStyles.test.js
+++ b/packages/daisyui/functions/compileAndExtractStyles.test.js
@@ -13,3 +13,19 @@ test("compileAndExtractStyles compiles with loaded themes and returns only wrapp
   expect(result).not.toContain("@layer wrapperStart")
   expect(result).not.toContain("@layer wrapperEnd")
 })
+
+test("keeps @layer daisyui nested inside selectors instead of hoisting it on @apply", async () => {
+  const { defaultTheme, theme } = await loadThemes()
+
+  const result = await compileAndExtractStyles(
+    ".foo { @layer daisyui.l1.l2 { @apply flex; &.bar { color: red; } } }",
+    defaultTheme,
+    theme,
+  )
+
+  // Tailwind 4.3.x otherwise hoists `@layer` above `.foo` and flattens `&.bar`
+  // into `.foo.bar`, which later makes `addComponents` emit duplicate rules.
+  expect(result.indexOf(".foo")).toBeLessThan(result.indexOf("@layer daisyui.l1.l2"))
+  expect(result).toContain("&.bar")
+  expect(result).toContain("display: flex;")
+})


### PR DESCRIPTION
In 4.3.1 compileAndExtractStyles.js resolved @apply via Tailwind's compile generating:
```css
.timeline {
  @layer daisyui.l1.l2 {
    @apply flex;
    &.timeline-vertical { … }
  }
}
```
In 4.3.3 compileAndExtractStyles.js resolved @apply via Tailwind's compile generating:

```css
@layer daisyui.l1.l2 {
  .timeline { … }
  .timeline.timeline-vertical { … }
}
```

So now resolving @apply inside a @layer hoists the at-rule to the top and flattens the selectors.

That flattened object, fed through addComponents, is what made Tailwind emit compound/descendant selectors (.timeline-compact.timeline-vertical > li, ...) 2–4 times each. The nestCssLayers workaround re-nested the @layer but left the duplicate compound selectors, hence the high level of duplicate rules.

This PR changes compileAndExtractStyles.js to temporary replace `@layer daisyui` with a placeholder `@daisyui-layer daisyui` before compiling (tailwind leaves unknown at-rules untouched) and restore it after extraction.

I also added a regression test in compileAndExtractStyles.test.js.

As a result the size of the compiled CSS will decrease with between 30% to 40%, and lots of recent problems will be solved without changes to the code.

ref #4737