### PR TITLE
docs: mark the custom property overrides in the tab and range examples so they follow a configured prefix

### DIFF
--- a/packages/docs/src/routes/(routes)/components/range/+page.md
+++ b/packages/docs/src/routes/(routes)/components/range/+page.md
@@ -181,7 +181,7 @@ classnames:
 
 ```html
 <input type="range" min="0" max="100" value="40" 
-  class="$$range text-blue-300 [--range-bg:orange] [--range-thumb:blue] [--range-fill:0]" />
+  class="$$range text-blue-300 [--$$range-bg:orange] [--$$range-thumb:blue] [--$$range-fill:0]" />
 ```
 
 

--- a/packages/docs/src/routes/(routes)/components/tab/+page.md
+++ b/packages/docs/src/routes/(routes)/components/tab/+page.md
@@ -377,7 +377,7 @@ classnames:
 ```html
 <div role="tablist" class="$$tabs $$tabs-lift">
   <a role="tab" class="$$tab">Tab 1</a>
-  <a role="tab" class="$$tab $$tab-active text-primary [--tab-bg:orange] [--tab-border-color:red]"> Tab 2</a>
+  <a role="tab" class="$$tab $$tab-active text-primary [--$$tab-bg:orange] [--$$tab-border-color:red]"> Tab 2</a>
   <a role="tab" class="$$tab">Tab 3</a>
 </div>
 ```


### PR DESCRIPTION
the tab and range pages have one example each that overrides a custom property from a class, like `[--tab-bg:orange]`. with a prefix configured, the plugin renames those variables too, so `.d-tab` reads `--d-tab-bg`, but the code block still says `--tab-bg` and the override does nothing.

this adds the `$$` marker to the five custom properties in those two code blocks, so the copied code follows the prefix like the class names already do. no change without a prefix.

docs only, no prose touched.
