### PR TITLE
docs: add the aria-labels from the footer and rating previews to their code blocks

### DIFF
--- a/packages/docs/src/routes/(routes)/components/footer/+page.md
+++ b/packages/docs/src/routes/(routes)/components/footer/+page.md
@@ -262,6 +262,7 @@ classnames:
     <div class="grid grid-flow-col gap-4">
       <a>
         <svg
+          aria-label="Twitter"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -273,6 +274,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="YouTube"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -284,6 +286,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="Facebook"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -348,6 +351,7 @@ classnames:
   <nav class="grid-flow-col gap-4 md:place-self-center md:justify-self-end">
     <a>
       <svg
+        aria-label="Twitter"
         xmlns="http://www.w3.org/2000/svg"
         width="24"
         height="24"
@@ -359,6 +363,7 @@ classnames:
     </a>
     <a>
       <svg
+        aria-label="YouTube"
         xmlns="http://www.w3.org/2000/svg"
         width="24"
         height="24"
@@ -370,6 +375,7 @@ classnames:
     </a>
     <a>
       <svg
+        aria-label="Facebook"
         xmlns="http://www.w3.org/2000/svg"
         width="24"
         height="24"
@@ -431,6 +437,7 @@ classnames:
     <div class="grid grid-flow-col gap-4">
       <a>
         <svg
+          aria-label="Twitter"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -442,6 +449,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="YouTube"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -453,6 +461,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="Facebook"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -603,6 +612,7 @@ classnames:
     <div class="grid grid-flow-col gap-4">
       <a>
         <svg
+          aria-label="Twitter"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -614,6 +624,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="YouTube"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -625,6 +636,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="Facebook"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -672,6 +684,7 @@ classnames:
     <div class="grid grid-flow-col gap-4">
       <a>
         <svg
+          aria-label="Twitter"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -683,6 +696,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="YouTube"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -694,6 +708,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="Facebook"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -797,6 +812,7 @@ classnames:
     <div class="grid grid-flow-col gap-4">
       <a>
         <svg
+          aria-label="Twitter"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -808,6 +824,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="YouTube"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -819,6 +836,7 @@ classnames:
       </a>
       <a>
         <svg
+          aria-label="Facebook"
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"

--- a/packages/docs/src/routes/(routes)/components/rating/+page.md
+++ b/packages/docs/src/routes/(routes)/components/rating/+page.md
@@ -260,7 +260,7 @@ classnames:
 
 ```html
 <div class="$$rating $$rating-lg $$rating-half">
-  <input type="radio" name="rating-11" class="$$rating-hidden" />
+  <input type="radio" name="rating-11" class="$$rating-hidden" aria-label="clear" />
   <input type="radio" name="rating-11" class="$$mask $$mask-star-2 $$mask-half-1 bg-green-500" aria-label="0.5 star" />
   <input type="radio" name="rating-11" class="$$mask $$mask-star-2 $$mask-half-2 bg-green-500" aria-label="1 star" />
   <input type="radio" name="rating-11" class="$$mask $$mask-star-2 $$mask-half-1 bg-green-500" aria-label="1.5 star" checked="checked" />


### PR DESCRIPTION
#4705 added aria-labels to the icon only links in the previews, but the code blocks under them still ship the social icons without one. the previews use single line svgs and the code blocks use multi line ones, so the code got missed. anyone copying the footer examples gets three unlabeled icon links.

this adds the same `aria-label` to the 18 social icons in the footer code blocks, and `aria-label="clear"` to the hidden radio in the half star rating code block, matching its preview.

docs only, `lang:validate` and `lang:prune` pass.
