### PR TITLE
fix(reset): keep elements with the hidden attribute hidden in daisyui.css

### DIFF
--- a/packages/daisyui/build.js
+++ b/packages/daisyui/build.js
@@ -88,7 +88,13 @@ async function generateFiles() {
 
     !isDev && generateThemeFiles({ srcDir: "src/themes", distDir: "theme" }),
 
-    !isDev && generateRawStyles({ srcDir: "../src/base", distDir: "../base", layer: "base" }),
+    !isDev &&
+      generateRawStyles({
+        srcDir: "../src/base",
+        distDir: "../base",
+        layer: "base",
+        unlayered: ["hidden"],
+      }),
 
     !isDev &&
       generateRawStyles({
@@ -120,7 +126,12 @@ async function generateFiles() {
         layer: "utilities",
       }),
     generatePlugins({ type: "base", srcDir: "src/themes", distDir: "theme" }),
-    generatePlugins({ type: "base", srcDir: "src/base", distDir: "base", exclude: ["reset"] }),
+    generatePlugins({
+      type: "base",
+      srcDir: "src/base",
+      distDir: "base",
+      exclude: ["reset", "hidden"],
+    }),
     generatePlugins({ type: "component", srcDir: "src/components", distDir: "components" }),
     generatePlugins({ type: "utility", srcDir: "src/utilities", distDir: "utilities" }),
   ])

--- a/packages/daisyui/functions/filesExist.test.js
+++ b/packages/daisyui/functions/filesExist.test.js
@@ -32,7 +32,7 @@ directories.forEach((dir) => {
     const files = readdirSync(srcDir).filter((file) => file.endsWith(".css"))
 
     // we need .css for reset but not .js
-    const exclusions = ["reset"]
+    const exclusions = ["reset", "hidden"]
 
     files.forEach((file) => {
       const targetFile = join(targetDir, file)

--- a/packages/daisyui/functions/generateRawStyles.js
+++ b/packages/daisyui/functions/generateRawStyles.js
@@ -89,6 +89,7 @@ async function processFile(
   responsive,
   exclude,
   layer,
+  unlayered,
 ) {
   const styleContent = await fs.readFile(path.join(stylesDir, `${distDir}/${file}.css`), "utf-8")
   let stylesContent = await compileAndExtractStyles(styleContent, defaultTheme, theme)
@@ -99,7 +100,7 @@ async function processFile(
 
   stylesContent = cleanCss(stylesContent)
 
-  if (layer) {
+  if (layer && !unlayered.includes(file)) {
     stylesContent = `@layer ${layer} {\n${stylesContent}\n}`
   }
 
@@ -115,6 +116,7 @@ export async function generateRawStyles({
   responsive = false,
   exclude = [],
   layer = null,
+  unlayered = [],
 }) {
   try {
     const { defaultTheme, theme } = await loadThemes()
@@ -124,11 +126,19 @@ export async function generateRawStyles({
 
     // Process all files concurrently
     const processPromises = files.map((file) =>
-      processFile(file, stylesDir, distDir, defaultTheme, theme, responsive, exclude, layer).catch(
-        (fileError) => {
-          throw new Error(`Error processing file ${file}: ${fileError.message}`)
-        },
-      ),
+      processFile(
+        file,
+        stylesDir,
+        distDir,
+        defaultTheme,
+        theme,
+        responsive,
+        exclude,
+        layer,
+        unlayered,
+      ).catch((fileError) => {
+        throw new Error(`Error processing file ${file}: ${fileError.message}`)
+      }),
     )
 
     // Wait for all files to be processed

--- a/packages/daisyui/src/base/hidden.css
+++ b/packages/daisyui/src/base/hidden.css
@@ -1,0 +1,3 @@
+[hidden]:where(:not([hidden="until-found"])) {
+  display: none;
+}

--- a/packages/daisyui/src/base/reset.css
+++ b/packages/daisyui/src/base/reset.css
@@ -128,3 +128,7 @@ video {
   max-width: 100%;
   height: auto;
 }
+
+[hidden]:where(:not([hidden="until-found"])) {
+  display: none !important;
+}

--- a/packages/daisyui/src/base/reset.css
+++ b/packages/daisyui/src/base/reset.css
@@ -128,7 +128,3 @@ video {
   max-width: 100%;
   height: auto;
 }
-
-[hidden]:where(:not([hidden="until-found"])) {
-  display: none !important;
-}


### PR DESCRIPTION
with the standalone `daisyui.css` (no tailwind, so no preflight) a `<button class="btn" hidden>` still renders, same for badge, card, alert, menu, input: the component's `display` beats the browser's `[hidden]` rule. `reset.css` trimmed preflight but dropped its `[hidden]` rule, this adds it back as is (preflight uses `!important` there too, it has to beat any `display`). plugin users are not affected, they get preflight.

example: https://play.tailwindcss.com/PhJiCBxS79
