### PR TITLE
fix(loading): the indicator shrinks inside a cramped flex container

### DIFF
--- a/packages/daisyui/src/components/loading.css
+++ b/packages/daisyui/src/components/loading.css
@@ -1,6 +1,6 @@
 .loading {
   @layer daisyui.l1.l2.l3 {
-    @apply pointer-events-none inline-block aspect-square bg-current align-middle;
+    @apply pointer-events-none inline-block aspect-square shrink-0 bg-current align-middle;
     width: calc(var(--size-selector, 0.25rem) * 6);
     mask-size: 100%;
     mask-repeat: no-repeat;


### PR DESCRIPTION
a loading indicator next to text inside a narrow button or a tight grid shrinks. in a `btn w-32` with a label it is 13px instead of 24px, in a three column button grid it goes down to 4px and is basically gone.

`.loading` sets its size with `width` only, so as a flex item it gives that width up when the container is short on space. `shrink-0` keeps it at its size, same as kbd and radial-progress already do.

before: https://play.tailwindcss.com/r10IShloei
