### PR TITLE
fix(btn): btn-disabled on a btn-link keeps the link color

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -325,8 +325,7 @@
   }
 }
 
-.btn-disabled,
-.btn:is(:disabled, [disabled], [aria-disabled="true"]) {
+.btn:is(.btn-disabled, :disabled, [disabled], [aria-disabled="true"]) {
   @layer daisyui {
     @apply pointer-events-none;
     color: color-mix(in oklch, var(--color-base-content) 20%, #0000);


### PR DESCRIPTION
`btn btn-link btn-disabled` renders in the full link color, same as an enabled link. the `disabled` attribute version is dimmed, and in 5.5.20 both were dimmed.

since #4619 `.btn-link` and `.btn-disabled` both sit in the top `daisyui` layer at (0,1,0), and the plugin output puts `.btn-link` after `.btn-disabled`, so the link color wins. the attribute arm `.btn:is(:disabled, ...)` is (0,2,0) and never had this problem. #4742 does not change it, i checked with it applied.

this folds `.btn-disabled` into that arm so the class form gets the same specificity as the attribute form. nothing else lives in that layer.

example: https://play.tailwindcss.com/rxglhHmosk
