### PR TITLE
fix(timeline): round the line ends next to the icon on the default timeline

### DIFF
--- a/packages/daisyui/src/components/timeline.css
+++ b/packages/daisyui/src/components/timeline.css
@@ -34,13 +34,17 @@
       @apply bg-base-300 h-1;
     }
 
-    &:has(.timeline-middle hr) {
-      &:first-child {
-        @apply rounded-e-selector rounded-s-none;
-      }
+    &:has(.timeline-middle) {
+      > li {
+        > hr {
+          &:first-child {
+            @apply rounded-e-selector rounded-s-none;
+          }
 
-      &:last-child {
-        @apply rounded-s-selector rounded-e-none;
+          &:last-child {
+            @apply rounded-s-selector rounded-e-none;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
on a plain `timeline` with `timeline-middle` icons the line ends next to the icons stay square, while `timeline-horizontal` and `timeline-vertical` round them. the base rule for it is `&:has(.timeline-middle hr) { &:first-child ... }`, which targets the `ul` itself and never matches. the `timeline-horizontal` block further down has the working form, this copies it.

example: https://play.tailwindcss.com/YC8LPjfQ2d (the red ring marks the line end, zoom in, the third row restates the fix)
