### PR TITLE
fix(btn): style aria-pressed and aria-current like btn-active

### DIFF
--- a/packages/daisyui/src/components/button.css
+++ b/packages/daisyui/src/components/button.css
@@ -84,7 +84,11 @@
       }
     }
 
-    &:active:not(.btn-active) {
+    &:active:not(
+        .btn-active,
+        [aria-pressed="true"],
+        [aria-current]:not([aria-current="false"], [aria-current=""])
+      ) {
       translate: 0 0.5px;
       --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
       color: var(--btn-fg, var(--color-base-content));
@@ -118,7 +122,8 @@
   }
 }
 
-.btn-active {
+.btn-active,
+.btn:is([aria-pressed="true"], [aria-current]:not([aria-current="false"], [aria-current=""])) {
   @layer daisyui.l1.l2 {
     --btn-bg: color-mix(in oklab, var(--btn-color, var(--color-base-200)), #000 5%);
     color: var(--btn-fg, var(--color-base-content));


### PR DESCRIPTION
a toggle button with `aria-pressed="true"` and a pagination button with `aria-current="page"` both look like a resting button, only the `btn-active` class gets the pressed style. this adds the attribute forms next to `.btn-active` (and skips the press translate on them the same way), like `aria-disabled` on btn and `aria-selected` on tab.

example: https://play.tailwindcss.com/o3A0oso4pQ
