### PR TITLE
docs(otp): add a disabled example

### DIFF
--- a/packages/docs/src/routes/(routes)/components/otp/+page.md
+++ b/packages/docs/src/routes/(routes)/components/otp/+page.md
@@ -318,3 +318,23 @@ classnames:
   <input type="text" autocomplete="one-time-code" inputmode="numeric" maxlength="4" pattern="[0-9]{4}" required />
 </label>
 ```
+
+### ~OTP disabled
+
+<label class="otp">
+  <span></span>
+  <span></span>
+  <span></span>
+  <span></span>
+  <input type="text" autocomplete="one-time-code" inputmode="numeric" maxlength="4" pattern="[0-9]&#123;4}" required disabled />
+</label>
+
+```html
+<label class="$$otp">
+  <span></span>
+  <span></span>
+  <span></span>
+  <span></span>
+  <input type="text" autocomplete="one-time-code" inputmode="numeric" maxlength="4" pattern="[0-9]{4}" required disabled />
+</label>
+```


### PR DESCRIPTION
5.7.37 added the disabled style for otp (#4750), this adds an example for it to the otp page, same markup as the first example plus `disabled`
