### PR TITLE
fix(badge): the badge shrinks and its text wraps out of the pill inside a cramped flex container

### DIFF
--- a/packages/daisyui/src/components/badge.css
+++ b/packages/daisyui/src/components/badge.css
@@ -1,6 +1,6 @@
 .badge {
   @layer daisyui.l1.l2.l3 {
-    @apply rounded-selector inline-flex items-center justify-center gap-2 align-middle;
+    @apply rounded-selector inline-flex shrink-0 items-center justify-center gap-2 align-middle;
     color: var(--badge-fg);
     border: var(--border) solid var(--badge-color, var(--color-base-200));
     font-size: 0.875rem;


### PR DESCRIPTION
a badge at the end of a flex row, next to a long title, gets squeezed when the row runs out of room. the pill keeps its fixed height but its width shrinks, so the text wraps and spills out below the pill.

`.badge` sizes itself with `width: fit-content` and nothing stops it from shrinking as a flex item. `shrink-0` keeps it at its size, same as kbd and radial-progress already do.

before: https://play.tailwindcss.com/v7bLp268RU
