### PR TITLE
fix(dock): show the active indicator on items with aria-current

### DIFF
--- a/packages/daisyui/src/components/dock.css
+++ b/packages/daisyui/src/components/dock.css
@@ -35,6 +35,11 @@
       }
     }
   }
+  @layer daisyui.l1.l2 {
+    > :is([aria-current="true"], [aria-current="page"]):after {
+      @apply w-10 bg-current text-current;
+    }
+  }
 }
 .dock-active {
   @layer daisyui.l1.l2 {
@@ -48,7 +53,7 @@
     height: 3rem;
     height: calc(3rem + env(safe-area-inset-bottom));
 
-    .dock-active {
+    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
       &:after {
         bottom: -0.1rem;
       }
@@ -66,7 +71,7 @@
     height: 3.5rem;
     height: calc(3.5rem + env(safe-area-inset-bottom));
 
-    .dock-active {
+    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
       &:after {
         bottom: -0.1rem;
       }
@@ -93,7 +98,7 @@
     height: 4.5rem;
     height: calc(4.5rem + env(safe-area-inset-bottom));
 
-    .dock-active {
+    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
       &:after {
         bottom: 0.4rem;
       }
@@ -110,7 +115,7 @@
     height: 5rem;
     height: calc(5rem + env(safe-area-inset-bottom));
 
-    .dock-active {
+    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
       &:after {
         bottom: 0.4rem;
       }

--- a/packages/daisyui/src/components/dock.css
+++ b/packages/daisyui/src/components/dock.css
@@ -36,7 +36,7 @@
     }
   }
   @layer daisyui.l1.l2 {
-    > :is([aria-current="true"], [aria-current="page"]):after {
+    > [aria-current]:not([aria-current="false"], [aria-current=""]):after {
       @apply w-10 bg-current text-current;
     }
   }
@@ -53,7 +53,7 @@
     height: 3rem;
     height: calc(3rem + env(safe-area-inset-bottom));
 
-    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
+    :is(.dock-active, [aria-current]:not([aria-current="false"], [aria-current=""])) {
       &:after {
         bottom: -0.1rem;
       }
@@ -71,7 +71,7 @@
     height: 3.5rem;
     height: calc(3.5rem + env(safe-area-inset-bottom));
 
-    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
+    :is(.dock-active, [aria-current]:not([aria-current="false"], [aria-current=""])) {
       &:after {
         bottom: -0.1rem;
       }
@@ -98,7 +98,7 @@
     height: 4.5rem;
     height: calc(4.5rem + env(safe-area-inset-bottom));
 
-    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
+    :is(.dock-active, [aria-current]:not([aria-current="false"], [aria-current=""])) {
       &:after {
         bottom: 0.4rem;
       }
@@ -115,7 +115,7 @@
     height: 5rem;
     height: calc(5rem + env(safe-area-inset-bottom));
 
-    :is(.dock-active, [aria-current="true"], [aria-current="page"]) {
+    :is(.dock-active, [aria-current]:not([aria-current="false"], [aria-current=""])) {
       &:after {
         bottom: 0.4rem;
       }


### PR DESCRIPTION
a dock item with `aria-current="page"` gets no indicator, only `dock-active` does, and that is the attribute react router's NavLink and vue router's RouterLink set on the active link. this treats `aria-current="true"` and `"page"` the same way `dock-active` is, sizes included, like tab does.

example: https://play.tailwindcss.com/ZvegZ2Swip
