### PR TITLE
fix(checkbox): checkmark and indeterminate dash sit off centre in the box

### DIFF
--- a/packages/daisyui/src/components/checkbox.css
+++ b/packages/daisyui/src/components/checkbox.css
@@ -46,6 +46,7 @@
 
       &:before {
         clip-path: polygon(20% 100%, 20% 80%, 50% 80%, 50% 0%, 70% 0%, 70% 100%);
+        translate: 3.5% -7%;
         @apply opacity-100;
       }
       @media (forced-colors: active) {
@@ -70,7 +71,7 @@
       );
       &:before {
         @apply rotate-0 opacity-100;
-        translate: 0 -35%;
+        translate: 0 -40%;
         clip-path: polygon(20% 100%, 20% 80%, 50% 80%, 50% 80%, 80% 80%, 80% 100%);
       }
     }


### PR DESCRIPTION
the checkmark sits a bit low and to the left inside the box, and the indeterminate dash sits a bit low. same at every size and border width, easiest to see at checkbox-xl or when zoomed.

measured against the box centre: the tick's ink is 7% low and 3.5% left, the dash 5% low. the tick is a rotated L shape and its own geometry puts it off centre, so this nudges it back with a translate, and moves the dash from -35% to -40%.

before: https://play.tailwindcss.com/emAzz3KCGR
