### PR TITLE
fix(menu): style items with aria-current like menu-active

### DIFF
--- a/packages/daisyui/src/components/menu.css
+++ b/packages/daisyui/src/components/menu.css
@@ -81,7 +81,12 @@
     :where(
       li:not(.menu-title, .disabled) > *:not(ul, menu, details, .menu-title),
       li:not(.menu-title, .disabled) > details > summary:not(.menu-title)
-    ):not(.menu-active, :active, .btn, [aria-current="true"], [aria-current="page"]) {
+    ):not(
+      .menu-active,
+      :active,
+      .btn,
+      [aria-current]:not([aria-current="false"], [aria-current=""])
+    ) {
       &.menu-focus,
       &:focus-visible {
         @apply bg-base-content/10 text-base-content cursor-pointer outline-hidden;
@@ -93,8 +98,7 @@
           .menu-active,
           :active,
           .btn,
-          [aria-current="true"],
-          [aria-current="page"]
+          [aria-current]:not([aria-current="false"], [aria-current=""])
         ):hover,
       li:not(.menu-title, .disabled)
         > details
@@ -102,8 +106,7 @@
           .menu-active,
           :active,
           .btn,
-          [aria-current="true"],
-          [aria-current="page"]
+          [aria-current]:not([aria-current="false"], [aria-current=""])
         ):hover
     ) {
       @apply bg-base-content/10 cursor-pointer outline-hidden;
@@ -129,8 +132,7 @@
       & > *:not(ul, menu, .menu-title, details, .btn).menu-active,
       &
         > *:not(ul, menu, .menu-title, details, .btn):is(
-          [aria-current="true"],
-          [aria-current="page"]
+          [aria-current]:not([aria-current="false"], [aria-current=""])
         ),
       & > details > summary:active {
         @apply outline-hidden;

--- a/packages/daisyui/src/components/menu.css
+++ b/packages/daisyui/src/components/menu.css
@@ -81,7 +81,7 @@
     :where(
       li:not(.menu-title, .disabled) > *:not(ul, menu, details, .menu-title),
       li:not(.menu-title, .disabled) > details > summary:not(.menu-title)
-    ):not(.menu-active, :active, .btn) {
+    ):not(.menu-active, :active, .btn, [aria-current="true"], [aria-current="page"]) {
       &.menu-focus,
       &:focus-visible {
         @apply bg-base-content/10 text-base-content cursor-pointer outline-hidden;
@@ -89,10 +89,22 @@
     }
     :where(
       li:not(.menu-title, .disabled)
-        > *:not(ul, menu, details, .menu-title):not(.menu-active, :active, .btn):hover,
+        > *:not(ul, menu, details, .menu-title):not(
+          .menu-active,
+          :active,
+          .btn,
+          [aria-current="true"],
+          [aria-current="page"]
+        ):hover,
       li:not(.menu-title, .disabled)
         > details
-        > summary:not(.menu-title):not(.menu-active, :active, .btn):hover
+        > summary:not(.menu-title):not(
+          .menu-active,
+          :active,
+          .btn,
+          [aria-current="true"],
+          [aria-current="page"]
+        ):hover
     ) {
       @apply bg-base-content/10 cursor-pointer outline-hidden;
       box-shadow:
@@ -115,6 +127,11 @@
 
       & > *:not(ul, menu, .menu-title, details, .btn):active,
       & > *:not(ul, menu, .menu-title, details, .btn).menu-active,
+      &
+        > *:not(ul, menu, .menu-title, details, .btn):is(
+          [aria-current="true"],
+          [aria-current="page"]
+        ),
       & > details > summary:active {
         @apply outline-hidden;
         color: var(--menu-active-fg);


### PR DESCRIPTION
a menu item with `aria-current="page"` looks like every other item, while the same attribute already gets the active style on tabs (#4054 asked for both). react router's NavLink and vue router's RouterLink put `aria-current="page"` on the active link by themselves, so a menu built from them has no active item. this adds `[aria-current="true"]` and `[aria-current="page"]` next to `.menu-active`, hover excluded the same way.

example: https://play.tailwindcss.com/HPnjNS50Z3
