### PR TITLE
fix(otp): add a disabled state

### DIFF
--- a/packages/daisyui/src/components/otp.css
+++ b/packages/daisyui/src/components/otp.css
@@ -151,6 +151,17 @@
         outline-color: var(--input-color);
       }
     }
+
+    &:has(> input:disabled) {
+      @apply cursor-not-allowed;
+      > input {
+        @apply text-base-content/40;
+      }
+      > span {
+        @apply border-base-200 bg-base-200;
+        box-shadow: none;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
a disabled otp looks exactly like an enabled one. `<input disabled>` inside `.otp`, or the whole thing inside `<fieldset disabled>`, keeps the white boxes, dark digits and normal cursor, so nothing tells the user it will not take input. input, select, textarea and file-input all grey out when disabled.

this adds `:has(> input:disabled)` to `.otp` with the same values `.input:disabled` uses (base-200 box and border, 40% text, `cursor: not-allowed`, no inset shadow). covers the fieldset case too, the input is disabled either way.

example: https://play.tailwindcss.com/kbuT3yld2N
